### PR TITLE
perf: 效能優化 — 共享 Firestore Subscription + Bundle 瘦身 + nginx gzip

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,12 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   basePath: '/family-ledger-web',
+  outputFileTracingRoot: '/Users/openclaw/.openclaw/shared/projects/family-ledger-web',
+  compress: true,
+  poweredByHeader: false,
+  experimental: {
+    optimizePackageImports: ['firebase', 'recharts'],
+  },
 }
 
 export default nextConfig

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useAuth } from '@/lib/auth'
 import { GroupProvider } from '@/lib/group-context'
+import { GroupDataProvider } from '@/lib/group-data-context'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { NavShell } from '@/components/nav-shell'
@@ -26,7 +27,9 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <GroupProvider>
-      <NavShell>{children}</NavShell>
+      <GroupDataProvider>
+        <NavShell>{children}</NavShell>
+      </GroupDataProvider>
     </GroupProvider>
   )
 }

--- a/src/lib/group-data-context.tsx
+++ b/src/lib/group-data-context.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, useMemo, ReactNode } from 'react'
+import { collection, onSnapshot, orderBy, query, where, limit } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { useGroupContext } from '@/lib/group-context'
+import { useAuth } from '@/lib/auth'
+import type { Expense, FamilyMember, Settlement, Category, AppNotification } from '@/lib/types'
+import { logger } from '@/lib/logger'
+
+interface GroupDataContextType {
+  expenses: Expense[]
+  members: FamilyMember[]
+  settlements: Settlement[]
+  categories: Category[]
+  notifications: AppNotification[]
+  unreadCount: number
+  expensesLoading: boolean
+  membersLoading: boolean
+  settlementsLoading: boolean
+  categoriesLoading: boolean
+}
+
+const GroupDataContext = createContext<GroupDataContextType>({
+  expenses: [],
+  members: [],
+  settlements: [],
+  categories: [],
+  notifications: [],
+  unreadCount: 0,
+  expensesLoading: true,
+  membersLoading: true,
+  settlementsLoading: true,
+  categoriesLoading: true,
+})
+
+export function GroupDataProvider({ children }: { children: ReactNode }) {
+  const { activeGroup } = useGroupContext()
+  const { user } = useAuth()
+  const groupId = activeGroup?.id
+
+  const [expenses, setExpenses] = useState<Expense[]>([])
+  const [members, setMembers] = useState<FamilyMember[]>([])
+  const [settlements, setSettlements] = useState<Settlement[]>([])
+  const [categories, setCategories] = useState<Category[]>([])
+  const [notifications, setNotifications] = useState<AppNotification[]>([])
+  const [expensesLoading, setExpensesLoading] = useState(true)
+  const [membersLoading, setMembersLoading] = useState(true)
+  const [settlementsLoading, setSettlementsLoading] = useState(true)
+  const [categoriesLoading, setCategoriesLoading] = useState(true)
+
+  // Reset all data when group changes
+  useEffect(() => {
+    setExpenses([])
+    setMembers([])
+    setSettlements([])
+    setCategories([])
+    setNotifications([])
+    setExpensesLoading(true)
+    setMembersLoading(true)
+    setSettlementsLoading(true)
+    setCategoriesLoading(true)
+  }, [groupId])
+
+  // Expenses subscription
+  useEffect(() => {
+    if (!groupId) { setExpensesLoading(false); return }
+    const q = query(collection(db, 'groups', groupId, 'expenses'), orderBy('date', 'desc'), limit(200))
+    const unsub = onSnapshot(q,
+      (snap) => { setExpenses(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Expense)); setExpensesLoading(false) },
+      (err) => { logger.error('[GroupData] expenses error:', err); setExpensesLoading(false) },
+    )
+    return unsub
+  }, [groupId])
+
+  // Members subscription
+  useEffect(() => {
+    if (!groupId) { setMembersLoading(false); return }
+    const q = query(collection(db, 'groups', groupId, 'members'), orderBy('sortOrder'))
+    const unsub = onSnapshot(q,
+      (snap) => { setMembers(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as FamilyMember)); setMembersLoading(false) },
+      (err) => { logger.error('[GroupData] members error:', err); setMembersLoading(false) },
+    )
+    return unsub
+  }, [groupId])
+
+  // Settlements subscription
+  useEffect(() => {
+    if (!groupId) { setSettlementsLoading(false); return }
+    const q = query(collection(db, 'groups', groupId, 'settlements'), orderBy('date', 'desc'))
+    const unsub = onSnapshot(q,
+      (snap) => { setSettlements(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Settlement)); setSettlementsLoading(false) },
+      (err) => { logger.error('[GroupData] settlements error:', err); setSettlementsLoading(false) },
+    )
+    return unsub
+  }, [groupId])
+
+  // Categories subscription
+  useEffect(() => {
+    if (!groupId) { setCategoriesLoading(false); return }
+    const q = query(collection(db, 'groups', groupId, 'categories'), orderBy('sortOrder'))
+    const unsub = onSnapshot(q,
+      (snap) => { setCategories(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Category)); setCategoriesLoading(false) },
+      (err) => { logger.error('[GroupData] categories error:', err); setCategoriesLoading(false) },
+    )
+    return unsub
+  }, [groupId])
+
+  // Notifications subscription (per-user, with limit)
+  useEffect(() => {
+    if (!groupId || !user) { setNotifications([]); return }
+    const q = query(
+      collection(db, 'groups', groupId, 'notifications'),
+      where('recipientId', '==', user.uid),
+      orderBy('createdAt', 'desc'),
+      limit(50),
+    )
+    const unsub = onSnapshot(q,
+      (snap) => { setNotifications(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AppNotification)) },
+      (err) => { logger.error('[GroupData] notifications error:', err.message) },
+    )
+    return unsub
+  }, [groupId, user])
+
+  const unreadCount = useMemo(() => notifications.filter((n) => !n.isRead).length, [notifications])
+
+  const value = useMemo(() => ({
+    expenses, members, settlements, categories, notifications, unreadCount,
+    expensesLoading, membersLoading, settlementsLoading, categoriesLoading,
+  }), [expenses, members, settlements, categories, notifications, unreadCount,
+       expensesLoading, membersLoading, settlementsLoading, categoriesLoading])
+
+  return (
+    <GroupDataContext.Provider value={value}>
+      {children}
+    </GroupDataContext.Provider>
+  )
+}
+
+export const useGroupData = () => useContext(GroupDataContext)

