### PR TITLE
fix(member): 刪除 currentUser 成員時自動遞補

### DIFF
--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -49,9 +49,9 @@ function MembersSection({ groupId }: { groupId: string }) {
     }
   }
 
-  async function handleDelete(memberId: string, memberName: string) {
+  async function handleDelete(memberId: string, memberName: string, isCurrentUser: boolean) {
     if (!confirm(`確定要刪除成員「${memberName}」嗎？此操作無法復原。`)) return
-    await removeMember(groupId, memberId, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined, memberName)
+    await removeMember(groupId, memberId, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined, memberName, isCurrentUser)
   }
 
   async function handleRename(memberId: string) {
@@ -111,7 +111,7 @@ function MembersSection({ groupId }: { groupId: string }) {
               </button>
               <button onClick={() => { setEditingId(m.id); setEditName(m.name) }}
                 className="text-xs px-2 py-1 rounded border border-[var(--border)] hover:bg-[var(--muted)] text-[var(--muted-foreground)]">改名</button>
-              <button onClick={() => handleDelete(m.id, m.name)}
+              <button onClick={() => handleDelete(m.id, m.name, m.isCurrentUser)}
                 className="text-xs px-2 py-1 rounded hover:bg-red-50 dark:hover:bg-red-950 text-[var(--destructive)]">刪除</button>
             </>
           )}

--- a/src/lib/services/member-service.ts
+++ b/src/lib/services/member-service.ts
@@ -1,4 +1,4 @@
-import { addDoc, collection, deleteDoc, doc, Timestamp, updateDoc } from 'firebase/firestore'
+import { addDoc, collection, deleteDoc, doc, getDocs, Timestamp, updateDoc } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
 import { addActivityLog } from './activity-log-service'
 import type { MemberRole } from '@/lib/types'
@@ -29,7 +29,22 @@ export async function addMember(groupId: string, name: string, role: MemberRole 
   return ref.id
 }
 
-export async function removeMember(groupId: string, memberId: string, actor?: Actor, removedMemberName?: string): Promise<void> {
+export async function removeMember(
+  groupId: string,
+  memberId: string,
+  actor?: Actor,
+  removedMemberName?: string,
+  wasCurrentUser?: boolean,
+): Promise<void> {
+  // If deleting the current user, promote another member first
+  if (wasCurrentUser) {
+    const snap = await getDocs(collection(db, 'groups', groupId, 'members'))
+    const replacement = snap.docs.find((d) => d.id !== memberId)
+    if (replacement) {
+      await updateDoc(doc(db, 'groups', groupId, 'members', replacement.id), { isCurrentUser: true })
+    }
+  }
+
   await deleteDoc(doc(db, 'groups', groupId, 'members', memberId))
   if (actor) {
     await addActivityLog(groupId, {


### PR DESCRIPTION
## Summary

刪除 `isCurrentUser === true` 的成員時，自動將另一成員升級為 currentUser，避免「我」標記消失。

## 變更

- `member-service.ts`: `removeMember` 支援 `wasCurrentUser` 參數，刪除前自動遞補
- `settings/page.tsx`: 傳入 `m.isCurrentUser` 至 `handleDelete`

## Test plan

- [ ] Build passes
- [ ] ESLint passes
- [ ] 手動測試：刪除「我」成員，確認另一成員被自動設為 currentUser

Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)