### PR TITLE
feat(ui): add global toast system + Firestore error feedback

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next'
 import { ThemeProvider } from 'next-themes'
 import { AuthProvider } from '@/lib/auth'
 import { ServiceWorkerRegister } from '@/components/service-worker-register'
+import { ToastProvider } from '@/components/toast'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -32,8 +33,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <AuthProvider>
-            <ServiceWorkerRegister />
-            {children}
+            <ToastProvider>
+              <ServiceWorkerRegister />
+              {children}
+            </ToastProvider>
           </AuthProvider>
         </ThemeProvider>
       </body>

--- a/src/components/nav-shell.tsx
+++ b/src/components/nav-shell.tsx
@@ -7,6 +7,7 @@ import { useGroup } from '@/lib/hooks/use-group'
 import { useAuth } from '@/lib/auth'
 import { useNotifications } from '@/lib/hooks/use-notifications'
 import { GroupSwitcher } from '@/components/group-switcher'
+import { OfflineBanner } from '@/components/offline-banner'
 
 const navItems = [
   { href: `/`, label: '首頁', icon: '🏠' },
@@ -99,6 +100,7 @@ export function NavShell({ children }: { children: React.ReactNode }) {
             <GroupSwitcher />
           </div>
         </div>
+        <OfflineBanner />
         {children}
       </main>
 

--- a/src/components/offline-banner.tsx
+++ b/src/components/offline-banner.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useToast } from '@/components/toast'
+
+export function OfflineBanner() {
+  const [isOffline, setIsOffline] = useState(false)
+  const toast = useToast()
+
+  useEffect(() => {
+    // Set initial state
+    setIsOffline(!navigator.onLine)
+
+    function handleOffline() {
+      setIsOffline(true)
+    }
+
+    function handleOnline() {
+      setIsOffline(false)
+      toast.success('已恢復連線')
+    }
+
+    window.addEventListener('offline', handleOffline)
+    window.addEventListener('online', handleOnline)
+
+    return () => {
+      window.removeEventListener('offline', handleOffline)
+      window.removeEventListener('online', handleOnline)
+    }
+  }, [toast])
+
+  if (!isOffline) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        background: 'oklch(0.88 0.12 85)',
+        color: 'oklch(0.3 0.08 85)',
+        borderBottom: '1px solid oklch(0.78 0.14 85)',
+        padding: '0.5rem 1rem',
+        fontSize: '0.8125rem',
+        fontWeight: 600,
+        textAlign: 'center',
+      }}
+    >
+      ⚡ 目前離線，顯示的是快取資料
+    </div>
+  )
+}

--- a/src/components/toast.tsx
+++ b/src/components/toast.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+
+type ToastType = 'success' | 'error' | 'warning'
+
+interface Toast {
+  id: number
+  type: ToastType
+  message: string
+}
+
+interface ToastContextType {
+  toast: {
+    success: (msg: string) => void
+    error: (msg: string) => void
+    warning: (msg: string) => void
+  }
+}
+
+const ToastContext = createContext<ToastContextType>({
+  toast: {
+    success: () => {},
+    error: () => {},
+    warning: () => {},
+  },
+})
+
+const ICONS: Record<ToastType, string> = {
+  success: '✓',
+  warning: '⚠',
+  error: '✕',
+}
+
+const MAX_TOASTS = 3
+let nextId = 1
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const timers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map())
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+    const timer = timers.current.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      timers.current.delete(id)
+    }
+  }, [])
+
+  const add = useCallback((type: ToastType, message: string) => {
+    const id = nextId++
+    setToasts((prev) => {
+      const updated = [...prev, { id, type, message }]
+      // Dismiss oldest if over limit
+      if (updated.length > MAX_TOASTS) {
+        const oldest = updated[0]
+        dismiss(oldest.id)
+        return updated.slice(1)
+      }
+      return updated
+    })
+    // Error toasts stay until manually closed
+    if (type !== 'error') {
+      const timer = setTimeout(() => dismiss(id), 3000)
+      timers.current.set(id, timer)
+    }
+  }, [dismiss])
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    const currentTimers = timers.current
+    return () => { currentTimers.forEach((t) => clearTimeout(t)) }
+  }, [])
+
+  const toast = {
+    success: (msg: string) => add('success', msg),
+    error: (msg: string) => add('error', msg),
+    warning: (msg: string) => add('warning', msg),
+  }
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      {toasts.length > 0 && (
+        <div
+          role="region"
+          aria-label="通知訊息"
+          style={{
+            position: 'fixed',
+            bottom: '5rem',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 9999,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.5rem',
+            alignItems: 'center',
+            pointerEvents: 'none',
+          }}
+        >
+          {toasts.map((t) => (
+            <ToastItem key={t.id} toast={t} onDismiss={dismiss} />
+          ))}
+        </div>
+      )}
+    </ToastContext.Provider>
+  )
+}
+
+function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: (id: number) => void }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    // Trigger fade-in on mount
+    requestAnimationFrame(() => setVisible(true))
+  }, [])
+
+  const bgColor =
+    toast.type === 'success'
+      ? 'var(--primary)'
+      : toast.type === 'error'
+        ? 'var(--destructive)'
+        : 'oklch(0.75 0.15 85)'
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        padding: '0.625rem 1rem',
+        borderRadius: '9999px',
+        background: bgColor,
+        color: 'var(--primary-foreground)',
+        fontSize: '0.875rem',
+        fontWeight: 600,
+        boxShadow: '0 4px 16px oklch(0 0 0 / 0.25)',
+        pointerEvents: 'all',
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(8px)',
+        transition: 'opacity 0.2s ease, transform 0.2s ease',
+        whiteSpace: 'nowrap',
+        maxWidth: '90vw',
+      }}
+    >
+      <span aria-hidden="true" style={{ flexShrink: 0 }}>{ICONS[toast.type]}</span>
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{toast.message}</span>
+      {toast.type === 'error' && (
+        <button
+          onClick={() => onDismiss(toast.id)}
+          aria-label="關閉"
+          style={{
+            flexShrink: 0,
+            background: 'none',
+            border: 'none',
+            color: 'inherit',
+            cursor: 'pointer',
+            padding: '0 0.25rem',
+            fontSize: '1rem',
+            lineHeight: 1,
+            opacity: 0.8,
+          }}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  )
+}
+
+export function useToast(): ToastContextType['toast'] {
+  return useContext(ToastContext).toast
+}

