### PR TITLE
fix: migrate enableIndexedDbPersistence to FirestoreSettings localCache

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,11 @@
 import { initializeApp, getApps } from 'firebase/app'
 import { getAuth, connectAuthEmulator } from 'firebase/auth'
-import { getFirestore, connectFirestoreEmulator, enableIndexedDbPersistence } from 'firebase/firestore'
+import {
+  initializeFirestore,
+  connectFirestoreEmulator,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+} from 'firebase/firestore'
 import { getStorage, connectStorageEmulator } from 'firebase/storage'
 
 const firebaseConfig = {
@@ -15,22 +20,13 @@ const firebaseConfig = {
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0]
 
 export const auth = getAuth(app)
-export const db = getFirestore(app)
 export const storage = getStorage(app)
 
-// Enable offline persistence for Firestore
-// This allows the app to work offline and sync when back online
-if (typeof window !== 'undefined') {
-  enableIndexedDbPersistence(db).catch((err) => {
-    if (err.code === 'failed-precondition') {
-      // Multiple tabs open - persistence can only be enabled in one tab at a time
-      console.warn('[Firebase] Offline persistence skipped: multiple tabs open')
-    } else if (err.code === 'unimplemented') {
-      // Browser doesn't support offline persistence
-      console.warn('[Firebase] Offline persistence not supported in this browser')
-    }
-  })
-}
+// Initialize Firestore with persistent local cache (replaces deprecated enableIndexedDbPersistence)
+const persistenceCache = persistentLocalCache({
+  tabManager: persistentMultipleTabManager(),
+})
+export const db = initializeFirestore(app, { localCache: persistenceCache })
 
 // Connect to Firebase Emulators in test/development mode
 if (process.env.NODE_ENV === 'test' || process.env.USE_FIREBASE_EMULATOR === 'true') {


### PR DESCRIPTION
## Summary

Firebase SDK 警告 enableIndexedDbPersistence 即將廢棄，遷移到新 API。

## Changes

- src/lib/firebase.ts: 替換舊的 enableIndexedDbPersistence 調用，改用 initializeFirestore + persistentLocalCache + persistentMultipleTabManager

## Test plan

- [x] Build passes
- [x] Unit tests pass 42/42
- [x] ESLint passes 0 errors

Closes #62