### PR TITLE
feat: 群組邀請碼功能 + 刪除群組即時刷新

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -43,10 +43,17 @@ service cloud.firestore {
         && request.resource.data.name.size() > 0
         && request.resource.data.name.size() <= 50;
 
-      // 更新：僅群組成員，但 ownerUid 不可變更（除非是 owner 自己轉移）
-      allow update: if isGroupMember(groupId)
-        && hasReasonableSize()
+      // 更新：群組成員，或持有邀請碼的登入使用者（加入群組）
+      // ownerUid 不可變更（除非是 owner 自己轉移）
+      // inviteCode 欄位只有 owner 能修改
+      allow update: if hasReasonableSize()
         && (request.resource.data.ownerUid == resource.data.ownerUid
+            || isGroupOwner(groupId))
+        && (isGroupMember(groupId)
+            || (isSignedIn()
+                && resource.data.inviteCode != null
+                && request.auth.uid in request.resource.data.memberUids))
+        && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['inviteCode'])
             || isGroupOwner(groupId));
 
       // 刪除：僅群組擁有者

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -1,11 +1,62 @@
 'use client'
 
+import { useState } from 'react'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useExpenses, useMonthlyExpenses, useRecentExpenses } from '@/lib/hooks/use-expenses'
 import { useSettlements } from '@/lib/hooks/use-settlements'
 import { useMembers } from '@/lib/hooks/use-members'
 import { simplifyDebts } from '@/lib/services/split-calculator'
+import { joinGroupByInviteCode } from '@/lib/services/group-service'
 import { currency, toDate, fmtDate } from '@/lib/utils'
