### PR TITLE
fix(split): add confirmation dialog before settlement deletion

### DIFF
--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -137,6 +137,11 @@ export default function SplitPage() {
 
   async function handleDeleteSettlement(id: string) {
     if (!group) return
+    const settlement = settlements.find(s => s.id === id)
+    const desc = settlement
+      ? `${settlement.fromMemberName} → ${settlement.toMemberName}（${currency(settlement.amount)}）`
+      : '此結算紀錄'
+    if (!confirm(`確定要刪除${desc}嗎？刪除後將影響債務計算。`)) return
     setDeletingId(id)
     try {
       await deleteSettlement(group.id, id, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)


### PR DESCRIPTION
## Summary
- 結算紀錄刪除新增 `confirm()` 確認對話框，顯示轉出人、轉入人與金額
- 與費用刪除（records/page.tsx）行為一致

Closes #102

## Test plan
- [ ] 點擊結算紀錄「刪除」→ 彈出確認對話框，顯示正確的轉帳資訊
- [ ] 按取消 → 不刪除
- [ ] 按確定 → 正常刪除，債務重新計算
- [ ] 手機上測試誤觸場景