### PR TITLE
fix(qa): clamp inputs, settle dialog error, toggle activity log (#56)

### DIFF
--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -12,6 +12,7 @@ import { useColorTheme, COLOR_THEMES } from '@/lib/hooks/use-color-theme'
 import { addMember, removeMember, updateMember } from '@/lib/services/member-service'
 import { createGroup } from '@/lib/services/group-service'
 import { addCategory, updateCategory } from '@/lib/services/category-service'
+import { addActivityLog } from '@/lib/services/activity-log-service'
 import { useRouter } from 'next/navigation'
 import type { FamilyMember, Category } from '@/lib/types'
 
@@ -86,6 +87,19 @@ function MembersSection({ groupId }: { groupId: string }) {
     batch.update(doc(db, 'groups', groupId, 'members', member.id), { isCurrentUser: next })
     try {
       await batch.commit()
+      if (next && user) {
+        try {
+          await addActivityLog(groupId, {
+            action: 'member_updated',
+            actorId: user.uid,
+            actorName: user.displayName ?? '未知',
+            description: `切換目前成員：${member.name}`,
+            entityId: member.id,
+          })
+        } catch (e) {
+          console.error('[Settings] Failed to log activity:', e)
+        }
+      }
     } catch (e) {
       console.error('[Settings] Failed to toggle current user:', e)
       alert('更新失敗，請稍後再試')

--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -28,7 +28,10 @@ function SettleDialog({ fromName, toName, suggested, onClose, onConfirm }: Settl
 
   async function handleSubmit() {
     const n = Math.round(parseFloat(amount))
-    if (!n || n <= 0) return
+    if (!n || n <= 0) {
+      setError('請輸入有效的金額')
+      return
+    }
     setSaving(true)
     setError(null)
     try {

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -303,7 +303,7 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
             <div key={m.id} className="flex items-center gap-2">
               <span className="w-16 text-sm">{m.name}</span>
               <input type="number" placeholder="%" value={percentages[m.id] ?? ''}
-                onChange={(e) => setPercentages({ ...percentages, [m.id]: parseFloat(e.target.value) || 0 })}
+                onChange={(e) => setPercentages({ ...percentages, [m.id]: Math.min(100, Math.max(0, parseFloat(e.target.value) || 0)) })}
                 className="flex-1 h-9 rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 text-sm" />
               <span className="text-xs text-[var(--muted-foreground)]">%</span>
             </div>
@@ -313,7 +313,7 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
             <div key={m.id} className="flex items-center gap-2">
               <span className="w-16 text-sm">{m.name}</span>
               <input type="number" placeholder="NT$" value={customAmounts[m.id] ?? ''}
-                onChange={(e) => setCustomAmounts({ ...customAmounts, [m.id]: parseFloat(e.target.value) || 0 })}
+                onChange={(e) => setCustomAmounts({ ...customAmounts, [m.id]: Math.max(0, parseFloat(e.target.value) || 0) })}
                 className="flex-1 h-9 rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 text-sm" />
             </div>
           ))}


### PR DESCRIPTION
## Summary

修復 QA 發現的 1 個 P2 + 3 個 P3 問題：

1. **expense-form.tsx**: 百分比分帳輸入夾在 0-100，自訂金額限制 >= 0
2. **split/page.tsx**: Settle dialog 無效金額時顯示錯誤訊息
3. **settings/page.tsx**: isCurrentUser toggle 完成後寫入 activity log

## Test plan

- [x] Build: ✅
- [x] TypeScript: 0 errors ✅
- [x] Unit Tests: 42 passed ✅
- [x] Lint: 0 errors (45 warnings — all console.error in catch blocks, intentional) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)