### PR TITLE
feat: 定期支出自動化 (Recurring Expenses)

### DIFF
--- a/__tests__/recurring-generator.test.ts
+++ b/__tests__/recurring-generator.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Unit tests for recurring-generator.ts
+ * Tests the pure function: getNextOccurrences(template, after, before)
+ *
+ * Range semantics: (after, before] — left exclusive, right inclusive.
+ */
+
+// Mock Firebase dependencies so the module can be imported without
+// a real Firebase project or API key in the test environment.
+jest.mock('@/lib/firebase', () => ({
+  db: {},
+  auth: {},
+  storage: {},
+}))
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  doc: jest.fn(),
+  getDocs: jest.fn(),
+  getDoc: jest.fn(),
+  setDoc: jest.fn(),
+  writeBatch: jest.fn(),
+  Timestamp: {
+    now: jest.fn(() => ({ toMillis: () => Date.now() })),
+    fromDate: jest.fn((d: Date) => ({ toDate: () => d })),
+  },
+}))
+
+import { getNextOccurrences } from '@/lib/services/recurring-generator'
+import type { RecurringExpense } from '@/lib/types'
+
+// Helper to create a minimal RecurringExpense with sensible defaults
+function mockTemplate(overrides: Partial<RecurringExpense>): RecurringExpense {
+  return {
+    id: 'test',
+    groupId: 'g1',
+    description: 'Test',
+    amount: 100,
+    category: 'Test',
+    payerId: 'p1',
+    payerName: 'Test',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    frequency: 'monthly',
+    isPaused: false,
+    createdBy: 'u1',
+    // Mock Timestamps
+    startDate: { toDate: () => new Date('2025-01-01') } as any,
+    createdAt: { toDate: () => new Date() } as any,
+    updatedAt: { toDate: () => new Date() } as any,
+    ...overrides,
+  } as RecurringExpense
+}
+
+// ── Monthly ───────────────────────────────────────────────────────
+
+describe('getNextOccurrences — monthly', () => {
+  test('single month: dayOfMonth=15 in range returns one occurrence', () => {
+    const template = mockTemplate({ frequency: 'monthly', dayOfMonth: 15 })
+    const after = new Date('2025-03-01')
+    const before = new Date('2025-03-31')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2025, 2, 15)) // March 15
+  })
+
+  test('multiple months: range covers 3 months returns 3 occurrences', () => {
+    const template = mockTemplate({ frequency: 'monthly', dayOfMonth: 10 })
+    const after = new Date('2025-01-01')
+    const before = new Date('2025-03-31')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual(new Date(2025, 0, 10)) // Jan 10
+    expect(result[1]).toEqual(new Date(2025, 1, 10)) // Feb 10
+    expect(result[2]).toEqual(new Date(2025, 2, 10)) // Mar 10
+  })
+
+  test('day clamping: dayOfMonth=31 in February clamps to 28 (non-leap year)', () => {
+    const template = mockTemplate({ frequency: 'monthly', dayOfMonth: 31 })
+    const after = new Date('2025-01-31')
+    const before = new Date('2025-02-28')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2025, 1, 28)) // Feb 28
+  })
+
+  test('day clamping: dayOfMonth=31 in April clamps to 30', () => {
+    const template = mockTemplate({ frequency: 'monthly', dayOfMonth: 31 })
+    const after = new Date('2025-03-31')
+    const before = new Date('2025-04-30')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2025, 3, 30)) // Apr 30
+  })
+
+  test('no occurrences when range is too narrow to include the target day', () => {
+    // dayOfMonth=15, but range is Jan 16-31 — 15th is excluded
+    const template = mockTemplate({ frequency: 'monthly', dayOfMonth: 15 })
+    const after = new Date('2025-01-16')
+    const before = new Date('2025-01-31')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(0)
+  })
+
+  test('boundary: after is exactly the target day — should NOT be included (exclusive left)', () => {
+    const template = mockTemplate({ frequency: 'monthly', dayOfMonth: 15 })
+    // after is midnight on Mar 15 — target falls exactly on after, so excluded
+    const after = new Date(2025, 2, 15, 0, 0, 0, 0)
+    const before = new Date('2025-04-30')
+
+    const result = getNextOccurrences(template, after, before)
+
+    // Mar 15 itself is excluded because candidate must be > after
+    // Apr 15 is the first valid occurrence
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2025, 3, 15)) // Apr 15
+  })
+
+  test('boundary: before is exactly the target day — should be included (inclusive right)', () => {
+    const template = mockTemplate({ frequency: 'monthly', dayOfMonth: 15 })
+    const after = new Date('2025-02-01')
+    const before = new Date(2025, 2, 15, 0, 0, 0, 0) // exactly Mar 15 midnight
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(2) // Feb 15 and Mar 15
+    expect(result[1]).toEqual(new Date(2025, 2, 15))
+  })
+
+  test('default dayOfMonth is 1 when not specified', () => {
+    const template = mockTemplate({ frequency: 'monthly' }) // dayOfMonth omitted
+    const after = new Date('2025-01-01')
+    const before = new Date('2025-02-28')
+
+    const result = getNextOccurrences(template, after, before)
+
+    // Jan 1 is excluded (after is Jan 1), Feb 1 is included
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2025, 1, 1)) // Feb 1
+  })
+})
+
+// ── Weekly ────────────────────────────────────────────────────────
+
+describe('getNextOccurrences — weekly', () => {
+  test('single week: dayOfWeek=1 (Monday) in range returns one occurrence', () => {
+    // 2025-03-03 is a Monday
+    const template = mockTemplate({ frequency: 'weekly', dayOfWeek: 1 })
+    const after = new Date('2025-03-01') // Saturday
+    const before = new Date('2025-03-05') // Wednesday
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].getDay()).toBe(1) // Monday
+    expect(result[0]).toEqual(new Date(2025, 2, 3, 0, 0, 0, 0))
+  })
+
+  test('multiple weeks: range spanning 3 weeks returns 3 occurrences', () => {
+    // Fridays: 2025-03-07, 2025-03-14, 2025-03-21
+    const template = mockTemplate({ frequency: 'weekly', dayOfWeek: 5 })
+    const after = new Date('2025-03-01')
+    const before = new Date('2025-03-22')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(3)
+    result.forEach((d) => expect(d.getDay()).toBe(5)) // all Fridays
+  })
+
+  test('dayOfWeek=0 (Sunday) is handled correctly', () => {
+    // 2025-03-02 is a Sunday; 2025-03-08 is a Saturday (before next Sunday)
+    const template = mockTemplate({ frequency: 'weekly', dayOfWeek: 0 })
+    const after = new Date(2025, 2, 1, 0, 0, 0, 0)  // Sat Mar 1
+    const before = new Date(2025, 2, 8, 0, 0, 0, 0) // Sat Mar 8 — excludes Mar 9 Sunday
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].getDay()).toBe(0)
+    expect(result[0]).toEqual(new Date(2025, 2, 2, 0, 0, 0, 0))
+  })
+
+  test('no occurrences when range is narrower than one week and misses target day', () => {
+    // dayOfWeek=1 (Monday), but range is Tue-Fri — no Monday present
+    // 2025-03-04 is Tuesday
+    const template = mockTemplate({ frequency: 'weekly', dayOfWeek: 1 })
+    const after = new Date('2025-03-04') // Tuesday
+    const before = new Date('2025-03-07') // Friday
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(0)
+  })
+
+  test('default dayOfWeek is 1 (Monday) when not specified', () => {
+    const template = mockTemplate({ frequency: 'weekly' }) // dayOfWeek omitted
+    // 2025-03-03 is a Monday
+    const after = new Date('2025-03-01')
+    const before = new Date('2025-03-05')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].getDay()).toBe(1)
+  })
+})
+
+// ── Yearly ────────────────────────────────────────────────────────
+
+describe('getNextOccurrences — yearly', () => {
+  test('single year: occurrence in range returns one date', () => {
+    // monthOfYear=6 (June), dayOfMonth=15 → June 15
+    const template = mockTemplate({ frequency: 'yearly', monthOfYear: 6, dayOfMonth: 15 })
+    const after = new Date('2025-01-01')
+    const before = new Date('2025-12-31')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2025, 5, 15)) // June 15 (0-indexed month)
+  })
+
+  test('range spanning two years returns two occurrences', () => {
+    const template = mockTemplate({ frequency: 'yearly', monthOfYear: 1, dayOfMonth: 1 })
+    const after = new Date('2024-06-01')
+    const before = new Date('2026-06-01')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual(new Date(2025, 0, 1)) // Jan 1 2025
+    expect(result[1]).toEqual(new Date(2026, 0, 1)) // Jan 1 2026
+  })
+
+  test('yearly Feb 29 in non-leap year clamps to Feb 28', () => {
+    // 2025 is not a leap year
+    const template = mockTemplate({ frequency: 'yearly', monthOfYear: 2, dayOfMonth: 29 })
+    const after = new Date('2025-01-01')
+    const before = new Date('2025-12-31')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2025, 1, 28)) // Feb 28 2025
+  })
+
+  test('yearly Feb 29 in leap year is NOT clamped', () => {
+    // 2024 is a leap year
+    const template = mockTemplate({ frequency: 'yearly', monthOfYear: 2, dayOfMonth: 29 })
+    const after = new Date('2024-01-01')
+    const before = new Date('2024-12-31')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2024, 1, 29)) // Feb 29 2024
+  })
+
+  test('no occurrence when yearly date falls outside range', () => {
+    // monthOfYear=12 (December), range ends before December
+    const template = mockTemplate({ frequency: 'yearly', monthOfYear: 12, dayOfMonth: 25 })
+    const after = new Date('2025-01-01')
+    const before = new Date('2025-11-30')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(0)
+  })
+
+  test('default monthOfYear=1 and dayOfMonth=1 when not specified', () => {
+    const template = mockTemplate({ frequency: 'yearly' })
+    const after = new Date('2024-12-31')
+    const before = new Date('2025-01-02')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2025, 0, 1)) // Jan 1 2025
+  })
+})
+
+// ── Edge cases ────────────────────────────────────────────────────
+
+describe('getNextOccurrences — edge cases', () => {
+  test('after === before → no occurrences regardless of frequency', () => {
+    const sameDate = new Date('2025-06-15')
+
+    const monthly = mockTemplate({ frequency: 'monthly', dayOfMonth: 15 })
+    expect(getNextOccurrences(monthly, sameDate, sameDate)).toHaveLength(0)
+
+    const weekly = mockTemplate({ frequency: 'weekly', dayOfWeek: sameDate.getDay() })
+    expect(getNextOccurrences(weekly, sameDate, sameDate)).toHaveLength(0)
+
+    const yearly = mockTemplate({ frequency: 'yearly', monthOfYear: 6, dayOfMonth: 15 })
+    expect(getNextOccurrences(yearly, sameDate, sameDate)).toHaveLength(0)
+  })
+
+  test('returns empty array for unknown/unsupported frequency', () => {
+    const template = mockTemplate({ frequency: 'daily' as any })
+    const after = new Date('2025-01-01')
+    const before = new Date('2025-12-31')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toEqual([])
+  })
+
+  test('monthly: occurrence on the last day of every month using dayOfMonth=31', () => {
+    // Jan 31, Feb 28, Mar 31 across 3 months
+    const template = mockTemplate({ frequency: 'monthly', dayOfMonth: 31 })
+    const after = new Date('2025-01-01')
+    const before = new Date('2025-03-31')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual(new Date(2025, 0, 31)) // Jan 31
+    expect(result[1]).toEqual(new Date(2025, 1, 28)) // Feb 28 (clamped)
+    expect(result[2]).toEqual(new Date(2025, 2, 31)) // Mar 31
+  })
+
+  test('weekly: after is at midnight, next day is target — included', () => {
+    // after = Sunday midnight, before = following Sunday midnight
+    // dayOfWeek=1 (Monday) → Monday should appear
+    // 2025-03-02 (Sun midnight) → 2025-03-03 (Mon) is in range
+    const template = mockTemplate({ frequency: 'weekly', dayOfWeek: 1 })
+    const after = new Date(2025, 2, 2, 0, 0, 0, 0) // Sun Mar 2 midnight
+    const before = new Date(2025, 2, 9, 0, 0, 0, 0) // Sun Mar 9 midnight
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(new Date(2025, 2, 3, 0, 0, 0, 0)) // Mon Mar 3
+  })
+
+  test('returns Date objects (not timestamps)', () => {
+    const template = mockTemplate({ frequency: 'monthly', dayOfMonth: 1 })
+    const after = new Date('2025-01-01')
+    const before = new Date('2025-02-28')
+
+    const result = getNextOccurrences(template, after, before)
+
+    expect(result.length).toBeGreaterThan(0)
+    result.forEach((d) => expect(d).toBeInstanceOf(Date))
+  })
+})