--- a/src/lib/hooks/use-categories.ts
+++ b/src/lib/hooks/use-categories.ts
@@ -1,37 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { collection, onSnapshot, orderBy, query } from 'firebase/firestore'
-import { db } from '@/lib/firebase'
-import type { Category } from '@/lib/types'
+import { useGroupData } from '@/lib/group-data-context'
 
-import { logger } from '@/lib/logger'
-
-export function useCategories(groupId: string | undefined) {
-  const [categories, setCategories] = useState<Category[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    if (!groupId) {
-      setLoading(false)
-      return
-    }
-    const q = query(
-      collection(db, 'groups', groupId, 'categories'),
-      orderBy('sortOrder'),
-    )
-    const unsub = onSnapshot(q,
-      (snap) => {
-        setCategories(snap.docs.map((d) => ({ id: d.id, ...d.data() } as Category)))
-        setLoading(false)
-      },
-      (err) => {
-        logger.error('[useCategories] Snapshot error:', err)
-        setLoading(false)
-      },
-    )
-    return unsub
-  }, [groupId])
-
+export function useCategories(_groupId?: string) {
+  const { categories, categoriesLoading: loading } = useGroupData()
   return { categories, loading }
 }

--- a/src/lib/hooks/use-expenses.ts
+++ b/src/lib/hooks/use-expenses.ts
@@ -1,37 +1,12 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
-import { collection, onSnapshot, orderBy, query } from 'firebase/firestore'
-import { db } from '@/lib/firebase'
+import { useMemo } from 'react'
+import { useGroupData } from '@/lib/group-data-context'
 import { toDate } from '@/lib/utils'
 import type { Expense } from '@/lib/types'
 
-import { logger } from '@/lib/logger'
-
-export function useExpenses(groupId: string | undefined) {
-  const [expenses, setExpenses] = useState<Expense[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    if (!groupId) {
-      setLoading(false)
-      return
-    }
-    // Path: groups/{groupId}/expenses
-    const q = query(collection(db, 'groups', groupId, 'expenses'), orderBy('date', 'desc'))
-    const unsub = onSnapshot(q,
-      (snap) => {
-        setExpenses(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Expense))
-        setLoading(false)
-      },
-      (err) => {
-        logger.error('[useExpenses] Snapshot error:', err)
-        setLoading(false)
-      },
-    )
-    return unsub
-  }, [groupId])
-
+export function useExpenses(_groupId?: string) {
+  const { expenses, expensesLoading: loading } = useGroupData()
   return { expenses, loading }
 }
 

