### PR TITLE
fix(types): add createdBy to Settlement interface

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -65,6 +65,7 @@ export interface Settlement {
   note?: string
   date: Timestamp
   createdAt: Timestamp
+  createdBy?: string
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary

- Add `createdBy?: string` to `Settlement` TypeScript interface
- The `settlement-service.ts` (PR #52) already writes `createdBy` to Firestore documents, but the type definition was missing this field
- Marked as optional (`?:`) for backward compatibility with existing settlements that may not have the field

## Test plan

- [x] Build: passes
- [x] TypeScript: 0 errors  
- [x] Unit tests: 42 passed