### PR TITLE
feat(sync-error): 改善資料同步失敗的使用者體驗

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -6,6 +6,7 @@ import { GroupDataProvider } from '@/lib/group-data-context'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { NavShell } from '@/components/nav-shell'
+import { ConnectionBanner } from '@/components/connection-banner'
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
@@ -28,6 +29,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
   return (
     <GroupProvider>
       <GroupDataProvider>
+        <ConnectionBanner />
         <NavShell>{children}</NavShell>
       </GroupDataProvider>
     </GroupProvider>

--- a/src/components/connection-banner.tsx
+++ b/src/components/connection-banner.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useGroupData } from '@/lib/group-data-context'
+
+export function ConnectionBanner() {
+  const { syncError } = useGroupData()
+
+  if (!syncError) return null
+
+  return (
+    <div
+      role="alert"
+      className="sticky top-0 z-50 flex items-center justify-between gap-3 px-4 py-2.5 text-sm font-medium"
+      style={{
+        backgroundColor: 'color-mix(in oklch, var(--destructive), transparent 85%)',
+        color: 'var(--destructive)',
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true">⚠</span>
+        <span>{syncError}</span>
+      </div>
+      <button
+        onClick={() => window.location.reload()}
+        className="shrink-0 rounded-md px-3 py-1 text-xs font-semibold transition-colors hover:opacity-80"
+        style={{
+          backgroundColor: 'var(--destructive)',
+          color: '#fff',
+        }}
+      >
+        重新載入
+      </button>
+    </div>
+  )
+}

--- a/src/lib/group-data-context.tsx
+++ b/src/lib/group-data-context.tsx
@@ -21,6 +21,7 @@ interface GroupDataContextType {
   settlementsLoading: boolean
   categoriesLoading: boolean
   notificationsLoading: boolean
+  syncError: string | null
 }
 
 const GroupDataContext = createContext<GroupDataContextType>({
@@ -35,7 +36,21 @@ const GroupDataContext = createContext<GroupDataContextType>({
   settlementsLoading: true,
   categoriesLoading: true,
   notificationsLoading: true,
+  syncError: null,
 })
+
+function getSyncErrorMessage(context: string, err: unknown): string {
+  const code = (err as { code?: string })?.code
+  if (code === 'permission-denied') return `${context}同步失敗：權限不足，請確認帳號已加入群組`
+  if (code === 'unauthenticated') return '登入已過期，請重新登入'
+  if (code === 'unavailable' || code === 'resource-exhausted') return `${context}暫時無法連線，將自動重試`
+  return `${context}同步失敗，請檢查網路連線`
+}
+
+function getSyncToastLevel(err: unknown): 'error' | 'warning' {
+  const code = (err as { code?: string })?.code
+  return (code === 'unavailable' || code === 'resource-exhausted') ? 'warning' : 'error'
+}
 
 export function GroupDataProvider({ children }: { children: ReactNode }) {
   const { activeGroup } = useGroupContext()
@@ -48,6 +63,7 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
   const [settlements, setSettlements] = useState<Settlement[]>([])
   const [categories, setCategories] = useState<Category[]>([])
   const [notifications, setNotifications] = useState<AppNotification[]>([])
+  const [syncError, setSyncError] = useState<string | null>(null)
   const [expensesLoading, setExpensesLoading] = useState(true)
   const [membersLoading, setMembersLoading] = useState(true)
   const [settlementsLoading, setSettlementsLoading] = useState(true)
@@ -61,6 +77,7 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     setSettlements([])
     setCategories([])
     setNotifications([])
+    setSyncError(null)
     setExpensesLoading(true)
     setMembersLoading(true)
     setSettlementsLoading(true)
@@ -73,8 +90,8 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     if (!groupId) { setExpensesLoading(false); return }
     const q = query(collection(db, 'groups', groupId, 'expenses'), orderBy('date', 'desc'), limit(200))
     const unsub = onSnapshot(q,
-      (snap) => { setExpenses(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Expense)); setExpensesLoading(false) },
-      (err) => { logger.error('[GroupData] expenses error:', err); addToast('資料同步失敗，請檢查網路連線', 'error'); setExpensesLoading(false) },
+      (snap) => { setExpenses(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Expense)); setExpensesLoading(false); setSyncError(null) },
+      (err) => { logger.error('[GroupData] expenses error:', err); addToast(getSyncErrorMessage('費用資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('費用資料', err)); setExpensesLoading(false) },
     )
     return unsub
   }, [groupId])
@@ -84,8 +101,8 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     if (!groupId) { setMembersLoading(false); return }
     const q = query(collection(db, 'groups', groupId, 'members'), orderBy('sortOrder'))
     const unsub = onSnapshot(q,
-      (snap) => { setMembers(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as FamilyMember)); setMembersLoading(false) },
-      (err) => { logger.error('[GroupData] members error:', err); addToast('資料同步失敗，請檢查網路連線', 'error'); setMembersLoading(false) },
+      (snap) => { setMembers(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as FamilyMember)); setMembersLoading(false); setSyncError(null) },
+      (err) => { logger.error('[GroupData] members error:', err); addToast(getSyncErrorMessage('成員資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('成員資料', err)); setMembersLoading(false) },
     )
     return unsub
   }, [groupId])
@@ -95,8 +112,8 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     if (!groupId) { setSettlementsLoading(false); return }
     const q = query(collection(db, 'groups', groupId, 'settlements'), orderBy('date', 'desc'), limit(200))
     const unsub = onSnapshot(q,
-      (snap) => { setSettlements(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Settlement)); setSettlementsLoading(false) },
-      (err) => { logger.error('[GroupData] settlements error:', err); addToast('資料同步失敗，請檢查網路連線', 'error'); setSettlementsLoading(false) },
+      (snap) => { setSettlements(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Settlement)); setSettlementsLoading(false); setSyncError(null) },
+      (err) => { logger.error('[GroupData] settlements error:', err); addToast(getSyncErrorMessage('結算資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('結算資料', err)); setSettlementsLoading(false) },
     )
     return unsub
   }, [groupId])
@@ -106,8 +123,8 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     if (!groupId) { setCategoriesLoading(false); return }
     const q = query(collection(db, 'groups', groupId, 'categories'), orderBy('sortOrder'))
     const unsub = onSnapshot(q,
-      (snap) => { setCategories(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Category)); setCategoriesLoading(false) },
-      (err) => { logger.error('[GroupData] categories error:', err); addToast('資料同步失敗，請檢查網路連線', 'error'); setCategoriesLoading(false) },
+      (snap) => { setCategories(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Category)); setCategoriesLoading(false); setSyncError(null) },
+      (err) => { logger.error('[GroupData] categories error:', err); addToast(getSyncErrorMessage('分類資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('分類資料', err)); setCategoriesLoading(false) },
     )
     return unsub
   }, [groupId])
@@ -122,8 +139,8 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
       limit(50),
     )
     const unsub = onSnapshot(q,
-      (snap) => { setNotifications(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AppNotification)); setNotificationsLoading(false) },
-      (err) => { logger.error('[GroupData] notifications error:', err.message); addToast('資料同步失敗，請檢查網路連線', 'error'); setNotificationsLoading(false) },
+      (snap) => { setNotifications(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AppNotification)); setNotificationsLoading(false); setSyncError(null) },
+      (err) => { logger.error('[GroupData] notifications error:', err.message); addToast(getSyncErrorMessage('通知', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('通知', err)); setNotificationsLoading(false) },
     )
     return unsub
   }, [groupId, user])