--- a/firestore.rules
+++ b/firestore.rules
@@ -212,6 +212,29 @@ service cloud.firestore {
         allow delete: if isGroupMember(groupId);
       }
 
+      // ─── 定期支出範本（Recurring Expenses） ───
+
+      match /recurringExpenses/{recurringId} {
+        allow read: if isGroupMember(groupId);
+        allow create: if isGroupMember(groupId)
+          && hasReasonableSize()
+          && request.resource.data.description is string
+          && request.resource.data.description.size() > 0
+          && request.resource.data.description.size() <= 200
+          && request.resource.data.category is string
+          && request.resource.data.payerId is string
+          && request.resource.data.createdBy == request.auth.uid
+          && request.resource.data.frequency in ['monthly', 'weekly', 'yearly'];
+        allow update: if isGroupMember(groupId)
+          && (resource.data.createdBy == request.auth.uid || isGroupOwner(groupId))
+          && hasReasonableSize()
+          && request.resource.data.description is string
+          && request.resource.data.description.size() > 0
+          && request.resource.data.description.size() <= 200;
+        allow delete: if isGroupMember(groupId)
+          && (resource.data.createdBy == request.auth.uid || isGroupOwner(groupId));
+      }
+
       // ─── 通知 ───
 
       match /notifications/{notifId} {

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useExpenses, useMonthlyExpenses, useRecentExpenses } from '@/lib/hooks/use-expenses'
@@ -13,6 +13,9 @@ import { currency, toDate, fmtDate } from '@/lib/utils'
 import { QuickAddBar } from '@/components/quick-add-bar'
 import { WeeklyDigest } from '@/components/weekly-digest'
 import { BudgetProgress } from '@/components/budget-progress'
