### PR TITLE
fix(settings): per-user current member preference

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -152,6 +152,13 @@ service cloud.firestore {
         allow delete: if isGroupOwner(groupId);
       }
 
+      // ─── 使用者偏好（per-user current member） ───
+
+      match /userPreferences/{uid} {
+        allow read: if isGroupMember(groupId);
+        allow write: if isSignedIn() && request.auth.uid == uid;
+      }
+
       // ─── 活動日誌 ───
 
       match /activityLogs/{logId} {

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -1,12 +1,11 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { writeBatch, doc } from 'firebase/firestore'
-import { db } from '@/lib/firebase'
 import { useTheme } from 'next-themes'
 import { useAuth } from '@/lib/auth'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useMembers } from '@/lib/hooks/use-members'
+import { useCurrentMember } from '@/lib/hooks/use-current-member'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { useColorTheme, COLOR_THEMES } from '@/lib/hooks/use-color-theme'
 import { addMember, removeMember, updateMember } from '@/lib/services/member-service'
@@ -35,6 +34,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 function MembersSection({ groupId }: { groupId: string }) {
   const { members, loading: membersLoading } = useMembers(groupId)
+  const { currentMemberId, setCurrentMember, loading: currentMemberLoading } = useCurrentMember(groupId)
   const { user } = useAuth()
   const [newName, setNewName] = useState('')
   const [adding, setAdding] = useState(false)
@@ -56,10 +56,10 @@ function MembersSection({ groupId }: { groupId: string }) {
     }
   }
 