+
+function NoGroupView() {
+  const [code, setCode] = useState('')
+  const [joining, setJoining] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleJoin() {
+    setJoining(true)
+    setError(null)
+    try {
+      await joinGroupByInviteCode(code)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '加入失敗')
+    } finally {
+      setJoining(false)
+    }
+  }
+
+  return (
+    <div className="p-6 max-w-sm mx-auto space-y-6 pt-20">
+      <div className="text-center space-y-2">
+        <div className="text-6xl">👨‍👩‍👧‍👦</div>
+        <h2 className="text-xl font-bold">歡迎使用家計本！</h2>
+        <p className="text-sm text-[var(--muted-foreground)]">輸入邀請碼加入家庭群組，或到設定頁建立新群組</p>
+      </div>
+
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 space-y-3">
+        <label className="text-sm font-medium block">輸入邀請碼</label>
+        <input
+          type="text"
+          value={code}
+          onChange={(e) => setCode(e.target.value.toUpperCase().slice(0, 6))}
+          placeholder="例如：A2B3C4"
+          maxLength={6}
+          className="w-full text-center text-2xl font-mono font-bold tracking-[0.3em] h-14 rounded-lg border border-[var(--border)] bg-[var(--background)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+        />
+        {error && <p className="text-xs text-[var(--destructive)]">{error}</p>}
+        <button
+          onClick={handleJoin}
+          disabled={joining || code.length !== 6}
+          className="w-full py-3 rounded-lg text-sm font-semibold text-white disabled:opacity-50 transition"
+          style={{ backgroundColor: 'var(--primary)' }}
+        >
+          {joining ? '加入中...' : '加入群組'}
+        </button>
+      </div>
+    </div>
+  )
+}
 
 export default function HomePage() {
   const { group, loading: groupLoading } = useGroup()
@@ -32,13 +83,7 @@ export default function HomePage() {
   }
 
   if (!group) {
-    return (
-      <div className="p-6 text-center space-y-4">
-        <div className="text-6xl opacity-30">👨‍👩‍👧‍👦</div>
-        <h2 className="text-xl font-bold">歡迎使用家計本！</h2>
-        <p className="text-[var(--muted-foreground)]">請先到設定新增家庭成員</p>
-      </div>
-    )
+    return <NoGroupView />
   }
 
   return (

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -10,7 +10,7 @@ import { useMembers } from '@/lib/hooks/use-members'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { useColorTheme, COLOR_THEMES } from '@/lib/hooks/use-color-theme'
 import { addMember, removeMember, updateMember } from '@/lib/services/member-service'
-import { createGroup, updateGroup, deleteGroup } from '@/lib/services/group-service'
+import { createGroup, updateGroup, deleteGroup, refreshInviteCode } from '@/lib/services/group-service'
 import { addCategory, updateCategory } from '@/lib/services/category-service'
 import { addActivityLog } from '@/lib/services/activity-log-service'
 import { useRouter } from 'next/navigation'
@@ -356,8 +356,59 @@ function ApiKeySection() {
 
 // ── Group Management section ─────────────────────────────────
 
+function InviteCodeBlock({ group }: { group: { id: string; name: string; inviteCode?: string | null } }) {
+  const [generating, setGenerating] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  async function handleGenerate() {
+    setGenerating(true)
+    try {
+      await refreshInviteCode(group.id)
+    } catch (e) {
+      logger.error('[Settings] Failed to generate invite code:', e)
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  function handleCopy() {
+    if (!group.inviteCode) return
+    navigator.clipboard.writeText(group.inviteCode)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="rounded-xl border border-dashed border-[var(--border)] p-3 space-y-2">
+      <div className="text-xs text-[var(--muted-foreground)]">
+        邀請碼 — {group.name}
+      </div>
+      {group.inviteCode ? (
+        <div className="flex items-center gap-2">
+          <code className="flex-1 text-center text-xl font-mono font-bold tracking-[0.3em] py-1 rounded-lg bg-[var(--muted)]">
+            {group.inviteCode}
+          </code>
+          <button onClick={handleCopy}
+            className="text-xs px-2.5 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)]">
+            {copied ? '已複製' : '複製'}
+          </button>
+          <button onClick={handleGenerate} disabled={generating}
+            className="text-xs px-2.5 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)] text-[var(--muted-foreground)]">
+            重新產生
+          </button>
+        </div>
+      ) : (
+        <button onClick={handleGenerate} disabled={generating}
+          className="w-full py-2 rounded-lg text-sm font-medium border border-[var(--border)] hover:bg-[var(--muted)] transition">
+          {generating ? '產生中...' : '產生邀請碼'}
+        </button>
+      )}
+    </div>
+  )
+}
+
 function GroupManagementSection() {
-  const { group, groups, setActiveGroupId } = useGroup()
+  const { group, groups, setActiveGroupId, removeGroup } = useGroup()
   const [newName, setNewName] = useState('')
   const [creating, setCreating] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -399,11 +450,11 @@ function GroupManagementSection() {
     }
     if (!confirm(`確定要刪除群組「${groupName}」嗎？所有支出、結算紀錄都會一併刪除，此操作無法復原。`)) return
     try {
+      // Optimistic: 先從 UI 移除，不等 Firestore snapshot
+      const remaining = groups.find((g) => g.id !== groupId)
+      if (group?.id === groupId && remaining) setActiveGroupId(remaining.id)
+      removeGroup(groupId)
       await deleteGroup(groupId)
-      if (group?.id === groupId) {
-        const remaining = groups.find((g) => g.id !== groupId)
-        if (remaining) setActiveGroupId(remaining.id)
-      }
     } catch (e) {
       logger.error('[Settings] Failed to delete group:', e)
       alert('刪除失敗')
@@ -449,6 +500,9 @@ function GroupManagementSection() {
           )}
         </div>
       ))}
+
+      {/* 邀請碼 */}
+      {group && <InviteCodeBlock group={group} />}
 
       <div className="flex gap-2 pt-1">
         <input

--- a/src/lib/group-context.tsx
+++ b/src/lib/group-context.tsx
@@ -13,6 +13,7 @@ interface GroupContextType {
   groups: FamilyGroup[]
   activeGroup: FamilyGroup | null
   setActiveGroupId: (id: string) => void
+  removeGroup: (id: string) => void
   loading: boolean
 }
 
@@ -20,6 +21,7 @@ const GroupContext = createContext<GroupContextType>({
   groups: [],
   activeGroup: null,
   setActiveGroupId: () => {},
+  removeGroup: () => {},
   loading: true,
 })
 
@@ -111,10 +113,14 @@ export function GroupProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(STORAGE_KEY, id)
   }, [])
 
+  const removeGroup = useCallback((id: string) => {
+    setGroups((prev) => prev.filter((g) => g.id !== id))
+  }, [])
+
   // Stable context value
   const value = useMemo(() => ({
-    groups, activeGroup, setActiveGroupId, loading,
-  }), [groups, activeGroup, setActiveGroupId, loading])
+    groups, activeGroup, setActiveGroupId, removeGroup, loading,
+  }), [groups, activeGroup, setActiveGroupId, removeGroup, loading])
 
   return (
     <GroupContext.Provider value={value}>

--- a/src/lib/hooks/use-group.ts
+++ b/src/lib/hooks/use-group.ts
@@ -9,7 +9,8 @@ export function useGroup(): {
   groups: FamilyGroup[]
   loading: boolean
   setActiveGroupId: (id: string) => void
+  removeGroup: (id: string) => void
 } {
-  const { activeGroup, groups, loading, setActiveGroupId } = useGroupContext()
-  return { group: activeGroup, groups, loading, setActiveGroupId }
+  const { activeGroup, groups, loading, setActiveGroupId, removeGroup } = useGroupContext()
+  return { group: activeGroup, groups, loading, setActiveGroupId, removeGroup }
 }

--- a/src/lib/services/group-service.ts
+++ b/src/lib/services/group-service.ts
@@ -1,6 +1,13 @@
-import { addDoc, collection, doc, updateDoc, deleteDoc, getDocs, Timestamp, arrayRemove, writeBatch } from 'firebase/firestore'
+import { addDoc, collection, doc, updateDoc, deleteDoc, getDocs, query, where, Timestamp, arrayRemove, arrayUnion, writeBatch } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
 import { auth } from '@/lib/firebase'
+
+function generateInviteCode(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789' // no 0/O/1/I to avoid confusion
+  const bytes = new Uint8Array(6)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, (b) => chars[b % chars.length]).join('')
+}
 
 const DEFAULT_CATEGORIES = [
   { name: '餐飲', icon: '🍜' },
@@ -69,6 +76,38 @@ export async function deleteGroup(groupId: string): Promise<void> {
   }
   // activityLogs are immutable (delete: false in rules), left as orphans
   await deleteDoc(doc(db, 'groups', groupId))
+}
+
+export async function refreshInviteCode(groupId: string): Promise<string> {
+  const code = generateInviteCode()
+  await updateDoc(doc(db, 'groups', groupId), {
+    inviteCode: code,
+    updatedAt: Timestamp.now(),
+  })
+  return code
+}
+
+export async function joinGroupByInviteCode(code: string): Promise<string> {
+  const user = auth.currentUser
+  if (!user) throw new Error('請先登入')
+  const trimmed = code.trim().toUpperCase()
+  if (!trimmed || trimmed.length !== 6) throw new Error('請輸入 6 位邀請碼')
+
+  const q = query(collection(db, 'groups'), where('inviteCode', '==', trimmed))
+  const snap = await getDocs(q)
+  if (snap.empty) throw new Error('邀請碼無效或已過期')
+
+  const groupDoc = snap.docs[0]
+  const data = groupDoc.data()
+  if ((data.memberUids as string[]).includes(user.uid)) {
+    throw new Error('你已經在這個群組中')
+  }
+
+  await updateDoc(groupDoc.ref, {
+    memberUids: arrayUnion(user.uid),
+    updatedAt: Timestamp.now(),
+  })
+  return groupDoc.id
 }
 
 export async function leaveGroup(groupId: string): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,6 +50,7 @@ export interface FamilyGroup {
   isPrimary: boolean
   ownerUid?: string
   memberUids: string[]
+  inviteCode?: string | null
   createdAt: Timestamp
   updatedAt: Timestamp
 }


