### PR TITLE
feat(statistics): Phase 6 — 統計圖表頁

### DIFF
--- a/src/app/(auth)/statistics/page.tsx
+++ b/src/app/(auth)/statistics/page.tsx
@@ -5,6 +5,7 @@ import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
   PieChart, Pie, Cell, Legend,
   BarChart, Bar,
+  type PieLabelRenderProps,
 } from 'recharts'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useMembers } from '@/lib/hooks/use-members'
@@ -29,6 +30,7 @@ function lastNMonths(n: number): { year: number; month: number }[] {
 
 function filterByMonth(expenses: Expense[], year: number, month: number) {
   return expenses.filter((e) => {
+    if (!e.date) return false
     const d = toDate(e.date)
     return d.getFullYear() === year && d.getMonth() === month
   })
@@ -82,7 +84,7 @@ function TrendChart({ expenses }: { expenses: Expense[] }) {
         <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
         <XAxis dataKey="label" tick={{ fontSize: 12 }} />
         <YAxis tick={{ fontSize: 12 }} tickFormatter={(v: number) => v >= 1000 ? `${v / 1000}k` : String(v)} />
-        <Tooltip formatter={(value) => [`NT$ ${Number(value).toLocaleString()}`, '支出']} />
+        <Tooltip formatter={(value) => [`NT$ ${Number(value).toLocaleString()}`, '支出'] as [string, string]} />
         <Line type="monotone" dataKey="total" stroke="var(--primary)" strokeWidth={2} dot={{ r: 4 }} activeDot={{ r: 6 }} />
       </LineChart>
     </ResponsiveContainer>
@@ -108,13 +110,13 @@ function CategoryPieChart({ expenses }: { expenses: Expense[] }) {
     <ResponsiveContainer width="100%" height={260}>
       <PieChart>
         <Pie data={data} dataKey="value" nameKey="name" cx="50%" cy="45%" outerRadius={90}
-          label={({ name, percent }: { name?: string; percent?: number }) =>
-            (percent ?? 0) > 0.04 ? `${name ?? ''} ${((percent ?? 0) * 100).toFixed(0)}%` : ''}>
+          label={(props: PieLabelRenderProps) =>
+            (props.percent ?? 0) > 0.04 ? `${props.name ?? ''} ${((props.percent ?? 0) * 100).toFixed(0)}%` : ''}>
           {data.map((_, i) => (
             <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} />
           ))}
         </Pie>
-        <Tooltip formatter={(value) => [`NT$ ${Number(value).toLocaleString()}`, '金額']} />
+        <Tooltip formatter={(value) => [`NT$ ${Number(value).toLocaleString()}`, '金額'] as [string, string]} />
         <Legend iconSize={10} wrapperStyle={{ fontSize: 12 }} />
       </PieChart>
     </ResponsiveContainer>
@@ -126,14 +128,15 @@ function MemberBarChart({ expenses, memberNames }: { expenses: Expense[]; member
   const data = useMemo(() => {
     const map: Record<string, number> = {}
     for (const e of expenses) {
-      // Count each participant's share amount
-      for (const s of e.splits) {
-        if (s.isParticipant) {
-          map[s.memberId] = (map[s.memberId] ?? 0) + s.shareAmount
+      if (e.isShared) {
+        // Shared: distribute by each participant's share amount
+        for (const s of e.splits) {
+          if (s.isParticipant) {
+            map[s.memberId] = (map[s.memberId] ?? 0) + s.shareAmount
+          }
         }
-      }
-      // For personal expenses, count full amount to payer
-      if (!e.isShared) {
+      } else {
+        // Personal: full amount attributed to the payer only
         map[e.payerId] = (map[e.payerId] ?? 0) + e.amount
       }
     }
@@ -150,7 +153,7 @@ function MemberBarChart({ expenses, memberNames }: { expenses: Expense[]; member
         <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
         <XAxis dataKey="name" tick={{ fontSize: 12 }} />
         <YAxis tick={{ fontSize: 12 }} tickFormatter={(v: number) => v >= 1000 ? `${v / 1000}k` : String(v)} />
-        <Tooltip formatter={(value) => [`NT$ ${Number(value).toLocaleString()}`, '分攤金額']} />
+        <Tooltip formatter={(value) => [`NT$ ${Number(value).toLocaleString()}`, '分攤金額'] as [string, string]} />
         <Bar dataKey="amount" fill="var(--primary)" radius={[4, 4, 0, 0]} />
       </BarChart>
     </ResponsiveContainer>
@@ -213,8 +216,10 @@ export default function StatisticsPage() {
   const { expenses, loading: expLoading } = useExpenses(group?.id)
   const members = useMembers(group?.id)
 
-  const now = new Date()
-  const [selectedMonth, setSelectedMonth] = useState({ year: now.getFullYear(), month: now.getMonth() })
+  const [selectedMonth, setSelectedMonth] = useState(() => {
+    const now = new Date()
+    return { year: now.getFullYear(), month: now.getMonth() }
+  })
 
   const memberNames = useMemo(
     () => Object.fromEntries(members.map((m) => [m.id, m.name])),


### PR DESCRIPTION
## Summary

- **月支出趨勢折線圖**：近 6 個月每月支出，固定顯示不受月份選擇器影響
- **類別分布圓餅圖**：所選月份支出按類別分組，顯示百分比標籤，最多 10 類
- **成員分攤長條圖**：所選月份每位成員的分攤金額（含個人支出）
- **月份選擇器**：下拉切換近 12 個月，類別圖和成員圖即時更新
- **摘要卡片**：總支出 / 共同支出 / 個人支出三欄顯示
- Recharts Tooltip 型別已適配 v3 的 `ValueType | undefined` 簽名

## Files

- `src/app/(auth)/statistics/page.tsx` — 完整統計頁（新建）

## Test Plan

- [ ] 統計頁顯示三種圖表，數據來自 Firestore expenses
- [ ] 月份選擇器切換 → 類別圖和成員圖更新
- [ ] 趨勢圖顯示近 6 個月（不受選擇器影響）
- [ ] 圖表在手機寬度（375px）和桌面（1280px）都正常
- [ ] 空資料月份顯示「尚無支出資料」提示
- [ ] `npm run build` 零 error

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)