### PR TITLE
fix(eslint): resolve 18 no-unused-vars warnings by prefixing with _

### DIFF
--- a/src/app/(auth)/expense/new/page.tsx
+++ b/src/app/(auth)/expense/new/page.tsx
@@ -15,7 +15,7 @@ export default function NewExpensePage() {
   const availableCategories = categories.filter((c) => c.isActive).map((c) => c.name)
 
   // Expose a setter that ExpenseForm can call back to us via ref
-  const onVoiceParsedRef = useRef<((result: ParsedExpense) => void) | null>(null)
+  const onVoiceParsedRef = useRef<((_result: ParsedExpense) => void) | null>(null)
 
   function handleVoiceParsed(result: ParsedExpense) {
     onVoiceParsedRef.current?.(result)

--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -17,7 +17,7 @@ interface SettleDialogProps {
   toName: string
   suggested: number
   onClose: () => void
-  onConfirm: (amount: number, note: string) => Promise<void>
+  onConfirm: (_amount: number, _note: string) => Promise<void>
 }
 
 function SettleDialog({ fromName, toName, suggested, onClose, onConfirm }: SettleDialogProps) {

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -18,7 +18,7 @@ interface Props {
   duplicateFrom?: Expense
   onSaved: () => void
   /** Ref to register a setter for voice-parsed results. Parent passes ref, form fills it on mount. */
-  onVoiceParsedRef?: RefObject<((result: ParsedExpense) => void) | null>
+  onVoiceParsedRef?: RefObject<((_result: ParsedExpense) => void) | null>
 }
 
 export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoiceParsedRef }: Props) {

--- a/src/components/voice-input.tsx
+++ b/src/components/voice-input.tsx
@@ -20,7 +20,7 @@ type SpeechRecognitionCtor = new () => ISpeechRecognition
 
 interface Props {
   availableCategories?: string[]
-  onParsed: (result: ParsedExpense) => void
+  onParsed: (_result: ParsedExpense) => void
 }
 
 type Status = 'idle' | 'listening' | 'processing' | 'error'

--- a/src/lib/repositories/base-repository.ts
+++ b/src/lib/repositories/base-repository.ts
@@ -19,9 +19,9 @@ export interface QueryOptions {
 }
 
 export interface BaseRepository<T, CreateInput, UpdateInput> {
-  create(groupId: string, input: CreateInput): Promise<string>
-  update(groupId: string, id: string, input: UpdateInput): Promise<void>
-  delete(groupId: string, id: string): Promise<void>
-  getById(groupId: string, id: string): Promise<T | null>
-  query(groupId: string, options?: QueryOptions): Promise<PaginatedResult<T>>
+  create(_groupId: string, _input: CreateInput): Promise<string>
+  update(_groupId: string, _id: string, _input: UpdateInput): Promise<void>
+  delete(_groupId: string, _id: string): Promise<void>
+  getById(_groupId: string, _id: string): Promise<T | null>
+  query(_groupId: string, _options?: QueryOptions): Promise<PaginatedResult<T>>
 }

--- a/src/lib/repositories/expense-repository.ts
+++ b/src/lib/repositories/expense-repository.ts
@@ -66,5 +66,5 @@ export interface ExpenseQueryOptions extends QueryOptions {
 }
 
 export type ExpenseRepository = BaseRepository<Expense, ExpenseInput, ExpenseUpdate> & {
-  queryWithFilters(groupId: string, options?: ExpenseQueryOptions): Promise<PaginatedResult<Expense>>
+  queryWithFilters(_groupId: string, _options?: ExpenseQueryOptions): Promise<PaginatedResult<Expense>>
 }


### PR DESCRIPTION
## Summary

將 18 個 no-unused-vars warnings 全部修復，透過將閒置的 interface method parameters 和 callback type parameters 加上 _ 前綴來符合 ESLint argsIgnorePattern 規則。

## Changes

- base-repository.ts: _groupId, _input, _id, _options
- expense-repository.ts: _groupId, _options
- voice-input.tsx: _result (callback)
- expense-form.tsx: _result (callback)
- split/page.tsx: _amount, _note (callback)
- expense/new/page.tsx: _result (callback)

## Test plan

- [x] Build passes
- [x] Unit tests pass 42/42
- [x] ESLint: 29 warnings remain (all no-console, intentional)

Closes #64