### PR TITLE
fix: error boundaries, percentage rounding, group validation (#60)

### DIFF
--- a/src/app/(auth)/error.tsx
+++ b/src/app/(auth)/error.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+export default function AuthError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-8">
+      <div className="max-w-sm w-full text-center space-y-4">
+        <div className="text-6xl">⚠️</div>
+        <h1 className="text-xl font-bold">載入失敗</h1>
+        <p className="text-sm text-[var(--muted-foreground)]">
+          無法載入頁面，請稍後再試。
+        </p>
+        {error.digest && (
+          <p className="text-xs text-[var(--muted-foreground)] font-mono">
+            {error.digest}
+          </p>
+        )}
+        <button
+          onClick={reset}
+          className="w-full h-10 rounded-lg font-medium text-white"
+          style={{ backgroundColor: 'var(--primary)' }}
+        >
+          重新整理
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-8">
+      <div className="max-w-sm w-full text-center space-y-4">
+        <div className="text-6xl">⚠️</div>
+        <h1 className="text-xl font-bold">發生錯誤</h1>
+        <p className="text-sm text-[var(--muted-foreground)]">
+          抱歉，發生了一些問題。請嘗試重新整理頁面。
+        </p>
+        {error.digest && (
+          <p className="text-xs text-[var(--muted-foreground)] font-mono">
+            Error ID: {error.digest}
+          </p>
+        )}
+        <button
+          onClick={reset}
+          className="w-full h-10 rounded-lg font-medium text-white"
+          style={{ backgroundColor: 'var(--primary)' }}
+        >
+          重新整理
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -115,6 +115,11 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         share = i === participants.length - 1 ? per + remainder : per
       } else if (splitMethod === 'percentage') {
         share = Math.round(amt * (percentages[m.id] ?? 0) / 100)
+        // Distribute rounding remainder to last participant to ensure sum matches amount
+        if (i === participants.length - 1) {
+          const total = participants.reduce((s, pm) => s + Math.round(amt * (percentages[pm.id] ?? 0) / 100), 0)
+          share += amt - total
+        }
       } else {
         share = customAmounts[m.id] ?? 0
       }

--- a/src/lib/services/group-service.ts
+++ b/src/lib/services/group-service.ts
@@ -5,9 +5,12 @@ import { auth } from '@/lib/firebase'
 export async function createGroup(name: string): Promise<string> {
   const user = auth.currentUser
   if (!user) throw new Error('User not authenticated')
+  const trimmed = name.trim()
+  if (!trimmed) throw new Error('群組名稱不能為空')
+  if (trimmed.length > 50) throw new Error('群組名稱最長 50 字')
 
   const ref = await addDoc(collection(db, 'groups'), {
-    name,
+    name: trimmed,
     isPrimary: true,
     ownerUid: user.uid,
     memberUids: [user.uid],


### PR DESCRIPTION
## Summary

修復 1 個 CRITICAL + 2 個 HIGH 問題：

1. **global-error.tsx + (auth)/error.tsx**: 新增 React Error Boundary，避免元件錯誤時顯示白畫面
2. **expense-form.tsx**: 百分比分帳時，將 rounding remainder 分配給最後一位參與者，確保加總正確（如 33.3%+33.3%+33.4% 不會因為各自round而少 NT）
3. **group-service.ts**: createGroup 新增 trim、空白檢查、50字上限驗證

## Test plan

- [x] Build: ✅
- [x] TypeScript: 0 errors ✅
- [x] Unit Tests: 42 passed ✅
- [x] Lint: 0 errors (49 warnings) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)