### PR TITLE
fix(statistics): warn when month may be incomplete due to 200-expense limit

### DIFF
--- a/src/app/(auth)/statistics/page.tsx
+++ b/src/app/(auth)/statistics/page.tsx
@@ -5,9 +5,14 @@ import dynamic from 'next/dynamic'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useMembers } from '@/lib/hooks/use-members'
 import { useExpenses } from '@/lib/hooks/use-expenses'
-import { toDate } from '@/lib/utils'
+import { toDate, fmtDateFull } from '@/lib/utils'
 import type { Expense } from '@/lib/types'
 import type { StatisticsChartsProps } from '@/components/statistics-charts'
+
+// Must stay in sync with the `limit()` used in group-data-context.tsx's expenses subscription.
+// When the loaded expense count hits this ceiling, months beyond the oldest loaded record
+// may be silently incomplete — we surface that to the user via a banner + MonthPicker label.
+const EXPENSE_LIMIT = 200
 
 // ── Lazy-load recharts bundle — keeps it out of the initial JS payload ─────
 
@@ -67,7 +72,15 @@ function filterByMonth(expenses: Expense[], year: number, month: number) {
 
 // ── Month picker ───────────────────────────────────────────────
 
-function MonthPicker({ value, onChange }: { value: { year: number; month: number }; onChange: (_v: { year: number; month: number }) => void }) {
+function MonthPicker({
+  value,
+  onChange,
+  truncatedBefore,
+}: {
+  value: { year: number; month: number }
+  onChange: (_v: { year: number; month: number }) => void
+  truncatedBefore: Date | null
+}) {
   const months = useMemo(() => lastNMonths(12), [])
 
   return (
@@ -78,11 +91,15 @@ function MonthPicker({ value, onChange }: { value: { year: number; month: number
         onChange({ year: y, month: m })
       }}
       className="h-9 rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 text-sm">
-      {months.map(({ year, month }) => (
-        <option key={`${year}-${month}`} value={`${year}-${month}`}>
-          {formatMonth(year, month)}
-        </option>
-      ))}
+      {months.map(({ year, month }) => {
+        const monthStart = new Date(year, month, 1)
+        const isTruncated = truncatedBefore !== null && monthStart < truncatedBefore
+        return (
+          <option key={`${year}-${month}`} value={`${year}-${month}`}>
+            {formatMonth(year, month)}{isTruncated ? '（資料不完整）' : ''}
+          </option>
+        )
+      })}
     </select>
   )
 }
@@ -161,6 +178,21 @@ export default function StatisticsPage() {
     return filterByMonth(expenses, prev.getFullYear(), prev.getMonth())
   }, [expenses, selectedMonth])
 
+  // The shared expenses subscription is capped at EXPENSE_LIMIT. When we hit the cap,
+  // the oldest record we have is a hard floor for any month that predates it.
+  // expenses are ordered by date desc, so the last item is the oldest loaded.
+  const oldestLoadedDate = useMemo<Date | null>(() => {
+    if (expenses.length < EXPENSE_LIMIT) return null
+    const oldest = expenses[expenses.length - 1]
+    return oldest?.date ? toDate(oldest.date) : null
+  }, [expenses])
+
+  const isSelectedMonthTruncated = useMemo(() => {
+    if (!oldestLoadedDate) return false
+    const monthStart = new Date(selectedMonth.year, selectedMonth.month, 1)
+    return monthStart < oldestLoadedDate
+  }, [oldestLoadedDate, selectedMonth])
+
   if (groupLoading || expLoading || membersLoading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -173,8 +205,32 @@ export default function StatisticsPage() {
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-4 md:space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">📊 統計</h1>
-        <MonthPicker value={selectedMonth} onChange={setSelectedMonth} />
+        <MonthPicker
+          value={selectedMonth}
+          onChange={setSelectedMonth}
+          truncatedBefore={oldestLoadedDate}
+        />
       </div>
+
+      {/* Truncation warning — only surfaces when the shared expense subscription hit
+          its limit AND the selected month predates the oldest record we have. */}
+      {isSelectedMonthTruncated && oldestLoadedDate && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-xl border border-[var(--border)] p-4"
+          style={{
+            backgroundColor: 'color-mix(in oklch, oklch(0.80 0.15 75), var(--card) 80%)',
+          }}
+        >
+          <div className="text-xl leading-none shrink-0" aria-hidden>⚠️</div>
+          <div className="flex-1 min-w-0 space-y-0.5">
+            <p className="text-sm font-semibold">資料可能不完整</p>
+            <p className="text-xs text-[var(--muted-foreground)]">
+              目前只載入最近 {EXPENSE_LIMIT} 筆支出。早於 {fmtDateFull(oldestLoadedDate)} 的資料未顯示，此月份的統計可能不完整。
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Summary */}
       <SummaryCards expenses={monthExpenses} prevExpenses={prevMonthExpenses} />


### PR DESCRIPTION
## Summary

- 偵測統計頁的月份資料截斷：當共用 expenses 訂閱達到 `limit(200)` 上限時，早於最舊紀錄的月份可能不完整但 UI 完全沒有提示
- 當選到會被截斷的月份時，顯示琥珀色警告 banner 告知「早於 {date} 的資料未顯示」
- MonthPicker 的 `<option>` 對被截斷的月份加上「（資料不完整）」標記
- 純 UI 改動，不動 Firestore query / schema / 既有 hook

Closes #126

## Why this matters

活躍家庭 2-3 個月就會累積 200 筆支出。在此 PR 之前，使用者切到 3 個月前的月份時會看到空白圖表，完全無法分辨「這個月真的沒花錢」vs「資料被截斷」。這是 silent data correctness bug。

## Screenshots (text preview)

When `expenses.length >= 200` and selected month predates oldest loaded:

```
📊 統計                    [2025/12（資料不完整） ▾]

⚠️  資料可能不完整
    目前只載入最近 200 筆支出。早於 2026/01/15 的資料未顯示，
    此月份的統計可能不完整。

┌──────────┬──────────┬──────────┐
│  總支出  │ 共同支出 │ 個人支出 │
...
```

When `expenses.length < 200`: no banner, no option labels — zero noise.

## Test plan

- [x] `npm run lint` — 0 errors, 4 pre-existing warnings in toast.tsx unchanged
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test -- split-calculator` — 34/34 passing
- [x] Manual trace: `expenses.length === 199` → no banner, no labels
- [x] Manual trace: `expenses.length === 200` and oldest from 2026/01/15 → Dec 2025 shows banner + label
- [ ] Manual visual check in dev server (reviewer)

## Out of scope (Phase 2 candidates)

- Dedicated month-scoped Firestore query (`useMonthExpenses(year, month)`)
- Pagination / infinite history
- Changing the `limit(200)` constant (needs cost evaluation)