### PR TITLE
fix: recurring expenses — critical bugs from review

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -230,7 +230,8 @@ service cloud.firestore {
           && hasReasonableSize()
           && request.resource.data.description is string
           && request.resource.data.description.size() > 0
-          && request.resource.data.description.size() <= 200;
+          && request.resource.data.description.size() <= 200
+          && request.resource.data.createdBy == resource.data.createdBy;
         allow delete: if isGroupMember(groupId)
           && (resource.data.createdBy == request.auth.uid || isGroupOwner(groupId));
       }

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -13,8 +13,7 @@ import { currency, toDate, fmtDate } from '@/lib/utils'
 import { QuickAddBar } from '@/components/quick-add-bar'
 import { WeeklyDigest } from '@/components/weekly-digest'
 import { BudgetProgress } from '@/components/budget-progress'
-import { generatePendingRecurring } from '@/lib/services/recurring-generator'
-import { confirmPendingExpense } from '@/lib/services/recurring-generator'
+import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { logger } from '@/lib/logger'
 
 function NoGroupView() {

--- a/src/app/(auth)/settings/recurring/page.tsx
+++ b/src/app/(auth)/settings/recurring/page.tsx
@@ -94,7 +94,7 @@ export default function RecurringPage() {
       orderBy('createdAt', 'desc'),
     )
     const unsub = onSnapshot(q, (snap) => {
-      setItems(snap.docs.map((d) => d.data() as RecurringExpense))
+      setItems(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as RecurringExpense))
     })
     return unsub
   }, [group?.id])
