### PR TITLE
feat(emulator): add Firebase Auth Emulator infrastructure for E2E testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm run test
 
   e2e-tests:
-    name: Playwright E2E Tests
+    name: Playwright E2E Tests (with Firebase Emulator)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,5 +42,24 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      - name: Install Firebase CLI and start Emulators
+        run: |
+          npm install -g firebase-tools
+          firebase emulators:start --only auth,firestore --project demo-test &
+          EMULATOR_PID=$!
+          echo "EMULATOR_PID=$EMULATOR_PID" >> $GITHUB_ENV
+          # Wait for emulators to start
+          sleep 15
+
       - name: Run Playwright tests
+        env:
+          USE_FIREBASE_EMULATOR: 'true'
+          FIREBASE_EMULATOR_HOST: 'localhost'
         run: npx playwright test
+
+      - name: Stop Firebase Emulators
+        if: always()
+        run: |
+          if [ -n "$EMULATOR_PID" ]; then
+            kill $EMULATOR_PID 2>/dev/null || true
+          fi

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,24 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "storage": {
+    "rules": "storage.rules"
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "storage": {
+      "port": 9199
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    },
+    "singleProjectMode": true
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,126 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // ─── 輔助函式 ───
+
+    // 是否已登入
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    // 是否為群組成員
+    function isGroupMember(groupId) {
+      return isSignedIn() &&
+        request.auth.uid in get(/databases/$(database)/documents/groups/$(groupId)).data.memberUids;
+    }
+
+    // 是否為群組擁有者
+    function isGroupOwner(groupId) {
+      return isSignedIn() &&
+        request.auth.uid == get(/databases/$(database)/documents/groups/$(groupId)).data.ownerUid;
+    }
+
+    // 資料大小限制
+    function isReasonableSize() {
+      return request.resource.data.keys().Size() < 30;
+    }
+
+    // ─── 群組 ───
+
+    match /groups/{groupId} {
+
+      // 讀取：群組成員，或已登入使用者透過邀請碼查詢（list query）
+      allow read: if isGroupMember(groupId)
+        || (isSignedIn() && resource.data.inviteCode != null);
+
+      // 建立：任何已登入使用者（建群組）
+      // 必須包含 ownerUid = 自己，且 memberUids 包含自己
+      allow create: if isSignedIn()
+        && request.resource.data.ownerUid == request.auth.uid
+        && request.auth.uid in request.resource.data.memberUids
+        && request.resource.data.name is string
+        && request.resource.data.name.size() > 0
+        && request.resource.data.name.size() <= 50;
+
+      // 更新：僅群組成員，但 ownerUid 不可變更（除非是 owner 自己轉移）
+      allow update: if isGroupMember(groupId)
+        && isReasonableSize()
+        && (request.resource.data.ownerUid == resource.data.ownerUid
+            || isGroupOwner(groupId));
+
+      // 刪除：僅群組擁有者
+      allow delete: if isGroupOwner(groupId);
+
+      // ─── 成員 ───
+
+      match /members/{memberId} {
+        allow read: if isGroupMember(groupId);
+        allow create: if isGroupMember(groupId)
+          && request.resource.data.name is string
+          && request.resource.data.name.size() > 0
+          && request.resource.data.name.size() <= 30;
+        allow update: if isGroupMember(groupId)
+          && request.resource.data.name is string
+          && request.resource.data.name.size() > 0
+          && request.resource.data.name.size() <= 30;
+        allow delete: if isGroupOwner(groupId);
+      }
+
+      // ─── 支出 ───
+
+      match /expenses/{expenseId} {
+        allow read: if isGroupMember(groupId);
+
+        allow create: if isGroupMember(groupId)
+          && request.resource.data.description is string
+          && request.resource.data.description.size() > 0
+          && request.resource.data.description.size() <= 200
+          && request.resource.data.amount is number
+          && request.resource.data.amount > 0
+          && request.resource.data.amount < 100000000
+          && request.resource.data.category is string
+          && request.resource.data.payerId is string
+          && request.resource.data.payerName is string
+          && isReasonableSize();
+
+        allow update: if isGroupMember(groupId)
+          && request.resource.data.amount is number
+          && request.resource.data.amount > 0
+          && request.resource.data.amount < 100000000
+          && isReasonableSize();
+
+        // 刪除：僅建立者或群組 owner
+        allow delete: if isGroupMember(groupId)
+          && (resource.data.createdBy == request.auth.uid || isGroupOwner(groupId));
+      }
+
+      // ─── 結算 ───
+
+      match /settlements/{settlementId} {
+        allow read: if isGroupMember(groupId);
+
+        allow create: if isGroupMember(groupId)
+          && request.resource.data.amount is number
+          && request.resource.data.amount > 0
+          && request.resource.data.amount < 100000000
+          && request.resource.data.fromMemberId is string
+          && request.resource.data.toMemberId is string
+          && isReasonableSize();
+
+        allow update: if isGroupMember(groupId)
+          && request.resource.data.amount is number
+          && request.resource.data.amount > 0
+          && request.resource.data.amount < 100000000;
+        // 刪除：僅建立者或群組 owner
+        allow delete: if isGroupMember(groupId)
+          && (resource.data.fromMemberId == request.auth.uid || isGroupOwner(groupId));
+      }
+    }
+
+    // ─── 其他路徑：全部拒絕 ───
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,5 +28,9 @@ export default defineConfig({
     url: 'http://localhost:3000',
     reuseExistingServer: true,
     timeout: 120 * 1000,
+    env: {
+      USE_FIREBASE_EMULATOR: 'true',
+      FIREBASE_EMULATOR_HOST: 'localhost',
+    },
   },
 })

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from 'firebase/app'
-import { getAuth } from 'firebase/auth'
-import { getFirestore } from 'firebase/firestore'
-import { getStorage } from 'firebase/storage'
+import { getAuth, connectAuthEmulator } from 'firebase/auth'
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore'
+import { getStorage, connectStorageEmulator } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: 'AIzaSyD9FyDSM4-acovBVfMvf_2kLW1IaJcVsMQ',
@@ -17,3 +17,12 @@ const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0
 export const auth = getAuth(app)
 export const db = getFirestore(app)
 export const storage = getStorage(app)
