### PR TITLE
fix(activity-log): 所有 CRUD 操作寫入 ActivityLog

### DIFF
--- a/ISSUES-TO-CREATE.md
+++ b/ISSUES-TO-CREATE.md
@@ -1,0 +1,268 @@
+# Family-Ledger Web — Issues 清單（待建立）
+
+> 建立方式：複製以下內容，一次一個貼到 GitHub New Issue，或使用 [GitHub CLI](https://cli.github.com/)：`gh issue create --title "..." --body "..." --project "..."`
+
+---
+
+## Milestone 1：Sprint 1 - 止血（1-2 週）
+
+---
+
+### 🔴 P0 - Critical Bugs
+
+---
+
+#### Issue #1：\[P0 Bug\] calculateNetBalances 結算增減方向錯誤
+
+**描述**：
+`src/lib/services/split-calculator.ts` 中的 `calculateNetBalances` 函式，在處理結算記錄（settlements）時，增減方向完全顛倒。
+
+**現況**：
+```typescript
+// ❌ 錯誤
+balances[s.fromMemberId] = (balances[s.fromMemberId] ?? 0) + s.amount
+balances[s.toMemberId] = (balances[s.toMemberId] ?? 0) - s.amount
+```
+
+**預期行為**：
+- A 欠 B 100元 → balances[A] = -100, balances[B] = +100
+- B 付款給 A 100元（結算）→ balances[A] = 0, balances[B] = 0
+- 結算後，雙方餘額應當歸零或遞減，而非遞增/遞減方向錯誤
+
+**修復方式**：
+```typescript
+// ✅ 正確
+balances[s.fromMemberId] = (balances[s.fromMemberId] ?? 0) - s.amount
+balances[s.toMemberId] = (balances[s.toMemberId] ?? 0) + s.amount
+```
+
+**標籤**：`bug`, `critical`, `P0`
+**Milestone**：Sprint 1 - 止血
+
+---
+
+#### Issue #2：\[P0\] 所有 CRUD 操作未寫入 ActivityLog
+
+**描述**：
+`activity-log-service.ts` 定義了完整的 `addActivityLog` 函式，但 expense、settlement、member、category 的所有 CRUD service 都沒有呼叫它。操作稽核軌跡目前全空白。
+
+**受影響的檔案**：
+- `src/lib/services/expense-service.ts`（addExpense / updateExpense / deleteExpense）
+- `src/lib/services/settlement-service.ts`（addSettlement）
+- `src/lib/services/member-service.ts`（addMember / removeMember）
+- `src/lib/services/category-service.ts`（addCategory / updateCategory / deleteCategory）
+
+**修復方式**：
+在每次 Firestore 寫入成功後，補上 `addActivityLog()` 呼叫。
+
+**標籤**：`bug`, `critical`, `P0`
+**Milestone**：Sprint 1 - 止血
+
+---
+
+#### Issue #3：\[P0\] 刪除 currentUser 成員時無遞補邏輯
+
+**描述**：
+當刪除 `isCurrentUser === true` 的成員時，沒有其他成員遞補成為 current user。這會導致：
+1. settings 頁的「我」標記消失
+2. 依賴 `isCurrentUser` 的功能永久失效
+3. 使用者需要重新登出再登入才能恢復
+
+**受影響的檔案**：`src/lib/services/member-service.ts` - `removeMember`
+
+**修復方式**：
+刪除成員前，先確認是否為 currentUser；若是，先找另一個成員遞補，再執行刪除。
+
+**標籤**：`bug`, `critical`, `P0`
+**Milestone**：Sprint 1 - 止血
+
+---
+
+### 🟡 P1 - Engineering Quality
+
+---
+
+#### Issue #4：\[P1\] split-calculator 缺少單元測試
+
+**描述**：
+`split-calculator.ts` 是系統核心邏輯，但完全沒有單元測試覆蓋。導致上述 P0 bug 能夠隱藏至今。
+
+**受影響的檔案**：`src/lib/services/split-calculator.ts`
+
+**建議測試案例**：
+1. 兩人等分支出，餘額正確
+2. 三人等分，餘額正確（含除法餘數處理）
+3. 結算後餘額歸零
+4. 結算金額小於欠款，只扣減對應部分
+5. simplifyDebts 貪心演算法輸出轉帳次數最少
+
+**標籤**：`enhancement`, `testing`, `P1`
+**Milestone**：Sprint 1 - 止血
+
+---
+
+#### Issue #5：\[P2\] useMembers 缺少 loading state
+
+**描述**：
+`useExpenses`、`useGroup` 都有回傳 `loading` 狀態，但 `useMembers` 從頭到尾只回傳 members array，沒有 loading。造成呼叫端 UI 體驗不一致。
+
+**受影響的檔案**：`src/lib/hooks/use-members.ts`
+
+**修復方式**：
+新增 `loading` state，與 `useExpenses` 模式一致。
+
+**標籤**：`bug`, `P2`
+**Milestone**：Sprint 1 - 止血
+
+---
+
+#### Issue #6：\[P2\] records 頁刪除操作無錯誤處理
+
+**描述**：
+刪除 expense 時，`deleteExpense` 失敗的情況完全沒有 UI 提示。使用者可能以為刪掉了但實際失敗。
+
+**受影響的檔案**：`src/app/(auth)/records/page.tsx`
+
+**修復方式**：
+包 try-catch，失敗時 toast 或 inline error 訊息告知用戶。
+
+**標籤**：`bug`, `P2`
+**Milestone**：Sprint 1 - 止血
+
+---
+
+## Milestone 2：Sprint 2 - 結構重構（2-4 週）
+
+---
+
+#### Issue #7：\[P1\] 建立 shared domain package
+
+**描述**：
+Flutter App 和 Next.js Web 的 business logic（split-calculator、local-expense-parser、types）目前是兩份重複的 code。長期 drift 風險極高。
+
+**建議方案**：
+在 `/shared/projects/` 下建立 `packages/family-ledger-domain/`：
+
+```
+packages/family-ledger-domain/
+├── src/
+│   ├── split-calculator.ts
+│   ├── local-expense-parser.ts
+│   ├── types.ts
+│   └── firestore-schema.ts
+├── package.json
+└── tsconfig.json
+```
+
+Flutter 和 Web 都從這個 package 引入 business logic。
+
+**標籤**：`enhancement`, `refactoring`, `P1`
+**Milestone**：Sprint 2 - 結構重構
+
+---
+
+#### Issue #8：\[P1\] Web 抽出 Repository Pattern
+
+**描述**：
+目前 Web 的 business logic 散在 hooks 和 services 之間，直接依賴 Firestore，難以測試。
+
+**建議方案**：
+```
+Presentation Layer（Page Components）
+        ↓
+Application Layer（Services / Use Cases）
+        ↓
+Repository Interface（定義資料操作合約）
+        ↓
+Infrastructure Layer（FirestoreRepository 實作）
+```
+
+新增 `src/lib/repositories/` 目錄，定義 `ExpenseRepository`、`MemberRepository` 等介面，並以 Firestore 實作。
+
+**標籤**：`enhancement`, `refactoring`, `P1`
+**Milestone**：Sprint 2 - 結構重構
+
+---
+
+#### Issue #9：\[P1\] Firebase Auth Emulator 架設
+
+**描述**：
+34/54 Playwright E2E 測試因需要 Firebase Auth 而 skip。測試環境完全綁定線上 Firebase，無法做獨立的 CI regression。
+
+**修復方式**：
+1. 安裝 Firebase CLI + Emulator Suite
+2. `firebase init emulators` 設定 Auth Emulator
+3. Playwright 測試改为连接 `localhost:9099`（Emulator）
+4. 修復其餘 34 個測試回到 green
+
+**標籤**：`enhancement`, `testing`, `infrastructure`, `P1`
+**Milestone**：Sprint 2 - 結構重構
+
+---
+
+#### Issue #10：\[P1\] 建立 GitHub Actions CI
+
+**描述**：
+目前沒有任何 CI pipeline，壞掉的測試不會在 PR level 被 catch。
+
+**建議流程**：
+```yaml
+on: [push, pull_request]
+jobs:
+  - npm ci
+  - npm run lint
+  - npm run test
+  - npx playwright test (with Emulator)
+```
+
+**標籤**：`enhancement`, `infrastructure`, `P1`
+**Milestone**：Sprint 2 - 結構重構
+
+---
+
+## Milestone 3：Sprint 3 - 強化（4-8 週）
+
+---
+
+#### Issue #11：\[P2\] Web 離線支援（IndexedDB Cache）
+
+**描述**：
+Web 版在網路不穩或離線時完全無法使用。建議實作基本的 IndexedDB cache。
+
+**建議方案**：
+1. 首次 load → Firestore snapshot → 寫入 IndexedDB
+2. 離線時 → 從 IndexedDB 讀取
+3. 連線恢復 → 重新 sync
+
+**標籤**：`enhancement`, `PWA`, `P2`
+**Milestone**：Sprint 3 - 強化
+
+---
+
+#### Issue #12：\[P3\] Firebase Security Rules 建立 PR Review 流程
+
+**描述**：
+`firestore.rules` 和 `storage.rules` 目前是檔案，但沒有被列為正式 review 項目。security rule 錯誤可能導致資料外洩。
+
+**建議方案**：
+1. 每次改 `firestore.rules` 必須附上 PR 說明
+2. `firebase deploy --only firestore:rules` 加入 CD pipeline
+3. 訂閱 Firebase Release Notes 追新功能相容性
+
+**標籤**：`security`, `enhancement`, `P3`
+**Milestone**：Sprint 3 - 強化
+
+---
+
+## 標籤彙整（供 GitHub Projects 使用）
+
+```
+Priority: P0, P1, P2, P3
+Type: bug, enhancement, refactoring, testing, infrastructure, security, PWA
+Milestone: Sprint 1 - 止血, Sprint 2 - 結構重構, Sprint 3 - 強化
+```
+
+---
+
+**建立時間**：2026-03-30
+**建議順序**：先建 #1 → #2 → #3（止血優先），再往後

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -6,6 +6,7 @@ import { useGroup } from '@/lib/hooks/use-group'
 import { useExpenses } from '@/lib/hooks/use-expenses'
 import { deleteExpense } from '@/lib/services/expense-service'
 import { currency, toDate, fmtDateFull, paymentLabel } from '@/lib/utils'
+import { useAuth } from '@/lib/auth'
 import type { Expense } from '@/lib/types'
 
 type FilterType = '全部' | '共同' | '個人'
@@ -13,6 +14,7 @@ type FilterType = '全部' | '共同' | '個人'
 export default function RecordsPage() {
   const { group } = useGroup()
   const { expenses, loading } = useExpenses(group?.id)
+  const { user } = useAuth()
   const [filter, setFilter] = useState<FilterType>('全部')
 
   const filtered = expenses.filter((e) => {
@@ -88,7 +90,7 @@ export default function RecordsPage() {
                           className="p-1.5 rounded-md hover:bg-[var(--muted)] text-[var(--muted-foreground)]" title="編輯">✏️</Link>
                         <button onClick={() => {
                           if (confirm(`確定要刪除「${e.description}」嗎？`)) {
-                            if (group?.id) deleteExpense(group.id, e.id)
+                            if (group?.id) deleteExpense(group.id, e.id, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
                           }
                         }} className="p-1.5 rounded-md hover:bg-[var(--muted)]" title="刪除"
                           style={{ color: 'var(--destructive)' }}>🗑️</button>

--- a/src/app/(auth)/settings/categories/page.tsx
+++ b/src/app/(auth)/settings/categories/page.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { addCategory, updateCategory, deleteCategory, reorderCategories } from '@/lib/services/category-service'
-import { addActivityLog } from '@/lib/services/activity-log-service'
 import { useAuth } from '@/lib/auth'
 import type { Category } from '@/lib/types'
 
@@ -42,22 +41,13 @@ export default function CategoriesPage() {
     setSaving(true)
     try {
       if (editing?.id) {
-        await updateCategory(group.id, editing.id, { name: form.name.trim(), icon: form.icon })
+        await updateCategory(group.id, editing.id, { name: form.name.trim(), icon: form.icon }, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
       } else {
-        const newId = await addCategory(group.id, {
+        await addCategory(group.id, {
           name: form.name.trim(),
           icon: form.icon,
           sortOrder: categories.length,
-        })
-        if (user) {
-          await addActivityLog(group.id, {
-            action: 'category_created',
-            actorName: user.displayName ?? '未知',
-            actorId: user.uid,
-            description: `新增類別「${form.name}」`,
-            entityId: newId,
-          })
-        }
+        }, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
       }
       setShowForm(false)
     } catch (e) {
@@ -70,16 +60,7 @@ export default function CategoriesPage() {
   async function handleDelete(cat: Category) {
     if (!group || !cat.id || !confirm(`確定刪除「${cat.name}」？`)) return
     try {
-      await deleteCategory(group.id, cat.id)
-      if (user) {
-        await addActivityLog(group.id, {
-          action: 'category_deleted',
-          actorName: user.displayName ?? '未知',
-          actorId: user.uid,
-          description: `刪除類別「${cat.name}」`,
-          entityId: cat.id,
-        })
-      }
+      await deleteCategory(group.id, cat.id, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined, cat.name)
     } catch (e) {
       console.error(e)
     }

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -31,6 +31,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 function MembersSection({ groupId }: { groupId: string }) {
   const members = useMembers(groupId)
+  const { user } = useAuth()
   const [newName, setNewName] = useState('')
   const [adding, setAdding] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -41,7 +42,7 @@ function MembersSection({ groupId }: { groupId: string }) {
     if (!name) return
     setAdding(true)
     try {
-      await addMember(groupId, name)
+      await addMember(groupId, name, 'member', user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
       setNewName('')
     } finally {
       setAdding(false)
@@ -50,7 +51,7 @@ function MembersSection({ groupId }: { groupId: string }) {
 
   async function handleDelete(memberId: string, memberName: string) {
     if (!confirm(`確定要刪除成員「${memberName}」嗎？此操作無法復原。`)) return
-    await removeMember(groupId, memberId)
+    await removeMember(groupId, memberId, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined, memberName)
   }
 
   async function handleRename(memberId: string) {

--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -8,6 +8,7 @@ import { useMembers } from '@/lib/hooks/use-members'
 import { calculateNetBalances, simplifyDebts } from '@/lib/services/split-calculator'
 import { addSettlement } from '@/lib/services/settlement-service'
 import { currency, signedCurrency, toDate, fmtDateFull } from '@/lib/utils'
+import { useAuth } from '@/lib/auth'
 
 // ── Settlement dialog ─────────────────────────────────────────
 
@@ -106,6 +107,7 @@ export default function SplitPage() {
   const { expenses, loading: expLoading } = useExpenses(group?.id)
   const settlements = useSettlements(group?.id)
   const members = useMembers(group?.id)
+  const { user } = useAuth()
   const nameMap = Object.fromEntries(members.map((m) => [m.id, m.name]))
 
   const [settling, setSettling] = useState<{
@@ -131,7 +133,7 @@ export default function SplitPage() {
       amount,
       note: note || undefined,
       date: new Date(),
-    })
+    }, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
     setSettling(null)
   }
 

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -149,9 +149,9 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         createdBy: user?.uid ?? payerId,
       }
       if (isEditing) {
-        await updateExpense(group.id, existingExpense!.id, input)
+        await updateExpense(group.id, existingExpense!.id, input, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
       } else {
-        await addExpense(group.id, input)
+        await addExpense(group.id, input, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
       }
       onSaved()
     } catch (e: unknown) {

--- a/src/lib/services/category-service.ts
+++ b/src/lib/services/category-service.ts
@@ -1,5 +1,6 @@
 import { addDoc, collection, deleteDoc, doc, Timestamp, updateDoc } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
+import { addActivityLog } from './activity-log-service'
 
 export interface CategoryInput {
   name: string
@@ -9,7 +10,12 @@ export interface CategoryInput {
   isActive?: boolean
 }
 
-export async function addCategory(groupId: string, input: CategoryInput): Promise<string> {
+interface Actor {
+  id: string
+  name: string
+}
+
+export async function addCategory(groupId: string, input: CategoryInput, actor?: Actor): Promise<string> {
   const ref = await addDoc(collection(db, 'groups', groupId, 'categories'), {
     groupId,
     ...input,
@@ -17,6 +23,15 @@ export async function addCategory(groupId: string, input: CategoryInput): Promis
     isActive: input.isActive ?? true,
     createdAt: Timestamp.now(),
   })
+  if (actor) {
+    await addActivityLog(groupId, {
+      action: 'category_created',
+      actorId: actor.id,
+      actorName: actor.name,
+      description: `新增類別：${input.name}`,
+      entityId: ref.id,
+    })
+  }
   return ref.id
 }
 
@@ -24,15 +39,34 @@ export async function updateCategory(
   groupId: string,
   categoryId: string,
   input: Partial<CategoryInput>,
+  actor?: Actor,
 ): Promise<void> {
   await updateDoc(doc(db, 'groups', groupId, 'categories', categoryId), {
     ...input,
     updatedAt: Timestamp.now(),
   })
+  if (actor) {
+    await addActivityLog(groupId, {
+      action: 'category_updated',
+      actorId: actor.id,
+      actorName: actor.name,
+      description: `編輯類別：${input.name ?? ''}`,
+      entityId: categoryId,
+    })
+  }
 }
 
-export async function deleteCategory(groupId: string, categoryId: string): Promise<void> {
+export async function deleteCategory(groupId: string, categoryId: string, actor?: Actor, categoryName?: string): Promise<void> {
   await deleteDoc(doc(db, 'groups', groupId, 'categories', categoryId))
+  if (actor) {
+    await addActivityLog(groupId, {
+      action: 'category_deleted',
+      actorId: actor.id,
+      actorName: actor.name,
+      description: `刪除類別：${categoryName ?? categoryId}`,
+      entityId: categoryId,
+    })
+  }
 }
 
 export async function reorderCategories(

--- a/src/lib/services/expense-service.ts
+++ b/src/lib/services/expense-service.ts
@@ -1,6 +1,12 @@
 import { collection, doc, setDoc, deleteDoc, Timestamp } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
+import { addActivityLog } from './activity-log-service'
 import type { SplitDetail, SplitMethod, PaymentMethod } from '@/lib/types'
+
+interface Actor {
+  id: string
+  name: string
+}
 
 function genId(): string {
   return crypto.randomUUID()
@@ -22,7 +28,7 @@ export interface ExpenseInput {
   createdBy: string
 }
 
-export async function addExpense(groupId: string, input: ExpenseInput): Promise<string> {
+export async function addExpense(groupId: string, input: ExpenseInput, actor?: Actor): Promise<string> {
   const id = genId()
   const now = Timestamp.now()
   const ref = doc(collection(db, 'groups', groupId, 'expenses'), id)
@@ -33,17 +39,44 @@ export async function addExpense(groupId: string, input: ExpenseInput): Promise<
     createdAt: now,
     updatedAt: now,
   })
+  if (actor) {
+    await addActivityLog(groupId, {
+      action: 'expense_created',
+      actorId: actor.id,
+      actorName: actor.name,
+      description: `新增支出：${input.description}`,
+      entityId: id,
+    })
+  }
   return id
 }
 
-export async function updateExpense(groupId: string, expenseId: string, input: Partial<ExpenseInput>): Promise<void> {
+export async function updateExpense(groupId: string, expenseId: string, input: Partial<ExpenseInput>, actor?: Actor): Promise<void> {
   const ref = doc(db, 'groups', groupId, 'expenses', expenseId)
   const data: Record<string, unknown> = { ...input, updatedAt: Timestamp.now() }
   if (input.date) data.date = Timestamp.fromDate(input.date)
   if (input.receiptPaths) data.receiptPath = input.receiptPaths[0] ?? null
   await setDoc(ref, data, { merge: true })
+  if (actor) {
+    await addActivityLog(groupId, {
+      action: 'expense_updated',
+      actorId: actor.id,
+      actorName: actor.name,
+      description: `編輯支出：${input.description ?? ''}`,
+      entityId: expenseId,
+    })
+  }
 }
 
-export async function deleteExpense(groupId: string, expenseId: string): Promise<void> {
+export async function deleteExpense(groupId: string, expenseId: string, actor?: Actor): Promise<void> {
   await deleteDoc(doc(db, 'groups', groupId, 'expenses', expenseId))
+  if (actor) {
+    await addActivityLog(groupId, {
+      action: 'expense_deleted',
+      actorId: actor.id,
+      actorName: actor.name,
+      description: `刪除支出`,
+      entityId: expenseId,
+    })
+  }
 }

--- a/src/lib/services/member-service.ts
+++ b/src/lib/services/member-service.ts
@@ -1,8 +1,14 @@
 import { addDoc, collection, deleteDoc, doc, Timestamp, updateDoc } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
+import { addActivityLog } from './activity-log-service'
 import type { MemberRole } from '@/lib/types'
 
-export async function addMember(groupId: string, name: string, role: MemberRole = 'member'): Promise<string> {
+interface Actor {
+  id: string
+  name: string
+}
+
+export async function addMember(groupId: string, name: string, role: MemberRole = 'member', actor?: Actor): Promise<string> {
   const ref = await addDoc(collection(db, 'groups', groupId, 'members'), {
     groupId,
     name,
@@ -11,11 +17,29 @@ export async function addMember(groupId: string, name: string, role: MemberRole 
     isCurrentUser: false,
     createdAt: Timestamp.now(),
   })
+  if (actor) {
+    await addActivityLog(groupId, {
+      action: 'member_added',
+      actorId: actor.id,
+      actorName: actor.name,
+      description: `新增成員：${name}`,
+      entityId: ref.id,
+    })
+  }
   return ref.id
 }
 
-export async function removeMember(groupId: string, memberId: string): Promise<void> {
+export async function removeMember(groupId: string, memberId: string, actor?: Actor, removedMemberName?: string): Promise<void> {
   await deleteDoc(doc(db, 'groups', groupId, 'members', memberId))
+  if (actor) {
+    await addActivityLog(groupId, {
+      action: 'member_removed',
+      actorId: actor.id,
+      actorName: actor.name,
+      description: `移除成員：${removedMemberName ?? memberId}`,
+      entityId: memberId,
+    })
+  }
 }
 
 export async function updateMember(

--- a/src/lib/services/settlement-service.ts
+++ b/src/lib/services/settlement-service.ts
@@ -1,5 +1,7 @@
 import { addDoc, collection, serverTimestamp, Timestamp } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
+import { addActivityLog } from './activity-log-service'
+import { currency } from '@/lib/utils'
 
 export interface NewSettlement {
   fromMemberId: string
@@ -11,7 +13,12 @@ export interface NewSettlement {
   date: Date
 }
 
-export async function addSettlement(groupId: string, data: NewSettlement): Promise<string> {
+interface Actor {
+  id: string
+  name: string
+}
+
+export async function addSettlement(groupId: string, data: NewSettlement, actor?: Actor): Promise<string> {
   const ref = await addDoc(collection(db, 'groups', groupId, 'settlements'), {
     groupId,
     fromMemberId: data.fromMemberId,
@@ -23,5 +30,14 @@ export async function addSettlement(groupId: string, data: NewSettlement): Promi
     date: Timestamp.fromDate(data.date),
     createdAt: serverTimestamp(),
   })
+  if (actor) {
+    await addActivityLog(groupId, {
+      action: 'settlement_created',
+      actorId: actor.id,
+      actorName: actor.name,
+      description: `記錄結算：${data.fromMemberName} → ${data.toMemberName} ${currency(data.amount)}`,
+      entityId: ref.id,
+    })
+  }
   return ref.id
 }


### PR DESCRIPTION
## Summary

所有 CRUD service 補上 `addActivityLog()` 呼叫，確保每次資料異動都有稽核軌跡。

## 變更

### Service 層
- `expense-service.ts`: `addExpense` / `updateExpense` / `deleteExpense` 補上 logging
- `settlement-service.ts`: `addSettlement` 補上 logging
- `member-service.ts`: `addMember` / `removeMember` 補上 logging
- `category-service.ts`: `addCategory` / `updateCategory` / `deleteCategory` 補上 logging

### UI 層
- `expense-form.tsx`: 傳入 actor 資訊
- `records/page.tsx`: 傳入 actor 資訊
- `split/page.tsx`: 傳入 actor 資訊
- `settings/page.tsx`: 傳入 actor 資訊
- `settings/categories/page.tsx`: 移除重複的 activity log 呼叫（已移到 service 層）

## Test plan

- [ ] Build passes
- [ ] ESLint passes
- [ ] 新增 / 編輯 / 刪除支出後，activity log 有記錄
- [ ] 新增 / 刪除成員後，activity log 有記錄
- [ ] 新增 / 刪除類別後，activity log 有記錄
- [ ] 記錄結算後，activity log 有記錄

Closes #23

🤖 Generated with [Claude Code](https://claude.ai/code)