### PR TITLE
fix(split): 修正 calculateNetBalances 結算增減方向

### DIFF
--- a/src/lib/services/split-calculator.ts
+++ b/src/lib/services/split-calculator.ts
@@ -27,8 +27,8 @@ export function calculateNetBalances(
 
   // 結算扣減
   for (const s of settlements) {
-    balances[s.fromMemberId] = (balances[s.fromMemberId] ?? 0) + s.amount
-    balances[s.toMemberId] = (balances[s.toMemberId] ?? 0) - s.amount
+    balances[s.fromMemberId] = (balances[s.fromMemberId] ?? 0) - s.amount
+    balances[s.toMemberId] = (balances[s.toMemberId] ?? 0) + s.amount
   }
 
   return balances


### PR DESCRIPTION
## Summary

- **Bug**: `calculateNetBalances` 處理結算（settlements）時增減方向完全顛倒
- 當 A 付款給 B 時，代碼卻讓 A 的餘額增加、B 的餘額減少
- 正確邏輯：A 償還欠款 → A 的淨額遞減、B 的淨額遞增

## Fix

```diff
- balances[s.fromMemberId] = (balances[s.fromMemberId] ?? 0) + s.amount
- balances[s.toMemberId] = (balances[s.toMemberId] ?? 0) - s.amount
+ balances[s.fromMemberId] = (balances[s.fromMemberId] ?? 0) - s.amount
+ balances[s.toMemberId] = (balances[s.toMemberId] ?? 0) + s.amount
```

## Test plan

- [ ] Build passes
- [ ] ESLint passes
- [ ] 手動驗證：確認結算後餘額正確歸零或遞減

Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)