+
+// Connect to Firebase Emulators in test/development mode
+if (process.env.NODE_ENV === 'test' || process.env.USE_FIREBASE_EMULATOR === 'true') {
+  const emulatorHost = process.env.FIREBASE_EMULATOR_HOST ?? 'localhost'
+
+  connectAuthEmulator(auth, `http://${emulatorHost}:9099`, { disableWarnings: true })
+  connectFirestoreEmulator(db, emulatorHost, 8080)
+  connectStorageEmulator(storage, emulatorHost, 9199)
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,23 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    // 收據照片：僅已登入使用者可讀寫自己上傳的檔案
+    match /receipts/{groupId}/{expenseId}/{fileName} {
+      // 讀取：任何已登入使用者（同群組驗證由 Firestore 處理）
+      allow read: if request.auth != null;
+
+      // 上傳：已登入 + 檔案 < 10MB + 圖片類型
+      allow write: if request.auth != null
+        && request.resource.size < 10 * 1024 * 1024
+        && request.resource.contentType.matches('image/.*');
+
+      // 刪除：已登入
+      allow delete: if request.auth != null;
+    }
+
+    // 其他路徑：全部拒絕
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/tests/helpers/firebase-auth-emulator.ts
+++ b/tests/helpers/firebase-auth-emulator.ts
@@ -1,0 +1,140 @@
+/**
+ * Firebase Auth Emulator helper for E2E tests
+ *
+ * Provides utilities to:
+ * - Create test users in the Auth Emulator
+ * - Sign in via email/password (easier than Google OAuth for testing)
+ */
+
+// Emulator REST API endpoints
+const EMULATOR_HOST = process.env.FIREBASE_EMULATOR_HOST ?? 'localhost'
+const AUTH_EMULATOR_URL = `http://${EMULATOR_HOST}:9099`
+
+export interface TestUser {
+  uid: string
+  email: string
+  password: string
+  displayName: string
+}
+
+/**
+ * Create a test user in the Firebase Auth Emulator
+ */
+export async function createTestUser(user: TestUser): Promise<void> {
+  const response = await fetch(`${AUTH_EMULATOR_URL}/identitytoolkit/v1/relyingparty/signupNewUser`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: user.email,
+      password: user.password,
+      displayName: user.displayName,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to create test user: ${await response.text()}`)
+  }
+}
+
+/**
+ * Create multiple test users for a family group
+ */
+export async function setupTestFamily(): Promise<TestUser[]> {
+  const family = [
+    { email: 'dad@test.com', password: 'testpass123', displayName: '爸爸' },
+    { email: 'mom@test.com', password: 'testpass123', displayName: '媽媽' },
+    { email: 'kid@test.com', password: 'testpass123', displayName: '小孩' },
+  ]
+
+  for (const user of family) {
+    await createTestUser(user)
+  }
+
+  return family
+}
+
+/**
+ * Sign in via email/password (Firebase Auth Emulator REST API)
+ * Returns the idToken needed for authenticated requests
+ */
+export async function signInWithEmailPassword(
+  email: string,
+  password: string
+): Promise<string> {
+  const response = await fetch(`${AUTH_EMULATOR_URL}/identitytoolkit/v1/relyingparty/verifyPassword`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email,
+      password,
+      returnSecureToken: true,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to sign in: ${await response.text()}`)
+  })
+
+  const data = await response.json()
+  return data.idToken
+}
+
+/**
+ * Delete a test user from the Auth Emulator
+ */
+export async function deleteTestUser(email: string): Promise<void> {
+  // First get the user by email to get the localId
+  const response = await fetch(
+    `${AUTH_EMULATOR_URL}/identitytoolkit/v1/relyingparty/getAccountInfo`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    }
+  )
+
+  if (!response.ok) {
+    return // User doesn't exist, nothing to delete
+  }
+
+  const data = await response.json()
+  if (data.users && data.users.length > 0) {
+    const uid = data.users[0].localId
+    await fetch(`${AUTH_EMULATOR_URL}/identitytoolkit/v1/relyingparty/deleteAccount`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ localId: uid }),
+    })
+  }
+}
+
+/**
+ * Clear all test users from the Auth Emulator
+ * Warning: This deletes ALL users in the emulator
+ */
+export async function clearAllTestUsers(): Promise<void> {
+  // List all users
+  const response = await fetch(
+    `${AUTH_EMULATOR_URL}/identitytoolkit/v1/relyingparty/getAccountInfo`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ limit: 100 }),
+    }
+  )
+
+  if (!response.ok) {
+    return
+  }
+
+  const data = await response.json()
+  if (data.users) {
+    for (const user of data.users) {
+      await fetch(`${AUTH_EMULATOR_URL}/identitytoolkit/v1/relyingparty/deleteAccount`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ localId: user.localId }),
+      })
+    }
+  }
+}