+import { generatePendingRecurring } from '@/lib/services/recurring-generator'
+import { confirmPendingExpense } from '@/lib/services/recurring-generator'
+import { logger } from '@/lib/logger'
 
 function NoGroupView() {
   const [code, setCode] = useState('')
@@ -74,6 +77,17 @@ export default function HomePage() {
   const nameMap = useMemo(() => Object.fromEntries(members.map((m) => [m.id, m.name])), [members])
   const debts = useMemo(() => simplifyDebts(expenses, settlements, nameMap), [expenses, settlements, nameMap])
 
+  // Pending confirmation: auto-generated recurring expenses
+  const pendingExpenses = useMemo(() => expenses.filter((e) => e.pendingConfirm), [expenses])
+
+  // Trigger recurring expense generation on page load
+  useEffect(() => {
+    if (!group?.id) return
+    generatePendingRecurring(group.id).catch((err) =>
+      logger.error('[Home] recurring generation failed:', err),
+    )
+  }, [group?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const now = new Date()
   const monthLabel = `${now.getFullYear()}年 ${now.getMonth() + 1}月`
   const total = useMemo(() => monthly.reduce((s, e) => s + e.amount, 0), [monthly])
@@ -98,6 +112,35 @@ export default function HomePage() {
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-4 md:space-y-6">
       {/* 快速記帳 */}
       <QuickAddBar />
+
+      {/* 定期支出待確認 */}
+      {pendingExpenses.length > 0 && (
+        <div className="card p-4 flex items-center gap-3 animate-fade-up"
+          style={{ backgroundColor: 'color-mix(in oklch, var(--primary), transparent 92%)' }}>
+          <span className="text-xl">📌</span>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold">{pendingExpenses.length} 筆定期支出已自動記錄</p>
+            <p className="text-xs text-[var(--muted-foreground)]">點擊確認或前往記錄頁檢視</p>
+          </div>
+          <button
+            onClick={async () => {
+              for (const e of pendingExpenses) {
+                if (e.amount > 0) {
+                  await confirmPendingExpense(group!.id, e.id)
+                }
+              }
+            }}
+            className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium text-white"
+            style={{ backgroundColor: 'var(--primary)' }}>
+            全部確認
+          </button>
+          <button
+            onClick={() => router.push('/records')}
+            className="shrink-0 px-3 py-1.5 rounded-lg text-xs border border-[var(--border)] hover:bg-[var(--muted)]">
+            查看
+          </button>
+        </div>
+      )}
 
       {/* 每週回顧（可關閉） */}
       <WeeklyDigest expenses={expenses} />

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -674,6 +674,16 @@ export default function SettingsPage() {
           </Section>
         )}
 
+        <Section title="🔄 定期支出">
+          <div className="space-y-2">
+            <p className="text-sm text-[var(--muted-foreground)]">自動記錄每月房租、訂閱、保險等固定支出</p>
+            <button onClick={() => router.push('/settings/recurring')}
+              className="w-full py-2.5 rounded-lg text-sm font-medium border border-[var(--border)] hover:bg-[var(--muted)] transition-colors">
+              管理定期支出 →
+            </button>
+          </div>
+        </Section>
+
         <Section title="🎨 外觀與主題">
           <ThemeSection />
         </Section>

--- a/src/app/(auth)/settings/recurring/page.tsx
+++ b/src/app/(auth)/settings/recurring/page.tsx
@@ -1,0 +1,520 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { collection, onSnapshot, query, orderBy } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { useGroup } from '@/lib/hooks/use-group'
+import { useMembers } from '@/lib/hooks/use-members'
+import { useCategories } from '@/lib/hooks/use-categories'
+import { useAuth } from '@/lib/auth'
+import {
+  addRecurringExpense,
+  updateRecurringExpense,
+  deleteRecurringExpense,
+  togglePauseRecurringExpense,
+  getCurrentUserId,
+} from '@/lib/services/recurring-expense-service'
+import { currency } from '@/lib/utils'
+import type { RecurringExpense, RecurringFrequency } from '@/lib/types'
+import { logger } from '@/lib/logger'
+import Link from 'next/link'
+
+// ── Constants ──────────────────────────────────────────────────
+
+const FREQ_LABELS: Record<RecurringFrequency, string> = {
+  monthly: '每月',
+  weekly: '每週',
+  yearly: '每年',
+}
+const DAY_NAMES = ['日', '一', '二', '三', '四', '五', '六']
+const MONTH_NAMES = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月']
+
+// ── Types ──────────────────────────────────────────────────────
+
+interface FormState {
+  description: string
+  amount: string
+  category: string
+  frequency: RecurringFrequency
+  dayOfMonth: number
+  dayOfWeek: number
+  monthOfYear: number
+  payerId: string
+  isShared: boolean
+  startDate: string
+  endDate: string
+}
+
+function defaultForm(firstMemberId = ''): FormState {
+  const today = new Date().toISOString().split('T')[0]
+  return {
+    description: '',
+    amount: '',
+    category: '',
+    frequency: 'monthly',
+    dayOfMonth: 1,
+    dayOfWeek: 1,
+    monthOfYear: 1,
+    payerId: firstMemberId,
+    isShared: true,
+    startDate: today,
+    endDate: '',
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function freqDayLabel(r: RecurringExpense): string {
+  if (r.frequency === 'monthly') return `${FREQ_LABELS.monthly} ${r.dayOfMonth ?? 1} 日`
+  if (r.frequency === 'weekly') return `${FREQ_LABELS.weekly} 星期${DAY_NAMES[r.dayOfWeek ?? 1]}`
+  if (r.frequency === 'yearly')
+    return `${FREQ_LABELS.yearly} ${MONTH_NAMES[(r.monthOfYear ?? 1) - 1]} ${r.dayOfMonth ?? 1} 日`
+  return FREQ_LABELS[r.frequency]
+}
+
+// ── Main page ──────────────────────────────────────────────────
+
+export default function RecurringPage() {
+  const { group } = useGroup()
+  const { members } = useMembers()
+  const { categories } = useCategories()
+  const { user } = useAuth()
+
+  const [items, setItems] = useState<RecurringExpense[]>([])
+  const [showForm, setShowForm] = useState(false)
+  const [editing, setEditing] = useState<RecurringExpense | null>(null)
+  const [form, setForm] = useState<FormState>(defaultForm())
+  const [saving, setSaving] = useState(false)
+
+  // Subscribe to recurring expenses
+  useEffect(() => {
+    if (!group?.id) return
+    const q = query(
+      collection(db, 'groups', group.id, 'recurringExpenses'),
+      orderBy('createdAt', 'desc'),
+    )
+    const unsub = onSnapshot(q, (snap) => {
+      setItems(snap.docs.map((d) => d.data() as RecurringExpense))
+    })
+    return unsub
+  }, [group?.id])
+
+  // Set default payerId when members load
+  useEffect(() => {
+    if (members.length > 0 && !form.payerId) {
+      setForm((f) => ({ ...f, payerId: members[0].id }))
+    }
+  }, [members])
+
+  function openAdd() {
+    setEditing(null)
+    setForm(defaultForm(members[0]?.id ?? ''))
+    setShowForm(true)
+  }
+
+  function openEdit(item: RecurringExpense) {
+    setEditing(item)
+    const startStr = item.startDate?.toDate().toISOString().split('T')[0] ?? new Date().toISOString().split('T')[0]
+    const endStr = item.endDate ? item.endDate.toDate().toISOString().split('T')[0] : ''
+    setForm({
+      description: item.description,
+      amount: item.amount !== null ? String(item.amount) : '',
+      category: item.category,
+      frequency: item.frequency,
+      dayOfMonth: item.dayOfMonth ?? 1,
+      dayOfWeek: item.dayOfWeek ?? 1,
+      monthOfYear: item.monthOfYear ?? 1,
+      payerId: item.payerId,
+      isShared: item.isShared,
+      startDate: startStr,
+      endDate: endStr,
+    })
+    setShowForm(true)
+  }
+
+  function buildSplits(payerId: string) {
+    if (!form.isShared || members.length === 0) return []
+    const share = Math.round(100 / members.length)
+    const remainder = 100 - share * (members.length - 1)
+    return members.map((m, i) => ({
+      memberId: m.id,
+      memberName: m.name,
+      shareAmount: i === 0 ? remainder : share,
+      paidAmount: m.id === payerId ? 100 : 0,
+      isParticipant: true,
+    }))
+  }
+
+  function getPayerName(payerId: string): string {
+    return members.find((m) => m.id === payerId)?.name ?? '未知'
+  }
+
+  async function handleSave() {
+    if (!form.description.trim() || !group?.id) return
+    setSaving(true)
+    const uid = getCurrentUserId() ?? user?.uid ?? ''
+    const payerName = getPayerName(form.payerId)
+    const splits = buildSplits(form.payerId)
+    const input = {
+      description: form.description.trim(),
+      amount: form.amount ? Number(form.amount) : null,
+      category: form.category || (categories[0]?.name ?? ''),
+      frequency: form.frequency,
+      dayOfMonth: form.frequency !== 'weekly' ? form.dayOfMonth : undefined,
+      dayOfWeek: form.frequency === 'weekly' ? form.dayOfWeek : undefined,
+      monthOfYear: form.frequency === 'yearly' ? form.monthOfYear : undefined,
+      payerId: form.payerId,
+      payerName,
+      isShared: form.isShared,
+      splitMethod: 'equal' as const,
+      splits,
+      paymentMethod: 'cash' as const,
+      startDate: new Date(form.startDate),
+      endDate: form.endDate ? new Date(form.endDate) : null,
+      createdBy: uid,
+    }
+
+    try {
+      if (editing?.id) {
+        await updateRecurringExpense(group.id, editing.id, input)
+      } else {
+        await addRecurringExpense(group.id, input)
+      }
+      setShowForm(false)
+    } catch (e) {
+      logger.error('[Recurring] Failed to save:', e)
+      alert('儲存失敗，請稍後再試')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete(item: RecurringExpense) {
+    if (!group?.id || !item.id || !confirm(`確定刪除「${item.description}」？`)) return
+    try {
+      await deleteRecurringExpense(group.id, item.id)
+    } catch (e) {
+      logger.error('[Recurring] Failed to delete:', e)
+      alert('刪除失敗，請稍後再試')
+    }
+  }
+
+  async function handleTogglePause(item: RecurringExpense) {
+    if (!group?.id || !item.id) return
+    try {
+      await togglePauseRecurringExpense(group.id, item.id, !item.isPaused)
+    } catch (e) {
+      logger.error('[Recurring] Failed to toggle pause:', e)
+      alert('操作失敗，請稍後再試')
+    }
+  }
+
+  return (
+    <div className="p-4 md:p-8 space-y-4 md:space-y-6 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/settings"
+          className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+        >
+          ← 設定
+        </Link>
+        <h1 className="text-xl font-bold flex-1">🔄 定期支出</h1>
+        <button
+          onClick={openAdd}
+          className="text-xs px-3 py-1.5 rounded-lg font-medium text-white"
+          style={{ backgroundColor: 'var(--primary)' }}
+        >
+          ＋ 新增
+        </button>
+      </div>
+
+      {/* List */}
+      {items.length === 0 ? (
+        <div className="text-center py-16 space-y-3">
+          <div className="text-5xl opacity-30">🔄</div>
+          <p className="text-[var(--muted-foreground)]">還沒有定期支出，點擊上方按鈕新增</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className={`rounded-2xl border bg-[var(--card)] p-4 space-y-2 transition-opacity ${
+                item.isPaused ? 'opacity-60 border-[var(--border)]' : 'border-[var(--border)]'
+              }`}
+            >
+              {/* Title row */}
+              <div className="flex items-start gap-2">
+                <span className="text-lg flex-shrink-0">🔁</span>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-sm leading-snug">{item.description}</div>
+                  <div className="text-xs text-[var(--muted-foreground)] mt-0.5">
+                    {item.amount !== null ? currency(item.amount) : '金額待定'} ·{' '}
+                    {item.isShared ? '共同分擔' : '個人支出'}
+                  </div>
+                </div>
+                {item.isPaused && (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-[var(--muted)] text-[var(--muted-foreground)] flex-shrink-0">
+                    已暫停
+                  </span>
+                )}
+              </div>
+
+              {/* Frequency badge */}
+              <div className="flex items-center gap-2">
+                <span
+                  className="inline-flex items-center text-xs px-2.5 py-1 rounded-full font-medium"
+                  style={{
+                    backgroundColor: 'color-mix(in oklch, var(--primary), transparent 85%)',
+                    color: 'var(--primary)',
+                  }}
+                >
+                  {freqDayLabel(item)}
+                </span>
+                <span className="text-xs text-[var(--muted-foreground)]">
+                  付款人：{item.payerName}
+                </span>
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center gap-2 pt-1">
+                <button
+                  onClick={() => handleTogglePause(item)}
+                  className="text-xs px-3 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)] transition-colors text-[var(--muted-foreground)]"
+                >
+                  {item.isPaused ? '▶ 恢復' : '⏸ 暫停'}
+                </button>
+                <button
+                  onClick={() => openEdit(item)}
+                  className="text-xs px-3 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)] transition-colors text-[var(--muted-foreground)]"
+                >
+                  編輯
+                </button>
+                <button
+                  onClick={() => handleDelete(item)}
+                  className="text-xs px-3 py-1.5 rounded-lg text-[var(--destructive)] hover:bg-[var(--destructive)]/10 transition-colors"
+                >
+                  刪除
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Form Modal */}
+      {showForm && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50">
+          <div className="w-full max-w-md mx-0 sm:mx-4 rounded-t-3xl sm:rounded-2xl bg-[var(--card)] border border-[var(--border)] shadow-xl p-6 space-y-4 max-h-[90dvh] overflow-y-auto">
+            <h2 className="text-lg font-bold sticky top-0 bg-[var(--card)] pb-1">
+              {editing ? '編輯定期支出' : '新增定期支出'}
+            </h2>
+
+            {/* Description */}
+            <div>
+              <label className="text-xs text-[var(--muted-foreground)] mb-1 block">說明 *</label>
+              <input
+                type="text"
+                value={form.description}
+                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                placeholder="例如：Netflix 訂閱"
+                autoFocus
+                className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              />
+            </div>
+
+            {/* Amount */}
+            <div>
+              <label className="text-xs text-[var(--muted-foreground)] mb-1 block">
+                金額（留空表示每次手動輸入）
+              </label>
+              <input
+                type="number"
+                value={form.amount}
+                onChange={(e) => setForm({ ...form, amount: e.target.value })}
+                placeholder="0"
+                min={0}
+                className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              />
+            </div>
+
+            {/* Category */}
+            <div>
+              <label className="text-xs text-[var(--muted-foreground)] mb-1 block">分類</label>
+              <select
+                value={form.category}
+                onChange={(e) => setForm({ ...form, category: e.target.value })}
+                className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              >
+                {categories.filter((c) => c.isActive).map((c) => (
+                  <option key={c.id ?? c.name} value={c.name}>
+                    {c.icon} {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Frequency */}
+            <div>
+              <label className="text-xs text-[var(--muted-foreground)] mb-1 block">頻率</label>
+              <div className="flex gap-2">
+                {(['monthly', 'weekly', 'yearly'] as RecurringFrequency[]).map((f) => (
+                  <button
+                    key={f}
+                    type="button"
+                    onClick={() => setForm({ ...form, frequency: f })}
+                    className={`flex-1 py-2 rounded-lg text-sm border transition-colors ${
+                      form.frequency === f
+                        ? 'border-[var(--primary)] text-[var(--primary)] font-semibold'
+                        : 'border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--muted)]'
+                    }`}
+                  >
+                    {FREQ_LABELS[f]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Day selectors */}
+            {form.frequency === 'monthly' && (
+              <div>
+                <label className="text-xs text-[var(--muted-foreground)] mb-1 block">每月幾號</label>
+                <select
+                  value={form.dayOfMonth}
+                  onChange={(e) => setForm({ ...form, dayOfMonth: Number(e.target.value) })}
+                  className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                >
+                  {Array.from({ length: 31 }, (_, i) => i + 1).map((d) => (
+                    <option key={d} value={d}>{d} 號</option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {form.frequency === 'weekly' && (
+              <div>
+                <label className="text-xs text-[var(--muted-foreground)] mb-1 block">星期幾</label>
+                <select
+                  value={form.dayOfWeek}
+                  onChange={(e) => setForm({ ...form, dayOfWeek: Number(e.target.value) })}
+                  className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                >
+                  {DAY_NAMES.map((name, idx) => (
+                    <option key={idx} value={idx}>星期{name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {form.frequency === 'yearly' && (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="text-xs text-[var(--muted-foreground)] mb-1 block">月份</label>
+                  <select
+                    value={form.monthOfYear}
+                    onChange={(e) => setForm({ ...form, monthOfYear: Number(e.target.value) })}
+                    className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  >
+                    {MONTH_NAMES.map((name, idx) => (
+                      <option key={idx} value={idx + 1}>{name}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-xs text-[var(--muted-foreground)] mb-1 block">日期</label>
+                  <select
+                    value={form.dayOfMonth}
+                    onChange={(e) => setForm({ ...form, dayOfMonth: Number(e.target.value) })}
+                    className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  >
+                    {Array.from({ length: 31 }, (_, i) => i + 1).map((d) => (
+                      <option key={d} value={d}>{d} 號</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            )}
+
+            {/* Payer */}
+            <div>
+              <label className="text-xs text-[var(--muted-foreground)] mb-1 block">付款人</label>
+              <select
+                value={form.payerId}
+                onChange={(e) => setForm({ ...form, payerId: e.target.value })}
+                className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              >
+                {members.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* isShared toggle */}
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm font-medium">共同分擔</div>
+                <div className="text-xs text-[var(--muted-foreground)]">開啟後依人數平均分攤</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setForm({ ...form, isShared: !form.isShared })}
+                className={`relative w-12 h-6 rounded-full transition-colors ${
+                  form.isShared ? 'bg-[var(--primary)]' : 'bg-[var(--muted)]'
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${
+                    form.isShared ? 'translate-x-6' : 'translate-x-0.5'
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Start date */}
+            <div>
+              <label className="text-xs text-[var(--muted-foreground)] mb-1 block">開始日期</label>
+              <input
+                type="date"
+                value={form.startDate}
+                onChange={(e) => setForm({ ...form, startDate: e.target.value })}
+                className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              />
+            </div>
+
+            {/* End date (optional) */}
+            <div>
+              <label className="text-xs text-[var(--muted-foreground)] mb-1 block">結束日期（選填）</label>
+              <input
+                type="date"
+                value={form.endDate}
+                onChange={(e) => setForm({ ...form, endDate: e.target.value })}
+                className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              />
+            </div>
+
+            {/* Buttons */}
+            <div className="flex gap-3 pt-1">
+              <button
+                type="button"
+                onClick={() => setShowForm(false)}
+                className="flex-1 rounded-lg border border-[var(--border)] py-2.5 text-sm font-medium hover:bg-[var(--muted)] transition-colors"
+              >
+                取消
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!form.description.trim() || saving}
+                className="flex-1 rounded-lg py-2.5 text-sm font-semibold text-white transition-colors disabled:opacity-50"
+                style={{ backgroundColor: 'var(--primary)' }}
+              >
+                {saving ? '儲存中...' : '儲存'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -6,6 +6,7 @@ import { useMembers } from '@/lib/hooks/use-members'
 import { useExpenses } from '@/lib/hooks/use-expenses'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { addExpense, updateExpense, type ExpenseInput } from '@/lib/services/expense-service'
+import { addRecurringExpense } from '@/lib/services/recurring-expense-service'
 import { learnFromExpense, suggestCategory } from '@/lib/services/transaction-rules-service'
 import { useAuth } from '@/lib/auth'
 import { toDate } from '@/lib/utils'
@@ -77,6 +78,8 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
   const [autoCategoryFilled, setAutoCategoryFilled] = useState(false)
   const [draftRestored, setDraftRestored] = useState(false)
   const [hasDraft, setHasDraft] = useState(false)
+  const [setAsRecurring, setSetAsRecurring] = useState(false)
+  const [recurringDayOfMonth, setRecurringDayOfMonth] = useState(() => new Date().getDate())
 
   // 語音解析回填：父元件透過 ref 呼叫此函數填入欄位
   useEffect(() => {
@@ -327,6 +330,24 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         await updateExpense(group.id, existingExpense!.id, input, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
       } else {
         await addExpense(group.id, input, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
+      }
+      // Create recurring template if toggled
+      if (setAsRecurring && !isEditing) {
+        addRecurringExpense(group.id, {
+          description: input.description,
+          amount: input.amount,
+          category: input.category,
+          payerId: input.payerId,
+          payerName: input.payerName,
+          isShared: input.isShared,
+          splitMethod: input.splitMethod,
+          splits: input.splits,
+          paymentMethod: input.paymentMethod,
+          frequency: 'monthly',
+          dayOfMonth: recurringDayOfMonth,
+          startDate: input.date,
+          createdBy: input.createdBy,
+        }).catch(() => { /* silent — template creation is non-critical */ })
       }
       // Learn from this save to improve future auto-categorization
       learnFromExpense(group.id, input.description, input.category).catch(() => { /* silent */ })
@@ -626,6 +647,30 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         <textarea value={note} onChange={(e) => setNote(e.target.value)} rows={2} placeholder="備註..."
           className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm resize-none" />
       </div>
+
+      {/* 設為定期 — 僅新增模式顯示 */}
+      {!isEditing && (
+        <div className="rounded-xl border border-[var(--border)] p-3 space-y-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" checked={setAsRecurring} onChange={(e) => setSetAsRecurring(e.target.checked)}
+              className="w-4 h-4 rounded" />
+            <span className="text-sm font-medium">🔁 同時設為每月定期支出</span>
+          </label>
+          {setAsRecurring && (
+            <div className="flex items-center gap-2 text-sm text-[var(--muted-foreground)]">
+              <span>每月</span>
+              <select value={recurringDayOfMonth}
+                onChange={(e) => setRecurringDayOfMonth(Number(e.target.value))}
+                className="rounded border border-[var(--border)] bg-[var(--card)] px-2 py-1 text-sm">
+                {Array.from({ length: 31 }, (_, i) => (
+                  <option key={i + 1} value={i + 1}>{i + 1}</option>
+                ))}
+              </select>
+              <span>號自動記錄</span>
+            </div>
+          )}
+        </div>
+      )}
 
       {error && <p className="text-sm" style={{ color: 'var(--destructive)' }}>{error}</p>}
 

--- a/src/lib/hooks/use-recurring-expenses.ts
+++ b/src/lib/hooks/use-recurring-expenses.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { collection, onSnapshot, query, orderBy } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { useGroup } from '@/lib/hooks/use-group'
+import type { RecurringExpense } from '@/lib/types'
+import { logger } from '@/lib/logger'
+
+export function useRecurringExpenses() {
+  const { group } = useGroup()
+  const [recurringExpenses, setRecurringExpenses] = useState<RecurringExpense[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!group?.id) { setLoading(false); return }
+    const q = query(collection(db, 'groups', group.id, 'recurringExpenses'), orderBy('createdAt', 'desc'))
+    const unsub = onSnapshot(q,
+      (snap) => { setRecurringExpenses(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as RecurringExpense)); setLoading(false) },
+      (err) => { logger.error('[RecurringExpenses] snapshot error:', err); setLoading(false) },
+    )
+    return unsub
+  }, [group?.id])
+
+  return { recurringExpenses, loading }
+}

--- a/src/lib/services/recurring-expense-service.ts
+++ b/src/lib/services/recurring-expense-service.ts
@@ -1,0 +1,81 @@
+import { collection, doc, setDoc, deleteDoc, Timestamp } from 'firebase/firestore'
+import { db, auth } from '@/lib/firebase'
+import { logger } from '@/lib/logger'
+import type { SplitDetail, SplitMethod, PaymentMethod, RecurringFrequency } from '@/lib/types'
+
+function genId(): string {
+  return crypto.randomUUID()
+}
+
+export interface RecurringExpenseInput {
+  description: string
+  amount: number | null
+  category: string
+  payerId: string
+  payerName: string
+  isShared: boolean
+  splitMethod: SplitMethod
+  splits: SplitDetail[]
+  paymentMethod: PaymentMethod
+  frequency: RecurringFrequency
+  dayOfMonth?: number
+  dayOfWeek?: number
+  monthOfYear?: number
+  startDate: Date
+  endDate?: Date | null
+  createdBy: string
+}
+
+export async function addRecurringExpense(groupId: string, input: RecurringExpenseInput): Promise<string> {
+  const id = genId()
+  const now = Timestamp.now()
+  const ref = doc(collection(db, 'groups', groupId, 'recurringExpenses'), id)
+
+  const { startDate, endDate, ...rest } = input
+  await setDoc(ref, {
+    ...rest,
+    id,
+    groupId,
+    startDate: Timestamp.fromDate(startDate),
+    endDate: endDate ? Timestamp.fromDate(endDate) : null,
+    lastGeneratedAt: null,
+    isPaused: false,
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  logger.info('[RecurringExpenseService] Created recurring expense', id)
+  return id
+}
+
+export async function updateRecurringExpense(
+  groupId: string,
+  id: string,
+  input: Partial<RecurringExpenseInput>,
+): Promise<void> {
+  const ref = doc(db, 'groups', groupId, 'recurringExpenses', id)
+  const { startDate, endDate, ...rest } = input
+  const data: Record<string, unknown> = { ...rest, updatedAt: Timestamp.now() }
+
+  if (startDate !== undefined) data.startDate = Timestamp.fromDate(startDate)
+  if (endDate !== undefined) data.endDate = endDate ? Timestamp.fromDate(endDate) : null
+
+  await setDoc(ref, data, { merge: true })
+  logger.info('[RecurringExpenseService] Updated recurring expense', id)
+}
+
+export async function deleteRecurringExpense(groupId: string, id: string): Promise<void> {
+  await deleteDoc(doc(db, 'groups', groupId, 'recurringExpenses', id))
+  logger.info('[RecurringExpenseService] Deleted recurring expense', id)
+}
+
+export async function togglePauseRecurringExpense(groupId: string, id: string, isPaused: boolean): Promise<void> {
+  const ref = doc(db, 'groups', groupId, 'recurringExpenses', id)
+  await setDoc(ref, { isPaused, updatedAt: Timestamp.now() }, { merge: true })
+  logger.info('[RecurringExpenseService] Toggled pause for recurring expense', { id, isPaused })
+}
+
+/** Returns the uid of the currently signed-in user, or null. */
+export function getCurrentUserId(): string | null {
+  return auth.currentUser?.uid ?? null
+}

--- a/src/lib/services/recurring-generator.ts
+++ b/src/lib/services/recurring-generator.ts
@@ -1,0 +1,180 @@
+import { collection, doc, getDocs, writeBatch, Timestamp, getDoc, setDoc } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { logger } from '@/lib/logger'
+import type { RecurringExpense } from '@/lib/types'
+
+const SWEEP_THROTTLE_MS = 6 * 60 * 60 * 1000 // 6 hours
+
+/**
+ * Returns all occurrence dates for a recurring template that fall in the range (after, before].
+ * Both boundaries are exclusive on the left and inclusive on the right.
+ */
+export function getNextOccurrences(template: RecurringExpense, after: Date, before: Date): Date[] {
+  const dates: Date[] = []
+
+  if (template.frequency === 'weekly') {
+    const targetDay = template.dayOfWeek ?? 1 // default Monday
+    // Start from the day after `after`, scan forward
+    const cursor = new Date(after)
+    cursor.setHours(0, 0, 0, 0)
+    cursor.setDate(cursor.getDate() + 1)
+
+    while (cursor <= before) {
+      if (cursor.getDay() === targetDay) {
+        dates.push(new Date(cursor))
+      }
+      cursor.setDate(cursor.getDate() + 1)
+    }
+  } else if (template.frequency === 'monthly') {
+    const targetDay = template.dayOfMonth ?? 1
+    // Iterate month-by-month starting from the month containing `after`
+    const cursor = new Date(after)
+    cursor.setHours(0, 0, 0, 0)
+    cursor.setDate(1) // go to first of the month to avoid skipping months
+
+    while (cursor <= before) {
+      const year = cursor.getFullYear()
+      const month = cursor.getMonth()
+      const lastDay = new Date(year, month + 1, 0).getDate()
+      const day = Math.min(targetDay, lastDay)
+      const candidate = new Date(year, month, day, 0, 0, 0, 0)
+      if (candidate > after && candidate <= before) {
+        dates.push(candidate)
+      }
+      cursor.setMonth(cursor.getMonth() + 1)
+    }
+  } else if (template.frequency === 'yearly') {
+    const targetMonth = (template.monthOfYear ?? 1) - 1 // 0-indexed
+    const targetDay = template.dayOfMonth ?? 1
+
+    for (let year = after.getFullYear(); year <= before.getFullYear(); year++) {
+      const lastDay = new Date(year, targetMonth + 1, 0).getDate()
+      const day = Math.min(targetDay, lastDay)
+      const candidate = new Date(year, targetMonth, day, 0, 0, 0, 0)
+      if (candidate > after && candidate <= before) {
+        dates.push(candidate)
+      }
+    }
+  }
+
+  return dates
+}
+
+/**
+ * Generates pending expense documents for all non-paused recurring templates in a group.
+ * Throttled to once per 6 hours via `lastRecurringSweepAt` on the group doc.
+ * Returns the number of expense documents written.
+ */
+export async function generatePendingRecurring(groupId: string): Promise<number> {
+  // --- Throttle check ---
+  const groupRef = doc(db, 'groups', groupId)
+  const groupSnap = await getDoc(groupRef)
+  if (!groupSnap.exists()) return 0
+
+  const lastSweep: Timestamp | undefined = groupSnap.data()?.lastRecurringSweepAt
+  if (lastSweep) {
+    const elapsed = Date.now() - lastSweep.toMillis()
+    if (elapsed < SWEEP_THROTTLE_MS) {
+      logger.info('[RecurringGenerator] Skipping sweep — last ran', { minutesAgo: Math.round(elapsed / 60000) })
+      return 0
+    }
+  }
+
+  // --- Fetch templates ---
+  const templatesSnap = await getDocs(collection(db, 'groups', groupId, 'recurringExpenses'))
+  if (templatesSnap.empty) {
+    await setDoc(groupRef, { lastRecurringSweepAt: Timestamp.now() }, { merge: true })
+    return 0
+  }
+
+  const now = new Date()
+  now.setHours(23, 59, 59, 999) // generate up through end of today
+
+  const templates = templatesSnap.docs.map((d) => ({ id: d.id, ...d.data() }) as RecurringExpense)
+
+  let totalGenerated = 0
+  let batch = writeBatch(db)
+  let batchCount = 0
+  const MAX_BATCH = 490 // leave headroom for template updates
+
+  const templateUpdates: Array<{ id: string; lastGeneratedAt: Timestamp }> = []
+
+  for (const template of templates) {
+    if (template.isPaused) continue
+
+    // Skip if past endDate
+    if (template.endDate && template.endDate.toDate() < now) continue
+
+    const after = template.lastGeneratedAt ? template.lastGeneratedAt.toDate() : template.startDate.toDate()
+    const occurrences = getNextOccurrences(template, after, now)
+
+    if (occurrences.length === 0) continue
+
+    for (const date of occurrences) {
+      const expenseId = crypto.randomUUID()
+      const expenseRef = doc(db, 'groups', groupId, 'expenses', expenseId)
+      const nowTs = Timestamp.now()
+
+      batch.set(expenseRef, {
+        id: expenseId,
+        groupId,
+        date: Timestamp.fromDate(date),
+        description: template.description,
+        amount: template.amount ?? 0,
+        category: template.category,
+        isShared: template.isShared,
+        splitMethod: template.splitMethod,
+        payerId: template.payerId,
+        payerName: template.payerName,
+        splits: template.splits,
+        paymentMethod: template.paymentMethod,
+        recurringId: template.id,
+        pendingConfirm: true,
+        createdBy: template.createdBy,
+        createdAt: nowTs,
+        updatedAt: nowTs,
+      })
+
+      batchCount++
+      totalGenerated++
+
+      // Flush batch before hitting Firestore limit
+      if (batchCount >= MAX_BATCH) {
+        await batch.commit()
+        batch = writeBatch(db)
+        batchCount = 0
+      }
+    }
+
+    templateUpdates.push({ id: template.id, lastGeneratedAt: Timestamp.fromDate(occurrences[occurrences.length - 1]) })
+  }
+
+  // Write template lastGeneratedAt updates into the same (or current) batch
+  for (const update of templateUpdates) {
+    const tRef = doc(db, 'groups', groupId, 'recurringExpenses', update.id)
+    batch.set(tRef, { lastGeneratedAt: update.lastGeneratedAt, updatedAt: Timestamp.now() }, { merge: true })
+    batchCount++
+
+    if (batchCount >= MAX_BATCH) {
+      await batch.commit()
+      batch = writeBatch(db)
+      batchCount = 0
+    }
+  }
+
+  // Update group sweep timestamp
+  batch.set(groupRef, { lastRecurringSweepAt: Timestamp.now() }, { merge: true })
+
+  if (batchCount > 0 || totalGenerated === 0) {
+    await batch.commit()
+  }
+
+  logger.info('[RecurringGenerator] Generated pending expenses', { groupId, totalGenerated })
+  return totalGenerated
+}
+
+/** Confirm a pending auto-generated expense (set pendingConfirm = false). */
+export async function confirmPendingExpense(groupId: string, expenseId: string): Promise<void> {
+  const ref = doc(db, 'groups', groupId, 'expenses', expenseId)
+  await setDoc(ref, { pendingConfirm: false, updatedAt: Timestamp.now() }, { merge: true })
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,6 +30,10 @@ export interface Expense {
   createdBy: string
   createdAt: Timestamp
   updatedAt: Timestamp
+  /** Source recurring expense template ID */
+  recurringId?: string | null
+  /** Auto-generated expense pending user confirmation */
+  pendingConfirm?: boolean
 }
 
 export interface FamilyMember {
@@ -119,4 +123,35 @@ export interface TransactionRule {
   hitCount: number
   createdAt: Timestamp
   lastUsed: Timestamp
+}
+
+export type RecurringFrequency = 'monthly' | 'weekly' | 'yearly'
+
+export interface RecurringExpense {
+  id: string
+  groupId: string
+  description: string
+  /** null = variable amount (generates draft requiring user to fill in) */
+  amount: number | null
+  category: string
+  payerId: string
+  payerName: string
+  isShared: boolean
+  splitMethod: SplitMethod
+  splits: SplitDetail[]
+  paymentMethod: PaymentMethod
+  frequency: RecurringFrequency
+  /** Day of month (1-31) for monthly frequency */
+  dayOfMonth?: number
+  /** Day of week (0=Sun, 1=Mon, ..., 6=Sat) for weekly frequency */
+  dayOfWeek?: number
+  /** Month (1-12) for yearly frequency */
+  monthOfYear?: number
+  startDate: Timestamp
+  endDate?: Timestamp | null
+  lastGeneratedAt?: Timestamp | null
+  isPaused: boolean
+  createdBy: string
+  createdAt: Timestamp
+  updatedAt: Timestamp
 }


### PR DESCRIPTION
## Summary
- 新增定期支出範本系統（每月/每週/每年），支援固定金額與可變金額
- Client-side 自動產生引擎：首頁載入時檢查到期範本，批量建立 expense 文件
- 設定頁新增「定期支出」管理介面（新增/編輯/暫停/刪除）
- 首頁顯示待確認 banner，可一鍵確認或前往檢視
- 記帳表單新增「🔁 同時設為每月定期支出」開關

Closes #135

## Changes
| File | Change |
|------|--------|
| `src/lib/types.ts` | `RecurringExpense` 型別 + `Expense.recurringId/pendingConfirm` |
| `src/lib/services/recurring-expense-service.ts` | 範本 CRUD service |
| `src/lib/services/recurring-generator.ts` | 自動產生引擎 + `confirmPendingExpense` |
| `src/lib/hooks/use-recurring-expenses.ts` | Firestore 即時訂閱 hook |
| `src/app/(auth)/settings/recurring/page.tsx` | 定期支出管理頁面 |
| `src/app/(auth)/page.tsx` | 首頁：generator trigger + 待確認 banner |
| `src/app/(auth)/settings/page.tsx` | 設定頁入口連結 |
| `src/components/expense-form.tsx` | 「設為定期」開關 |
| `firestore.rules` | `recurringExpenses` collection 權限 |
| `__tests__/recurring-generator.test.ts` | 24 個單元測試 |

## Test plan
- [x] TypeScript 編譯通過 (`tsc --noEmit`)
- [x] ESLint 零錯誤
- [x] 66 tests pass（42 existing + 24 new recurring generator tests）
- [ ] 手動測試：建立定期支出範本 → 隔日確認自動產生
- [ ] 手動測試：暫停範本後不再產生
- [ ] 手動測試：可變金額範本產生草稿
- [ ] 手動測試：首頁 banner 顯示 + 全部確認