@@ -133,8 +150,10 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
   const value = useMemo(() => ({
     expenses, members, settlements, categories, notifications, unreadCount,
     expensesLoading, membersLoading, settlementsLoading, categoriesLoading, notificationsLoading,
+    syncError,
   }), [expenses, members, settlements, categories, notifications, unreadCount,
-       expensesLoading, membersLoading, settlementsLoading, categoriesLoading, notificationsLoading])
+       expensesLoading, membersLoading, settlementsLoading, categoriesLoading, notificationsLoading,
+       syncError])
 
   return (
     <GroupDataContext.Provider value={value}>


### PR DESCRIPTION
## Summary
- **差異化錯誤訊息**：根據 Firebase error code（permission-denied、unauthenticated、unavailable、resource-exhausted）顯示對應中文訊息，並標示失敗的資料類型（費用/成員/結算/分類/通知）
- **連線狀態 banner**：新增 `ConnectionBanner` 元件，在同步失敗時顯示 sticky alert + 重新載入按鈕，重連成功自動消失
- **暫時性錯誤降級**：`unavailable`/`resource-exhausted` 使用 warning 級別 toast（非 error），因為 Firebase 會自動重試

Closes #114

## Changed Files
| File | Change |
|------|--------|
| `src/lib/group-data-context.tsx` | 新增 `getSyncErrorMessage`/`getSyncToastLevel` helpers；5 個 error handler 改用差異化訊息；新增 `syncError` state |
| `src/components/connection-banner.tsx` | 新增連線狀態 banner 元件 |
| `src/app/(auth)/layout.tsx` | 插入 `<ConnectionBanner />` |

## Test plan
- [ ] 模擬 Firestore permission-denied（修改 security rules）→ 應顯示「權限不足」
- [ ] 斷網後重連 → banner 出現「暫時無法連線」→ 重連後 banner 消失
- [ ] Auth token 過期 → 應顯示「登入已過期」
- [ ] 正常使用下不應出現 banner 或多餘 toast