--- a/tests/helpers/firebase-emulator-setup.ts
+++ b/tests/helpers/firebase-emulator-setup.ts
@@ -1,0 +1,181 @@
+/**
+ * Firebase Emulator Setup Helper for E2E Tests
+ *
+ * Provides utilities to:
+ * - Set up test group with members in Firestore emulator
+ * - Seed test expenses
+ */
+
+import type { TestUser } from './firebase-auth-emulator'
+
+const EMULATOR_HOST = process.env.FIREBASE_EMULATOR_HOST ?? 'localhost'
+const FIRESTORE_EMULATOR_URL = `http://${EMULATOR_HOST}:8080`
+const PROJECT_ID = 'family-ledger-784ed'
+
+interface TestMember {
+  id: string
+  name: string
+  isCurrentUser?: boolean
+}
+
+/**
+ * Create a test group with members in Firestore
+ */
+export async function setupTestGroup(
+  ownerUid: string,
+  ownerName: string,
+  members: TestMember[]
+): Promise<string> {
+  const groupId = `test-group-${Date.now()}`
+
+  // Create group document
+  await fetch(
+    `https://${PROJECT_ID}.firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/groups/${groupId}`,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer owner',
+      },
+      body: JSON.stringify({
+        fields: {
+          name: { stringValue: '測試家庭' },
+          ownerUid: { stringValue: ownerUid },
+          memberUids: {
+            arrayValue: {
+              values: members.map((m) => ({ stringValue: m.id })),
+            },
+          },
+          isPrimary: { booleanValue: true },
+          createdAt: { timestampValue: new Date().toISOString() },
+        },
+      }),
+    }
+  )
+
+  // Create member documents
+  for (const member of members) {
+    await fetch(
+      `https://${PROJECT_ID}.firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/groups/${groupId}/members/${member.id}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer owner',
+        },
+        body: JSON.stringify({
+          fields: {
+            name: { stringValue: member.name },
+            role: { stringValue: 'member' },
+            isCurrentUser: { booleanValue: member.isCurrentUser ?? false },
+            sortOrder: { integerValue: 0 },
+          },
+        }),
+      }
+    )
+  }
+
+  return groupId
+}
+
+/**
+ * Seed test expenses for a group
+ */
+export async function seedTestExpenses(
+  groupId: string,
+  expenses: Array<{
+    description: string
+    amount: number
+    category: string
+    payerId: string
+    payerName: string
+    isShared: boolean
+  }>
+): Promise<void> {
+  for (let i = 0; i < expenses.length; i++) {
+    const exp = expenses[i]
+    const docId = `test-exp-${Date.now()}-${i}`
+
+    await fetch(
+      `https://${PROJECT_ID}.firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/groups/${groupId}/expenses/${docId}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer owner',
+        },
+        body: JSON.stringify({
+          fields: {
+            description: { stringValue: exp.description },
+            amount: { integerValue: exp.amount },
+            category: { stringValue: exp.category },
+            payerId: { stringValue: exp.payerId },
+            payerName: { stringValue: exp.payerName },
+            isShared: { booleanValue: exp.isShared },
+            date: { timestampValue: new Date().toISOString() },
+            splitMethod: { stringValue: 'equal' },
+            paymentMethod: { stringValue: 'cash' },
+            createdBy: { stringValue: exp.payerId },
+            splits: {
+              arrayValue: {
+                values: exp.isShared
+                  ? [
+                      { mapValue: { fields: { memberId: { stringValue: exp.payerId }, memberName: { stringValue: exp.payerName }, shareAmount: { integerValue: exp.amount }, paidAmount: { integerValue: exp.amount }, isParticipant: { booleanValue: true } } } },
+                    ]
+                  : [],
+              },
+            },
+          },
+        }),
+      }
+    )
+  }
+}
+
+/**
+ * Clean up test group data
+ */
+export async function cleanupTestGroup(groupId: string): Promise<void> {
+  // Delete expenses
+  const expResponse = await fetch(
+    `https://${PROJECT_ID}.firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents:runQuery`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        structuredQuery: {
+          from: [{ collectionId: 'expenses' }],
+          where: {
+            fieldFilter: {
+              field: { fieldPath: '__name__' },
+              op: 'PATH_STARTS_WITH',
+              value: { stringValue: `groups/${groupId}/expenses/` },
+            },
+          },
+        },
+      }),
+    }
+  )
+
+  if (expResponse.ok) {
+    const expData = await expResponse.json()
+    for (const doc of expData) {
+      if (doc.document) {
+        const docPath = doc.document.name
+        await fetch(`https://${PROJECT_ID}.firestore.googleapis.com/v1/${docPath}`, {
+          method: 'DELETE',
+          headers: { Authorization: 'Bearer owner' },
+        })
+      }
+    }
+  }
+
+  // Delete members
+  await fetch(
+    `https://${PROJECT_ID}.firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents/groups/${groupId}`,
+    {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer owner' },
+    }
+  )
+}


### PR DESCRIPTION
## Summary

Sets up Firebase Auth Emulator infrastructure to enable the 34 skipped E2E tests that require Firebase authentication.

### Changes

- **firebase.json**: Added emulator configuration (auth:9099, firestore:8080, storage:9199)
- **firestore.rules / storage.rules**: Copied from Flutter app for consistent security rules
- **src/lib/firebase.ts**: Added emulator connection when `USE_FIREBASE_EMULATOR=true`
- **tests/helpers/**: Added test helpers for creating users and test data in emulator
- **playwright.config.ts**: Added emulator environment variables
- **CI workflow**: Updated to start emulators before running E2E tests

### Test plan

- [x] Build passes
- [x] Jest tests pass (40/40)
- [ ] Verify Firebase emulator starts correctly
- [ ] Enable skipped E2E tests to run with emulator

Closes #30