### PR TITLE
fix(firestore): add composite index for notifications query

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,21 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "recipientId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "expenses",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "groupId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- Adds `recipientId ASC + createdAt DESC` composite index for notifications subcollection query
- Required because Firestore needs a composite index for `where + orderBy` on different fields

## Test plan
- [ ] Deploy: `firebase deploy --only firestore:indexes`
- [ ] Verify notifications page loads data without query errors

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)