--- a/src/lib/hooks/use-members.ts
+++ b/src/lib/hooks/use-members.ts
@@ -1,34 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { collection, onSnapshot, orderBy, query } from 'firebase/firestore'
-import { db } from '@/lib/firebase'
-import type { FamilyMember } from '@/lib/types'
+import { useGroupData } from '@/lib/group-data-context'
 
-import { logger } from '@/lib/logger'
-
-export function useMembers(groupId: string | undefined) {
-  const [members, setMembers] = useState<FamilyMember[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    if (!groupId) {
-      setLoading(false)
-      return
-    }
-    const q = query(collection(db, 'groups', groupId, 'members'), orderBy('sortOrder'))
-    const unsub = onSnapshot(q,
-      (snap) => {
-        setMembers(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as FamilyMember))
-        setLoading(false)
-      },
-      (err) => {
-        logger.error('[useMembers] Snapshot error:', err)
-        setLoading(false)
-      },
-    )
-    return unsub
-  }, [groupId])
-
+export function useMembers(_groupId?: string) {
+  const { members, membersLoading: loading } = useGroupData()
   return { members, loading }
 }

--- a/src/lib/hooks/use-notifications.ts
+++ b/src/lib/hooks/use-notifications.ts
@@ -1,41 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { collection, query, orderBy, onSnapshot, where } from 'firebase/firestore'
-import { db } from '@/lib/firebase'
-import type { AppNotification } from '@/lib/types'
+import { useGroupData } from '@/lib/group-data-context'
 
-import { logger } from '@/lib/logger'
-
-export function useNotifications(groupId: string | undefined, recipientId: string | undefined) {
-  const [notifications, setNotifications] = useState<AppNotification[]>([])
-  const [unreadCount, setUnreadCount] = useState(0)
-
-  useEffect(() => {
-    if (!groupId || !recipientId) return
-
-    const q = query(
-      collection(db, 'groups', groupId, 'notifications'),
-      where('recipientId', '==', recipientId),
-      orderBy('createdAt', 'desc')
-    )
-
-    const unsub = onSnapshot(
-      q,
-      (snap) => {
-        const notifs = snap.docs.map((d) => ({ id: d.id, ...d.data() } as AppNotification))
-        setNotifications(notifs)
-        setUnreadCount(notifs.filter((n) => !n.isRead).length)
-      },
-      (err) => {
-        // Likely a missing composite index (recipientId + createdAt).
-        // Deploy: firebase deploy --only firestore:indexes
-        logger.error('[useNotifications] Firestore query failed:', err.message)
-      },
-    )
-
-    return unsub
-  }, [groupId, recipientId])
-
+export function useNotifications(_groupId?: string, _recipientId?: string) {
+  const { notifications, unreadCount } = useGroupData()
   return { notifications, unreadCount }
 }

--- a/src/lib/hooks/use-settlements.ts
+++ b/src/lib/hooks/use-settlements.ts
@@ -1,35 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { collection, onSnapshot, orderBy, query } from 'firebase/firestore'
-import { db } from '@/lib/firebase'
-import type { Settlement } from '@/lib/types'
+import { useGroupData } from '@/lib/group-data-context'
 
-import { logger } from '@/lib/logger'
-
-export function useSettlements(groupId: string | undefined) {
-  const [settlements, setSettlements] = useState<Settlement[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    if (!groupId) {
-      setLoading(false)
-      return
-    }
-    // Path: groups/{groupId}/settlements
-    const q = query(collection(db, 'groups', groupId, 'settlements'), orderBy('date', 'desc'))
-    const unsub = onSnapshot(q,
-      (snap) => {
-        setSettlements(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Settlement))
-        setLoading(false)
-      },
-      (err) => {
-        logger.error('[useSettlements] Snapshot error:', err)
-        setLoading(false)
-      },
-    )
-    return unsub
-  }, [groupId])
-
+export function useSettlements(_groupId?: string) {
+  const { settlements, settlementsLoading: loading } = useGroupData()
   return { settlements, loading }
 }


### PR DESCRIPTION
## Summary
- 新建 GroupDataProvider：5 個 Firestore listener 集中管理（原本每頁 3-5 個獨立 listener）
- 所有 hooks 改為 context 消費者（零重複訂閱）
- expenses limit(200)、notifications limit(50)
- Context value useMemo 穩定 reference
- next.config: optimizePackageImports + compress + outputFileTracingRoot
- nginx: gzip + 靜態資源 immutable cache

## Test plan
- [ ] 首頁載入正常，資料顯示正確
- [ ] 頁面切換流暢，無重新載入 spinner
- [ ] 拆帳、記帳、統計功能正常
- [ ] 清快取後首次載入速度改善

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)