### PR TITLE
fix: lint errors 全部修正 + Service Worker basePath

### DIFF
--- a/src/components/service-worker-register.tsx
+++ b/src/components/service-worker-register.tsx
@@ -7,7 +7,8 @@ import { logger } from '@/lib/logger'
 export function ServiceWorkerRegister() {
   useEffect(() => {
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js').catch((err) => {
+      const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+      navigator.serviceWorker.register(`${basePath}/sw.js`).catch((err) => {
         logger.warn('SW registration failed:', err)
       })
     }

--- a/src/lib/group-context.tsx
+++ b/src/lib/group-context.tsx
@@ -12,8 +12,8 @@ const STORAGE_KEY = 'active-group-id'
 interface GroupContextType {
   groups: FamilyGroup[]
   activeGroup: FamilyGroup | null
-  setActiveGroupId: (id: string) => void
-  removeGroup: (id: string) => void
+  setActiveGroupId: (_id: string) => void
+  removeGroup: (_id: string) => void
   loading: boolean
 }
 

--- a/src/lib/hooks/use-categories.ts
+++ b/src/lib/hooks/use-categories.ts
@@ -2,6 +2,7 @@
 
 import { useGroupData } from '@/lib/group-data-context'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function useCategories(_groupId?: string) {
   const { categories, categoriesLoading: loading } = useGroupData()
   return { categories, loading }

--- a/src/lib/hooks/use-expenses.ts
+++ b/src/lib/hooks/use-expenses.ts
@@ -5,6 +5,7 @@ import { useGroupData } from '@/lib/group-data-context'
 import { toDate } from '@/lib/utils'
 import type { Expense } from '@/lib/types'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function useExpenses(_groupId?: string) {
   const { expenses, expensesLoading: loading } = useGroupData()
   return { expenses, loading }

--- a/src/lib/hooks/use-group.ts
+++ b/src/lib/hooks/use-group.ts
@@ -8,8 +8,8 @@ export function useGroup(): {
   group: FamilyGroup | null
   groups: FamilyGroup[]
   loading: boolean
-  setActiveGroupId: (id: string) => void
-  removeGroup: (id: string) => void
+  setActiveGroupId: (_id: string) => void
+  removeGroup: (_id: string) => void
 } {
   const { activeGroup, groups, loading, setActiveGroupId, removeGroup } = useGroupContext()
   return { group: activeGroup, groups, loading, setActiveGroupId, removeGroup }

--- a/src/lib/hooks/use-members.ts
+++ b/src/lib/hooks/use-members.ts
@@ -2,6 +2,7 @@
 
 import { useGroupData } from '@/lib/group-data-context'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function useMembers(_groupId?: string) {
   const { members, membersLoading: loading } = useGroupData()
   return { members, loading }

--- a/src/lib/hooks/use-notifications.ts
+++ b/src/lib/hooks/use-notifications.ts
@@ -2,6 +2,7 @@
 
 import { useGroupData } from '@/lib/group-data-context'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function useNotifications(_groupId?: string, _recipientId?: string) {
   const { notifications, unreadCount } = useGroupData()
   return { notifications, unreadCount }

--- a/src/lib/hooks/use-settlements.ts
+++ b/src/lib/hooks/use-settlements.ts
@@ -2,6 +2,7 @@
 
 import { useGroupData } from '@/lib/group-data-context'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function useSettlements(_groupId?: string) {
   const { settlements, settlementsLoading: loading } = useGroupData()
   return { settlements, loading }


### PR DESCRIPTION
## Summary
- 修正 6 個 lint errors（unused `_groupId` params in hooks）和 4 個 warnings
- Service Worker 註冊路徑配合 basePath，避免 404

## Test plan
- [ ] `npm run lint` 通過 0 errors 0 warnings
- [ ] CI lint job 通過（--max-warnings=0）
- [ ] Service Worker 在 /family-ledger-web 路徑下正確註冊

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)