### PR DESCRIPTION
## Summary
- 群組設定頁可產生/複製/重新產生 6 位邀請碼
- 新用戶登入後輸入邀請碼即可加入家庭群組
- 刪除群組後 UI 立即刷新（optimistic update）
- 安全修正：邀請碼改用 CSPRNG，inviteCode 只有 owner 能修改

## Files Changed
- `src/lib/types.ts` — FamilyGroup 加 inviteCode 欄位
- `src/lib/services/group-service.ts` — 產生邀請碼 + joinGroupByInviteCode
- `src/app/(auth)/settings/page.tsx` — 邀請碼 UI + optimistic delete
- `src/app/(auth)/page.tsx` — 無群組用戶的加入群組表單
- `src/lib/group-context.tsx` — removeGroup optimistic update
- `src/lib/hooks/use-group.ts` — 暴露 removeGroup
- `firestore.rules` — 邀請碼加入規則 + owner-only inviteCode 修改

## Test plan
- [ ] 設定頁產生邀請碼，顯示 6 位碼，可複製
- [ ] 新帳號登入後輸入邀請碼成功加入群組
- [ ] 輸入錯誤邀請碼顯示錯誤訊息
- [ ] 非 owner 成員無法重新產生邀請碼
- [ ] 刪除群組後列表立即消失

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)