### PR TITLE
feat(records): add search bar and advanced filter panel

### DIFF
--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -60,7 +60,7 @@ export default function RecordsPage() {
       // Payer filter
       if (payerFilter && e.payerId !== payerFilter) return false
 
-      // Category filter
+      // Category filter (match by name since expense stores category name)
       if (categoryFilter && e.category !== categoryFilter) return false
 
       return true
@@ -188,7 +188,7 @@ export default function RecordsPage() {
               >
                 <option value="">全部分類</option>
                 {categories.map((c) => (
-                  <option key={c} value={c}>{c}</option>
+                  <option key={c.name} value={c.name}>{c.icon} {c.name}</option>
                 ))}
               </select>
             </div>


### PR DESCRIPTION
## Summary

- Add instant keyword search bar (debounced 300ms) that filters across description, category, and payer name
- Add collapsible advanced filter panel with date range, payer select, and category select
- Show filter result summary (matching count / total + sum amount) when any filter is active
- Show friendly empty state with "clear filters" action when no results match

## Technical Details

- All filtering is client-side using `useMemo` chains — no backend changes
- Debounce implemented with dual state (`searchInput` for UI, `searchQuery` for filter logic)
- Category type properly handled as `Category` object (using `c.name` / `c.icon`)
- File stays at ~317 lines, well under 400 limit

## Test Plan

- [x] `npm run build` — passes (TypeScript + production build)
- [x] `npm run test` — 42/42 tests pass
- [ ] Manual: search by description keyword filters instantly
- [ ] Manual: date range filter shows only expenses within range
- [ ] Manual: payer and category select filters work correctly
- [ ] Manual: "清除篩選" resets all filters
- [ ] Manual: filter summary shows correct count and total
- [ ] Manual: mobile layout — filter panel doesn't overlap bottom nav

Closes #99