-  async function handleDelete(memberId: string, memberName: string, isCurrentUser: boolean) {
+  async function handleDelete(memberId: string, memberName: string) {
     if (!confirm(`確定要刪除成員「${memberName}」嗎？此操作無法復原。`)) return
     try {
-      await removeMember(groupId, memberId, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined, memberName, isCurrentUser)
+      await removeMember(groupId, memberId, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined, memberName)
     } catch (e) {
       logger.error('[Settings] Failed to delete member:', e)
       alert('刪除失敗，請稍後再試')
@@ -78,24 +78,18 @@ function MembersSection({ groupId }: { groupId: string }) {
     }
   }
 
-  async function handleToggleCurrent(member: FamilyMember) {
-    const next = !member.isCurrentUser
-    const batch = writeBatch(db)
-    // Atomically update both members in one batch to avoid intermediate inconsistent state
-    if (next) {
-      const prev = members.find((m) => m.isCurrentUser && m.id !== member.id)
-      if (prev) batch.update(doc(db, 'groups', groupId, 'members', prev.id), { isCurrentUser: false })
-    }
-    batch.update(doc(db, 'groups', groupId, 'members', member.id), { isCurrentUser: next })
+  async function handleSetCurrentMember(member: FamilyMember) {
+    // If already selected, do nothing
+    if (currentMemberId === member.id) return
     try {
-      await batch.commit()
-      if (next && user) {
+      await setCurrentMember(member.id)
+      if (user) {
         try {
           await addActivityLog(groupId, {
             action: 'member_updated',
             actorId: user.uid,
             actorName: user.displayName ?? '未知',
-            description: `切換目前成員：${member.name}`,
+            description: `設為我：${member.name}`,
             entityId: member.id,
           })
         } catch (e) {
@@ -103,57 +97,64 @@ function MembersSection({ groupId }: { groupId: string }) {
         }
       }
     } catch (e) {
-      logger.error('[Settings] Failed to toggle current user:', e)
+      logger.error('[Settings] Failed to set current member:', e)
       alert('更新失敗，請稍後再試')
     }
   }
 
+  const isLoading = membersLoading || currentMemberLoading
+
   return (
     <div className="space-y-3">
-      {membersLoading ? (
+      {isLoading ? (
         <p className="text-sm text-[var(--muted-foreground)]">載入中...</p>
       ) : members.length === 0 ? (
         <p className="text-sm text-[var(--muted-foreground)]">還沒有成員，請新增</p>
       ) : null}
-      {members.map((m) => (
-        <div key={m.id} className="flex items-center gap-2">
-          {editingId === m.id ? (
-            <>
-              <input
-                autoFocus
-                value={editName}
-                onChange={(e) => setEditName(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && handleRename(m.id)}
-                className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-              />
-              <button onClick={() => handleRename(m.id)}
-                className="text-xs px-2.5 py-1.5 rounded-lg font-medium text-white"
-                style={{ backgroundColor: 'var(--primary)' }}>儲存</button>
-              <button onClick={() => setEditingId(null)}
-                className="text-xs px-2.5 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)]">取消</button>
-            </>
-          ) : (
-            <>
-              <div className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0"
-                style={{ backgroundColor: 'color-mix(in oklch, var(--primary), transparent 80%)', color: 'var(--primary)' }}>
-                {m.name.slice(0, 1)}
-              </div>
-              <span className="flex-1 text-sm font-medium">{m.name}</span>
-              {m.isCurrentUser && (
-                <span className="text-xs px-1.5 py-0.5 rounded-full bg-[var(--primary)] text-[var(--primary-foreground)]">我</span>
-              )}
-              <button onClick={() => handleToggleCurrent(m)}
-                className="text-xs px-2 py-1 rounded border border-[var(--border)] hover:bg-[var(--muted)] text-[var(--muted-foreground)]">
-                {m.isCurrentUser ? '取消' : '設為我'}
-              </button>
-              <button onClick={() => { setEditingId(m.id); setEditName(m.name) }}
-                className="text-xs px-2 py-1 rounded border border-[var(--border)] hover:bg-[var(--muted)] text-[var(--muted-foreground)]">改名</button>
-              <button onClick={() => handleDelete(m.id, m.name, m.isCurrentUser)}
-                className="text-xs px-2 py-1 rounded hover:bg-red-50 dark:hover:bg-red-950 text-[var(--destructive)]">刪除</button>
-            </>
-          )}
-        </div>
-      ))}
+      {members.map((m) => {
+        const isMe = currentMemberId === m.id
+        return (
+          <div key={m.id} className="flex items-center gap-2">
+            {editingId === m.id ? (
+              <>
+                <input
+                  autoFocus
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleRename(m.id)}
+                  className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                />
+                <button onClick={() => handleRename(m.id)}
+                  className="text-xs px-2.5 py-1.5 rounded-lg font-medium text-white"
+                  style={{ backgroundColor: 'var(--primary)' }}>儲存</button>
+                <button onClick={() => setEditingId(null)}
+                  className="text-xs px-2.5 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)]">取消</button>
+              </>
+            ) : (
+              <>
+                <div className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0"
+                  style={{ backgroundColor: 'color-mix(in oklch, var(--primary), transparent 80%)', color: 'var(--primary)' }}>
+                  {m.name.slice(0, 1)}
+                </div>
+                <span className="flex-1 text-sm font-medium">{m.name}</span>
+                {isMe && (
+                  <span className="text-xs px-1.5 py-0.5 rounded-full bg-[var(--primary)] text-[var(--primary-foreground)]">我</span>
+                )}
+                {!isMe && (
+                  <button onClick={() => handleSetCurrentMember(m)}
+                    className="text-xs px-2 py-1 rounded border border-[var(--border)] hover:bg-[var(--muted)] text-[var(--muted-foreground)]">
+                    設為我
+                  </button>
+                )}
+                <button onClick={() => { setEditingId(m.id); setEditName(m.name) }}
+                  className="text-xs px-2 py-1 rounded border border-[var(--border)] hover:bg-[var(--muted)] text-[var(--muted-foreground)]">改名</button>
+                <button onClick={() => handleDelete(m.id, m.name)}
+                  className="text-xs px-2 py-1 rounded hover:bg-red-50 dark:hover:bg-red-950 text-[var(--destructive)]">刪除</button>
+              </>
+            )}
+          </div>
+        )
+      })}
       <div className="flex gap-2 pt-1">
         <input
           value={newName}

--- a/src/lib/hooks/use-current-member.ts
+++ b/src/lib/hooks/use-current-member.ts
@@ -1,0 +1,76 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { doc, onSnapshot } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { useAuth } from '@/lib/auth'
+import { useMembers } from '@/lib/hooks/use-members'
+import { setCurrentMember as setCurrentMemberService } from '@/lib/services/user-preference-service'
+
+import { logger } from '@/lib/logger'
+
+/**
+ * Hook that returns the current user's linked member ID for a group.
+ * Subscribes to `groups/{groupId}/userPreferences/{uid}` via onSnapshot.
+ * Falls back to the legacy `member.isCurrentUser` field if no preference exists.
+ */
+export function useCurrentMember(groupId: string | undefined) {
+  const { user } = useAuth()
+  const { members } = useMembers(groupId)
+  const [currentMemberId, setCurrentMemberId] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  // Track whether a userPreference doc exists (null = not yet checked)
+  const [hasPreferenceDoc, setHasPreferenceDoc] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    if (!groupId || !user?.uid) {
+      setCurrentMemberId(null)
+      setLoading(false)
+      setHasPreferenceDoc(null)
+      return
+    }
+
+    const ref = doc(db, 'groups', groupId, 'userPreferences', user.uid)
+    const unsubscribe = onSnapshot(
+      ref,
+      (snap) => {
+        if (snap.exists()) {
+          setCurrentMemberId(snap.data().linkedMemberId ?? null)
+          setHasPreferenceDoc(true)
+        } else {
+          setCurrentMemberId(null)
+          setHasPreferenceDoc(false)
+        }
+        setLoading(false)
+      },
+      (error) => {
+        logger.error('[useCurrentMember] onSnapshot error:', error)
+        setHasPreferenceDoc(false)
+        setLoading(false)
+      },
+    )
+
+    return () => unsubscribe()
+  }, [groupId, user?.uid])
+
+  // Backward compatibility: fallback to legacy isCurrentUser if no preference doc
+  const resolvedMemberId =
+    currentMemberId ??
+    (hasPreferenceDoc === false
+      ? (members.find((m) => m.isCurrentUser)?.id ?? null)
+      : null)
+
+  const setCurrentMember = useCallback(
+    async (memberId: string) => {
+      if (!groupId) return
+      await setCurrentMemberService(groupId, memberId)
+    },
+    [groupId],
+  )
+
+  return {
+    currentMemberId: resolvedMemberId,
+    setCurrentMember,
+    loading,
+  }
+}

--- a/src/lib/services/user-preference-service.ts
+++ b/src/lib/services/user-preference-service.ts
@@ -1,0 +1,31 @@
+import { doc, getDoc, setDoc, Timestamp } from 'firebase/firestore'
+import { db, auth } from '@/lib/firebase'
+
+import { logger } from '@/lib/logger'
+
+/**
+ * Per-user preference for linking a Firebase Auth user to a family member.
+ * Stored at: groups/{groupId}/userPreferences/{uid}
+ */
+
+export async function setCurrentMember(groupId: string, memberId: string): Promise<void> {
+  const uid = auth.currentUser?.uid
+  if (!uid) throw new Error('Not authenticated')
+
+  const ref = doc(db, 'groups', groupId, 'userPreferences', uid)
+  await setDoc(ref, {
+    linkedMemberId: memberId,
+    updatedAt: Timestamp.now(),
+  })
+  logger.info(`[UserPreference] User ${uid} linked to member ${memberId} in group ${groupId}`)
+}
+
+export async function getCurrentMemberId(groupId: string): Promise<string | null> {
+  const uid = auth.currentUser?.uid
+  if (!uid) return null
+
+  const ref = doc(db, 'groups', groupId, 'userPreferences', uid)
+  const snap = await getDoc(ref)
+  if (!snap.exists()) return null
+  return snap.data().linkedMemberId ?? null
+}


### PR DESCRIPTION
## Summary
- `isCurrentUser` 原本是 member document 上的全域 boolean，多人使用同一群組時會互相覆蓋
- 新增 `groups/{groupId}/userPreferences/{uid}` subcollection，每位使用者各自儲存 `linkedMemberId`
- Settings 頁面改用 `useCurrentMember` hook，透過 onSnapshot 即時訂閱自己的偏好
- Firestore rules: 群組成員可讀、僅本人可寫自己的 preference doc
- 向下相容：若無 userPreference doc，fallback 到舊的 `member.isCurrentUser`

## Changes
- **New**: `src/lib/services/user-preference-service.ts` — `setCurrentMember()` / `getCurrentMemberId()`
- **New**: `src/lib/hooks/use-current-member.ts` — onSnapshot hook with legacy fallback
- **Modified**: `src/app/(auth)/settings/page.tsx` — removed `handleToggleCurrent`, use per-user hook
- **Modified**: `firestore.rules` — added `userPreferences/{uid}` rules

## Test plan
- [ ] User A 設為「爸爸」，User B 設為「媽媽」，互不影響
- [ ] 新群組（無 userPreference doc）仍能 fallback 顯示舊的 isCurrentUser 標記
- [ ] Firestore rules: 無法寫入他人的 userPreference doc
- [ ] Build passes (`npm run build`)

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)