--- a/src/lib/group-data-context.tsx
+++ b/src/lib/group-data-context.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { createContext, useContext, useEffect, useState, useMemo, ReactNode } from 'react'
+import { createContext, useContext, useEffect, useState, useMemo, useCallback, ReactNode } from 'react'
 import { collection, onSnapshot, orderBy, query, where, limit } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
 import { useGroupContext } from '@/lib/group-context'
 import { useAuth } from '@/lib/auth'
 import type { Expense, FamilyMember, Settlement, Category, AppNotification } from '@/lib/types'
 import { logger } from '@/lib/logger'
+import { useToast } from '@/components/toast'
 
 interface GroupDataContextType {
   expenses: Expense[]
@@ -19,6 +20,7 @@ interface GroupDataContextType {
   membersLoading: boolean
   settlementsLoading: boolean
   categoriesLoading: boolean
+  hasError: boolean
 }
 
 const GroupDataContext = createContext<GroupDataContextType>({
@@ -32,12 +34,14 @@ const GroupDataContext = createContext<GroupDataContextType>({
   membersLoading: true,
   settlementsLoading: true,
   categoriesLoading: true,
+  hasError: false,
 })
 
 export function GroupDataProvider({ children }: { children: ReactNode }) {
   const { activeGroup } = useGroupContext()
   const { user } = useAuth()
   const groupId = activeGroup?.id
+  const toast = useToast()
 
   const [expenses, setExpenses] = useState<Expense[]>([])
   const [members, setMembers] = useState<FamilyMember[]>([])
@@ -48,6 +52,13 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
   const [membersLoading, setMembersLoading] = useState(true)
   const [settlementsLoading, setSettlementsLoading] = useState(true)
   const [categoriesLoading, setCategoriesLoading] = useState(true)
+  const [hasError, setHasError] = useState(false)
+
+  const handleError = useCallback((label: string, message: string, err: unknown) => {
+    logger.error(label, err)
+    setHasError(true)
+    toast.error(message)
+  }, [toast])
 
   // Reset all data when group changes
   useEffect(() => {
@@ -60,6 +71,7 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     setMembersLoading(true)
     setSettlementsLoading(true)
     setCategoriesLoading(true)
+    setHasError(false)
   }, [groupId])
 
   // Expenses subscription
@@ -68,10 +80,10 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     const q = query(collection(db, 'groups', groupId, 'expenses'), orderBy('date', 'desc'), limit(200))
     const unsub = onSnapshot(q,
       (snap) => { setExpenses(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Expense)); setExpensesLoading(false) },
-      (err) => { logger.error('[GroupData] expenses error:', err); setExpensesLoading(false) },
+      (err) => { handleError('[GroupData] expenses error:', '支出資料同步失敗，請檢查網路連線', err); setExpensesLoading(false) },
     )
     return unsub
-  }, [groupId])
+  }, [groupId, handleError])
 
   // Members subscription
   useEffect(() => {
@@ -79,10 +91,10 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     const q = query(collection(db, 'groups', groupId, 'members'), orderBy('sortOrder'))
     const unsub = onSnapshot(q,
       (snap) => { setMembers(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as FamilyMember)); setMembersLoading(false) },
-      (err) => { logger.error('[GroupData] members error:', err); setMembersLoading(false) },
+      (err) => { handleError('[GroupData] members error:', '成員資料同步失敗，請檢查網路連線', err); setMembersLoading(false) },
     )
     return unsub
-  }, [groupId])
+  }, [groupId, handleError])
 
   // Settlements subscription
   useEffect(() => {
@@ -90,10 +102,10 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     const q = query(collection(db, 'groups', groupId, 'settlements'), orderBy('date', 'desc'))
     const unsub = onSnapshot(q,
       (snap) => { setSettlements(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Settlement)); setSettlementsLoading(false) },
-      (err) => { logger.error('[GroupData] settlements error:', err); setSettlementsLoading(false) },
+      (err) => { handleError('[GroupData] settlements error:', '結算資料同步失敗，請檢查網路連線', err); setSettlementsLoading(false) },
     )
     return unsub
-  }, [groupId])
+  }, [groupId, handleError])
 
   // Categories subscription
   useEffect(() => {
@@ -101,10 +113,10 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     const q = query(collection(db, 'groups', groupId, 'categories'), orderBy('sortOrder'))
     const unsub = onSnapshot(q,
       (snap) => { setCategories(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Category)); setCategoriesLoading(false) },
-      (err) => { logger.error('[GroupData] categories error:', err); setCategoriesLoading(false) },
+      (err) => { handleError('[GroupData] categories error:', '分類資料同步失敗，請檢查網路連線', err); setCategoriesLoading(false) },
     )
     return unsub
-  }, [groupId])
+  }, [groupId, handleError])
 
   // Notifications subscription (per-user, with limit)
   useEffect(() => {
@@ -117,18 +129,18 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     )
     const unsub = onSnapshot(q,
       (snap) => { setNotifications(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AppNotification)) },
-      (err) => { logger.error('[GroupData] notifications error:', err.message) },
+      (err) => { handleError('[GroupData] notifications error:', '通知資料同步失敗，請檢查網路連線', err) },
     )
     return unsub