@@ -134,13 +134,15 @@ export default function RecurringPage() {
 
   function buildSplits(payerId: string) {
     if (!form.isShared || members.length === 0) return []
-    const share = Math.round(100 / members.length)
-    const remainder = 100 - share * (members.length - 1)
+    const amount = form.amount ? Number(form.amount) : 0
+    const perPerson = members.length > 0 ? Math.round(amount / members.length) : 0
+    const remainder = members.length > 0 ? amount - perPerson * (members.length - 1) : 0
+    // Store actual currency amounts; the generator will recompute these from the template amount
     return members.map((m, i) => ({
       memberId: m.id,
       memberName: m.name,
-      shareAmount: i === 0 ? remainder : share,
-      paidAmount: m.id === payerId ? 100 : 0,
+      shareAmount: i === 0 ? remainder : perPerson,
+      paidAmount: m.id === payerId ? amount : 0,
       isParticipant: true,
     }))
   }

--- a/src/lib/services/recurring-expense-service.ts
+++ b/src/lib/services/recurring-expense-service.ts
@@ -23,15 +23,19 @@ export interface RecurringExpenseInput {
   monthOfYear?: number
   startDate: Date
   endDate?: Date | null
-  createdBy: string
+  // createdBy is resolved from auth.currentUser inside addRecurringExpense
+  createdBy?: string
 }
 
 export async function addRecurringExpense(groupId: string, input: RecurringExpenseInput): Promise<string> {
+  const uid = auth.currentUser?.uid
+  if (!uid) throw new Error('User must be authenticated to create a recurring expense')
+
   const id = genId()
   const now = Timestamp.now()
   const ref = doc(collection(db, 'groups', groupId, 'recurringExpenses'), id)
 
-  const { startDate, endDate, ...rest } = input
+  const { startDate, endDate, createdBy: _ignored, ...rest } = input
   // Filter out undefined values — Firestore rejects them
   const cleaned = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined))
   await setDoc(ref, {
@@ -42,6 +46,7 @@ export async function addRecurringExpense(groupId: string, input: RecurringExpen
     endDate: endDate ? Timestamp.fromDate(endDate) : null,
     lastGeneratedAt: null,
     isPaused: false,
+    createdBy: uid,
     createdAt: now,
     updatedAt: now,
   })

--- a/src/lib/services/recurring-generator.ts
+++ b/src/lib/services/recurring-generator.ts
@@ -1,5 +1,5 @@
 import { collection, doc, getDocs, writeBatch, Timestamp, getDoc, setDoc } from 'firebase/firestore'
-import { db } from '@/lib/firebase'
+import { db, auth } from '@/lib/firebase'
 import { logger } from '@/lib/logger'
 import type { RecurringExpense } from '@/lib/types'
 
@@ -22,6 +22,7 @@ export function getNextOccurrences(template: RecurringExpense, after: Date, befo
     while (cursor <= before) {
       if (cursor.getDay() === targetDay) {
         dates.push(new Date(cursor))
+        if (dates.length >= 12) break
       }
       cursor.setDate(cursor.getDate() + 1)
     }
@@ -40,6 +41,7 @@ export function getNextOccurrences(template: RecurringExpense, after: Date, befo
       const candidate = new Date(year, month, day, 0, 0, 0, 0)
       if (candidate > after && candidate <= before) {
         dates.push(candidate)
+        if (dates.length >= 12) break
       }
       cursor.setMonth(cursor.getMonth() + 1)
     }
@@ -53,6 +55,7 @@ export function getNextOccurrences(template: RecurringExpense, after: Date, befo
       const candidate = new Date(year, targetMonth, day, 0, 0, 0, 0)
       if (candidate > after && candidate <= before) {
         dates.push(candidate)
+        if (dates.length >= 12) break
       }
     }
   }
@@ -66,6 +69,13 @@ export function getNextOccurrences(template: RecurringExpense, after: Date, befo
  * Returns the number of expense documents written.
  */
 export async function generatePendingRecurring(groupId: string): Promise<number> {
+  // S1: ensure user is authenticated before generating expenses
+  const currentUid = auth.currentUser?.uid
+  if (!currentUid) {
+    logger.info('[RecurringGenerator] Skipping sweep — user not authenticated')
+    return 0
+  }
+
   // --- Throttle check ---
   const groupRef = doc(db, 'groups', groupId)
   const groupSnap = await getDoc(groupRef)
@@ -105,32 +115,56 @@ export async function generatePendingRecurring(groupId: string): Promise<number>
     // Skip if past endDate
     if (template.endDate && template.endDate.toDate() < now) continue
 
+    // S2: skip variable-amount templates — they can't be auto-generated meaningfully
+    if (template.amount === null) continue
+
     const after = template.lastGeneratedAt ? template.lastGeneratedAt.toDate() : template.startDate.toDate()
     const occurrences = getNextOccurrences(template, after, now)
 
     if (occurrences.length === 0) continue
 
     for (const date of occurrences) {
-      const expenseId = crypto.randomUUID()
+      // S4: use deterministic ID to prevent duplicate writes from concurrent sweeps
+      const dateKey = date.toISOString().split('T')[0]
+      const expenseId = `${template.id}_${dateKey}`
       const expenseRef = doc(db, 'groups', groupId, 'expenses', expenseId)
       const nowTs = Timestamp.now()
+
+      // C2: recompute equal splits based on the actual template amount
+      const amount = template.amount
+      const participants = template.splits.filter((s) => s.isParticipant)
+      const perPerson = participants.length > 0 ? Math.round(amount / participants.length) : 0
+      const remainder = participants.length > 0 ? amount - perPerson * (participants.length - 1) : 0
+      let participantIndex = 0
+      const computedSplits = template.splits.map((s) => {
+        if (!s.isParticipant) {
+          return { ...s, shareAmount: 0, paidAmount: s.memberId === template.payerId ? amount : 0 }
+        }
+        const shareAmount = participantIndex === 0 ? remainder : perPerson
+        participantIndex++
+        return {
+          ...s,
+          shareAmount,
+          paidAmount: s.memberId === template.payerId ? amount : 0,
+        }
+      })
 
       batch.set(expenseRef, {
         id: expenseId,
         groupId,
         date: Timestamp.fromDate(date),
         description: template.description,
-        amount: template.amount ?? 0,
+        amount,
         category: template.category,
         isShared: template.isShared,
         splitMethod: template.splitMethod,
         payerId: template.payerId,
         payerName: template.payerName,
-        splits: template.splits,
+        splits: computedSplits,
         paymentMethod: template.paymentMethod,
         recurringId: template.id,
         pendingConfirm: true,
-        createdBy: template.createdBy,
+        createdBy: currentUid,
         createdAt: nowTs,
         updatedAt: nowTs,
       })


### PR DESCRIPTION
## Summary
修復 code review + security review 發現的 2 CRITICAL + 4 HIGH 問題

| Fix | 嚴重度 | 說明 |
|-----|--------|------|
| S1 | CRITICAL | generator 用 `auth.currentUser.uid` 取代 `template.createdBy` |
| S2 | CRITICAL | 跳過 null-amount 範本（`amount:0` 違反 Firestore rule） |
| S3 | HIGH | Firestore rules 鎖定 `createdBy` 不可變 |
| S4 | HIGH | occurrence cap 12 + deterministic ID 防重複 |
| C1 | HIGH | recurring page `onSnapshot` 加 `id: d.id` |
| C2 | HIGH | `buildSplits` 用實際金額，generator 重新計算 splits |

額外：合併重複 import、`createdBy` 改在 service 內部取

Closes #138

## Test plan
- [x] 66 tests pass
- [x] `tsc --noEmit` zero errors
- [ ] 手動驗證：建立範本 → 暫停/編輯/刪除正常
- [ ] 手動驗證：多人群組 sweep 不報錯

🤖 Generated with [Claude Code](https://claude.com/claude-code)