### PR TITLE
chore(test): add sequential execution config and destructive flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ yarn-error.log*
 playwright-report/
 test-results/
 coverage/
+.playwright-mcp/
+*.png
 
 # Firebase
 .firebase/

--- a/docs/test-journeys/01-auth-navigation.json
+++ b/docs/test-journeys/01-auth-navigation.json
@@ -2,6 +2,11 @@
   "journey": "auth-navigation",
   "version": "1.0.0",
   "baseUrl": "https://mac-mini.tailde842d.ts.net",
+  "execution": {
+    "mode": "sequential",
+    "order": 1,
+    "requiresAuth": true
+  },
   "credentials": {
     "USER": {
       "email": "test-user@example.com",
@@ -269,6 +274,7 @@
     },
     {
       "id": "AUTH-12",
+      "destructive": true,
       "name": "Logout flow",
       "role": "USER",
       "steps": [

--- a/docs/test-journeys/02-expense-management.json
+++ b/docs/test-journeys/02-expense-management.json
@@ -2,6 +2,11 @@
   "journey": "expense-management",
   "version": "1.0.0",
   "baseUrl": "https://mac-mini.tailde842d.ts.net",
+  "execution": {
+    "mode": "sequential",
+    "order": 2,
+    "requiresAuth": true
+  },
   "credentials": {
     "USER": {
       "email": "test-user@example.com",
@@ -12,6 +17,7 @@
   "testCases": [
     {
       "id": "EXP-01",
+      "destructive": true,
       "name": "Create shared expense (equal split)",
       "tags": ["crud", "create"],
       "steps": [
@@ -67,6 +73,7 @@
     },
     {
       "id": "EXP-02",
+      "destructive": true,
       "name": "Create personal expense",
       "tags": ["crud", "create"],
       "steps": [
@@ -100,6 +107,7 @@
     },
     {
       "id": "EXP-03",
+      "destructive": true,
       "name": "Create expense with percentage split",
       "tags": ["crud", "create"],
       "steps": [
@@ -147,6 +155,7 @@
     },
     {
       "id": "EXP-04",
+      "destructive": true,
       "name": "Create expense with custom split",
       "tags": ["crud", "create"],
       "steps": [
@@ -194,6 +203,7 @@
     },
     {
       "id": "EXP-05",
+      "destructive": true,
       "name": "Create expense with credit card payment",
       "tags": ["crud", "create"],
       "steps": [
@@ -227,6 +237,7 @@
     },
     {
       "id": "EXP-06",
+      "destructive": true,
       "name": "Create expense with transfer payment",
       "tags": ["crud", "create"],
       "steps": [
@@ -260,6 +271,7 @@
     },
     {
       "id": "EXP-07",
+      "destructive": true,
       "name": "Create expense with note",
       "tags": ["crud", "create"],
       "steps": [
@@ -383,6 +395,7 @@
     },
     {
       "id": "EXP-12",
+      "destructive": true,
       "name": "Edit expense",
       "tags": ["crud", "update"],
       "steps": [
@@ -415,6 +428,7 @@
     },
     {
       "id": "EXP-13",
+      "destructive": true,
       "name": "Delete expense",
       "tags": ["crud", "delete"],
       "steps": [
@@ -523,6 +537,7 @@
     },
     {
       "id": "EXP-17",
+      "destructive": true,
       "name": "Expense with all fields",
       "tags": ["crud", "create", "regression"],
       "steps": [

--- a/docs/test-journeys/03-settlement-debts.json
+++ b/docs/test-journeys/03-settlement-debts.json
@@ -2,6 +2,11 @@
   "journey": "settlement-debts",
   "version": "1.0.0",
   "baseUrl": "https://mac-mini.tailde842d.ts.net",
+  "execution": {
+    "mode": "sequential",
+    "order": 3,
+    "requiresAuth": true
+  },
   "credentials": {
     "USER": {
       "email": "test-user@example.com",
@@ -100,6 +105,7 @@
     },
     {
       "id": "STL-05",
+      "destructive": true,
       "name": "Create settlement",
       "role": "USER",
       "steps": [
@@ -181,6 +187,7 @@
     },
     {
       "id": "STL-07",
+      "destructive": true,
       "name": "Delete settlement",
       "role": "USER",
       "steps": [
@@ -305,6 +312,7 @@
     },
     {
       "id": "STL-12",
+      "destructive": true,
       "name": "Settlement updates balance",
       "role": "USER",
       "steps": [

--- a/docs/test-journeys/04-settings-management.json
+++ b/docs/test-journeys/04-settings-management.json
@@ -2,6 +2,11 @@
   "journey": "settings-management",
   "version": "1.0.0",
   "baseUrl": "https://mac-mini.tailde842d.ts.net",
+  "execution": {
+    "mode": "sequential",
+    "order": 4,
+    "requiresAuth": true
+  },
   "credentials": {
     "USER": {
       "email": "test-user@example.com",
@@ -32,6 +37,7 @@
     },
     {
       "id": "SET-02",
+      "destructive": true,
       "name": "Add member",
       "role": "USER",
       "steps": [
@@ -65,6 +71,7 @@
     },
     {
       "id": "SET-03",
+      "destructive": true,
       "name": "Edit member name",
       "role": "USER",
       "steps": [
@@ -98,6 +105,7 @@
     },
     {
       "id": "SET-04",
+      "destructive": true,
       "name": "Delete member",
       "role": "USER",
       "steps": [
@@ -190,6 +198,7 @@
     },
     {
       "id": "SET-08",
+      "destructive": true,
       "name": "Add custom category",
       "role": "USER",
       "steps": [
@@ -227,6 +236,7 @@
     },
     {
       "id": "SET-09",
+      "destructive": true,
       "name": "Delete custom category",
       "role": "USER",
       "steps": [
@@ -339,6 +349,7 @@
     },
     {
       "id": "SET-14",
+      "destructive": true,
       "name": "Mark all notifications read",
       "role": "USER",
       "steps": [

--- a/docs/test-journeys/runner-config.json
+++ b/docs/test-journeys/runner-config.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0.0",
+  "execution": {
+    "mode": "sequential",
+    "reason": "Playwright MCP shares a single browser instance; parallel agents cause page navigation conflicts",
+    "order": [
+      "01-auth-navigation.json",
+      "02-expense-management.json",
+      "03-settlement-debts.json",
+      "04-settings-management.json"
+    ],
+    "betweenModules": {
+      "navigateToHome": true,
+      "waitMs": 1000
+    }
+  },
+  "environment": {
+    "type": "production",
+    "skipDestructive": true,
+    "destructiveActions": ["create", "update", "delete"],
+    "destructiveNote": "Tests tagged with crud/create, crud/update, or crud/delete will be marked BLOCKED when skipDestructive is true"
+  },
+  "auth": {
+    "method": "google-oauth",
+    "automated": false,
+    "note": "Google OAuth requires manual login before test run. Firebase Emulator supports automated email/password auth."
+  },
+  "reporting": {
+    "screenshotDir": ".playwright-mcp",
+    "generateSummary": true
+  }
+}


### PR DESCRIPTION
## Summary
- Add `runner-config.json` — sequential execution mode prevents Playwright browser contention
- Add `execution` metadata (`mode`, `order`, `requiresAuth`) to all 4 journey files
- Mark 20 write-operation tests as `destructive: true` for production safety
- Update `.gitignore` to exclude `.playwright-mcp/` and `*.png` screenshots

## Test plan
- [x] All 5 JSON files valid (validated with Python json.load)
- [x] 37 safe tests + 20 destructive tests = 57 total (unchanged)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)