### PR TITLE
feat(domain): 建立 shared domain package (#28)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
+        "@family-ledger/domain": "file:../packages/family-ledger-domain/dist",
         "@playwright/test": "^1.58.2",
         "@swc/core": "^1.15.21",
         "@swc/jest": "^0.2.39",
@@ -38,6 +39,9 @@
         "ts-jest": "^29.4.6",
         "typescript-eslint": "^8.57.2"
       }
+    },
+    "../packages/family-ledger-domain/dist": {
+      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -832,6 +836,10 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
+    },
+    "node_modules/@family-ledger/domain": {
+      "resolved": "../packages/family-ledger-domain/dist",
+      "link": true
     },
     "node_modules/@firebase/ai": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@family-ledger/domain": "file:../packages/family-ledger-domain/dist",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",


### PR DESCRIPTION
## Summary
- 建立 `@family-ledger/domain` shared domain package，位於 `../packages/family-ledger-domain/`
- 包含 types、split-calculator、local-expense-parser、firestore-schema
- Web app 新增 dependency 指向 shared package

## 架構說明
shared domain package 包含平台無關的商業邏輯：
- `types.ts` - 共享類型（Expense, Settlement, SplitDetail 等）
- `split-calculator.ts` - 分帳計算邏輯（equal/percentage/custom split, debt simplification）
- `local-expense-parser.ts` - 中文智慧記帳解析
- `firestore-schema.ts` - Firestore 路徑常量

Web app 目前使用 local copy，未來可迁移到直接 import `@family-ledger/domain`。

## Test plan
- [x] `npm run build` - Build passes
- [x] `npm run test` - 40/40 tests pass
- [x] `npm run lint` - 0 errors, 28 warnings (現有 warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)