-  }, [groupId, user])
+  }, [groupId, user, handleError])
 
   const unreadCount = useMemo(() => notifications.filter((n) => !n.isRead).length, [notifications])
 
   const value = useMemo(() => ({
     expenses, members, settlements, categories, notifications, unreadCount,
-    expensesLoading, membersLoading, settlementsLoading, categoriesLoading,
+    expensesLoading, membersLoading, settlementsLoading, categoriesLoading, hasError,
   }), [expenses, members, settlements, categories, notifications, unreadCount,
-       expensesLoading, membersLoading, settlementsLoading, categoriesLoading])
+       expensesLoading, membersLoading, settlementsLoading, categoriesLoading, hasError])
 
   return (
     <GroupDataContext.Provider value={value}>


### PR DESCRIPTION
## Summary
Closes #101

- Add lightweight `ToastProvider` with `useToast()` hook — supports `success`, `error`, `warning` levels
- Firestore `onSnapshot` errors in `GroupDataProvider` now surface as user-visible toast messages (previously silent)
- Add `OfflineBanner` component using `navigator.onLine` detection
- Add `hasError` state to `GroupDataContext` for downstream consumers

## Changes
| File | Change |
|------|--------|
| `src/components/toast.tsx` | **New** — ToastProvider + useToast hook (177 lines) |
| `src/components/offline-banner.tsx` | **New** — Offline detection banner (51 lines) |
| `src/lib/group-data-context.tsx` | Modified — handleError helper + hasError state |
| `src/app/layout.tsx` | Modified — wrap with ToastProvider |
| `src/components/nav-shell.tsx` | Modified — add OfflineBanner |

## Test plan
- [x] `npm test` — 42/42 passed
- [ ] Manual: disconnect network → verify yellow offline banner appears
- [ ] Manual: reconnect → verify "已恢復連線" toast appears
- [ ] Manual: Firestore permission error → verify error toast shown
- [ ] Verify toast auto-dismiss (3s for success/warning, stays for error)
- [ ] Verify max 3 toasts stacking