### PR TITLE
fix: date UTC bug, stale closures, code deduplication

### DIFF
--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -9,7 +9,7 @@ import { useMembers } from '@/lib/hooks/use-members'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { deleteExpense, loadMoreExpenses } from '@/lib/services/expense-service'
 import { currency, toDate, fmtDateFull, paymentLabel } from '@/lib/utils'
-import { useAuth } from '@/lib/auth'
+import { useAuth, getActor } from '@/lib/auth'
 import { useGroupData } from '@/lib/group-data-context'
 import { FilterChips } from '@/components/filter-chips'
 import { useToast } from '@/components/toast'
@@ -360,7 +360,7 @@ export default function RecordsPage() {
                             if (!confirm(`確定要刪除「${e.description}」嗎？`)) return
                             if (!group?.id) return
                             try {
-                              await deleteExpense(group.id, e.id, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
+                              await deleteExpense(group.id, e.id, getActor(user))
                             } catch {
                               addToast('刪除失敗，請稍後再試', 'error')
                             }

--- a/src/app/(auth)/settings/categories/page.tsx
+++ b/src/app/(auth)/settings/categories/page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { addCategory, updateCategory, deleteCategory, reorderCategories } from '@/lib/services/category-service'
-import { useAuth } from '@/lib/auth'
+import { useAuth, getActor } from '@/lib/auth'
 import type { Category } from '@/lib/types'
 
 import { logger } from '@/lib/logger'
@@ -66,7 +66,7 @@ export default function CategoriesPage() {
           group.id,
           editing.id,
           { name: form.name.trim(), icon: form.icon, parentCategoryName: form.parentCategoryName },
-          user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined,
+          getActor(user),
         )
       } else {
         await addCategory(
@@ -77,7 +77,7 @@ export default function CategoriesPage() {
             sortOrder: categories.length,
             parentCategoryName: form.parentCategoryName,
           },
-          user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined,
+          getActor(user),
         )
       }
       setShowForm(false)
@@ -92,7 +92,7 @@ export default function CategoriesPage() {
   async function handleDelete(cat: Category) {
     if (!group || !cat.id || !confirm(`確定刪除「${cat.name}」？`)) return
     try {
-      await deleteCategory(group.id, cat.id, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined, cat.name)
+      await deleteCategory(group.id, cat.id, getActor(user), cat.name)
     } catch (e) {
       logger.error('[Categories] Failed to delete category:', e)
       addToast('刪除失敗，請稍後再試', 'error')

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { useTheme } from 'next-themes'
-import { useAuth } from '@/lib/auth'
+import { useAuth, getActor } from '@/lib/auth'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useMembers } from '@/lib/hooks/use-members'
 import { useCurrentMember } from '@/lib/hooks/use-current-member'
@@ -49,7 +49,7 @@ function MembersSection({ groupId }: { groupId: string }) {
     if (!name) return
     setAdding(true)
     try {
-      await addMember(groupId, name, 'member', user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
+      await addMember(groupId, name, 'member', getActor(user))
       setNewName('')
     } catch (e) {
       logger.error('[Settings] Failed to add member:', e)
@@ -62,7 +62,7 @@ function MembersSection({ groupId }: { groupId: string }) {
   async function handleDelete(memberId: string, memberName: string) {
     if (!confirm(`確定要刪除成員「${memberName}」嗎？此操作無法復原。`)) return
     try {
-      await removeMember(groupId, memberId, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined, memberName)
+      await removeMember(groupId, memberId, getActor(user), memberName)
     } catch (e) {
       logger.error('[Settings] Failed to delete member:', e)
       addToast('刪除失敗，請稍後再試', 'error')

--- a/src/app/(auth)/settings/recurring/page.tsx
+++ b/src/app/(auth)/settings/recurring/page.tsx
@@ -1,11 +1,10 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { collection, onSnapshot, query, orderBy } from 'firebase/firestore'
-import { db } from '@/lib/firebase'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useMembers } from '@/lib/hooks/use-members'
 import { useCategories } from '@/lib/hooks/use-categories'
+import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { useAuth } from '@/lib/auth'
 import {
   addRecurringExpense,
@@ -14,6 +13,7 @@ import {
   togglePauseRecurringExpense,
   getCurrentUserId,
 } from '@/lib/services/recurring-expense-service'
+import { buildEqualSplits } from '@/lib/services/split-calculator'
 import { currency } from '@/lib/utils'
 import type { RecurringExpense, RecurringFrequency } from '@/lib/types'
 import { logger } from '@/lib/logger'
@@ -79,32 +79,19 @@ export default function RecurringPage() {
   const { group } = useGroup()
   const { members } = useMembers()
   const { categories } = useCategories()
+  const { recurringExpenses: items } = useRecurringExpenses()
   const { user } = useAuth()
   const { addToast } = useToast()
 
-  const [items, setItems] = useState<RecurringExpense[]>([])
   const [showForm, setShowForm] = useState(false)
   const [editing, setEditing] = useState<RecurringExpense | null>(null)
   const [form, setForm] = useState<FormState>(defaultForm())
   const [saving, setSaving] = useState(false)
 
-  // Subscribe to recurring expenses
-  useEffect(() => {
-    if (!group?.id) return
-    const q = query(
-      collection(db, 'groups', group.id, 'recurringExpenses'),
-      orderBy('createdAt', 'desc'),
-    )
-    const unsub = onSnapshot(q, (snap) => {
-      setItems(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as RecurringExpense))
-    })
-    return unsub
-  }, [group?.id])
-
   // Set default payerId when members load
   useEffect(() => {
-    if (members.length > 0 && !form.payerId) {
-      setForm((f) => ({ ...f, payerId: members[0].id }))
+    if (members.length > 0) {
+      setForm((f) => f.payerId ? f : { ...f, payerId: members[0].id })
     }
   }, [members])
 
@@ -137,16 +124,7 @@ export default function RecurringPage() {
   function buildSplits(payerId: string) {
     if (!form.isShared || members.length === 0) return []
     const amount = form.amount ? Number(form.amount) : 0
-    const perPerson = members.length > 0 ? Math.round(amount / members.length) : 0
-    const remainder = members.length > 0 ? amount - perPerson * (members.length - 1) : 0
-    // Store actual currency amounts; the generator will recompute these from the template amount
-    return members.map((m, i) => ({
-      memberId: m.id,
-      memberName: m.name,
-      shareAmount: i === 0 ? remainder : perPerson,
-      paidAmount: m.id === payerId ? amount : 0,
-      isParticipant: true,
-    }))
+    return buildEqualSplits(amount, members, payerId)
   }
 
   function getPayerName(payerId: string): string {
@@ -173,8 +151,8 @@ export default function RecurringPage() {
       splitMethod: 'equal' as const,
       splits,
       paymentMethod: 'cash' as const,
-      startDate: new Date(form.startDate),
-      endDate: form.endDate ? new Date(form.endDate) : null,
+      startDate: new Date(`${form.startDate}T00:00:00`),
+      endDate: form.endDate ? new Date(`${form.endDate}T00:00:00`) : null,
       createdBy: uid,
     }
 

--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -10,7 +10,7 @@ import { calculateNetBalances, simplifyDebts } from '@/lib/services/split-calcul
 import { addSettlement, addSettlements, deleteSettlement } from '@/lib/services/settlement-service'
 import { useToast } from '@/components/toast'
 import { currency, signedCurrency, toDate, fmtDateFull } from '@/lib/utils'
-import { useAuth } from '@/lib/auth'
+import { useAuth, getActor } from '@/lib/auth'
 import { useCurrentMember } from '@/lib/hooks/use-current-member'
 
 import { logger } from '@/lib/logger'
@@ -200,7 +200,7 @@ export default function SplitPage() {
       amount: data.amount,
       note: data.note || undefined,
       date: data.date,
-    }, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
+    }, getActor(user))
     setSettling(null)
   }
 

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -6,9 +6,10 @@ import { useMembers } from '@/lib/hooks/use-members'
 import { useExpenses } from '@/lib/hooks/use-expenses'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { addExpense, updateExpense, type ExpenseInput } from '@/lib/services/expense-service'
+import { buildEqualSplits } from '@/lib/services/split-calculator'
 import { addRecurringExpense } from '@/lib/services/recurring-expense-service'
 import { learnFromExpense, suggestCategory } from '@/lib/services/transaction-rules-service'
-import { useAuth } from '@/lib/auth'
+import { useAuth, getActor } from '@/lib/auth'
 import { toDate } from '@/lib/utils'
 import type { Expense, SplitMethod, PaymentMethod, SplitDetail } from '@/lib/types'
 import type { ParsedExpense } from '@/lib/services/local-expense-parser'
@@ -252,13 +253,13 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
     if (participants.length === 0) return []
     const nameMap = Object.fromEntries(members.map((m) => [m.id, m.name]))
 
+    if (splitMethod === 'equal') {
+      return buildEqualSplits(amt, participants, payerId)
+    }
+
     return participants.map((m, i) => {
       let share: number
-      if (splitMethod === 'equal') {
-        const per = Math.round(amt / participants.length)
-        const remainder = amt - per * participants.length
-        share = i === participants.length - 1 ? per + remainder : per
-      } else if (splitMethod === 'percentage') {
+      if (splitMethod === 'percentage') {
         share = Math.round(amt * (percentages[m.id] ?? 0) / 100)
         // Distribute rounding remainder to last participant to ensure sum matches amount
         if (i === participants.length - 1) {
@@ -312,7 +313,7 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
     setError(null)
     try {
       const input: ExpenseInput = {
-        date: new Date(date),
+        date: new Date(`${date}T00:00:00`),
         description: description.trim(),
         amount: saveAmt,
         category,
@@ -327,9 +328,9 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         createdBy: user?.uid ?? payerId,
       }
       if (isEditing) {
-        await updateExpense(group.id, existingExpense!.id, input, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
+        await updateExpense(group.id, existingExpense!.id, input, getActor(user))
       } else {
-        await addExpense(group.id, input, user ? { id: user.uid, name: user.displayName ?? '未知' } : undefined)
+        await addExpense(group.id, input, getActor(user))
       }
       // Create recurring template if toggled
       if (setAsRecurring && !isEditing) {

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -3,13 +3,13 @@
 import { createContext, useContext, useEffect, useState, useCallback, useMemo, ReactNode } from 'react'
 import { User, onAuthStateChanged, signInWithPopup, GoogleAuthProvider, signOut as fbSignOut } from 'firebase/auth'
 
+import { auth } from './firebase'
+import { logger } from '@/lib/logger'
+
 export function getActor(user: User | null): { id: string; name: string } | undefined {
   if (!user) return undefined
   return { id: user.uid, name: user.displayName ?? '未知' }
 }
-import { auth } from './firebase'
-
-import { logger } from '@/lib/logger'
 
 interface AuthContextType {
   user: User | null

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -2,6 +2,11 @@
 
 import { createContext, useContext, useEffect, useState, useCallback, useMemo, ReactNode } from 'react'
 import { User, onAuthStateChanged, signInWithPopup, GoogleAuthProvider, signOut as fbSignOut } from 'firebase/auth'
+
+export function getActor(user: User | null): { id: string; name: string } | undefined {
+  if (!user) return undefined
+  return { id: user.uid, name: user.displayName ?? '未知' }
+}
 import { auth } from './firebase'
 
 import { logger } from '@/lib/logger'

--- a/src/lib/group-data-context.tsx
+++ b/src/lib/group-data-context.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useEffect, useState, useMemo, ReactNode } from 'react'
+import { createContext, useContext, useEffect, useState, useMemo, useRef, ReactNode } from 'react'
 import { collection, onSnapshot, orderBy, query, where, limit, DocumentSnapshot } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
 import { useGroupContext } from '@/lib/group-context'
@@ -62,6 +62,8 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
   const { activeGroup } = useGroupContext()
   const { user } = useAuth()
   const { addToast } = useToast()
+  const addToastRef = useRef(addToast)
+  useEffect(() => { addToastRef.current = addToast }, [addToast])
   const groupId = activeGroup?.id
 
   const [expenses, setExpenses] = useState<Expense[]>([])
@@ -108,7 +110,7 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
         setExpensesLoading(false)
         setSyncError(null)
       },
-      (err) => { logger.error('[GroupData] expenses error:', err); addToast(getSyncErrorMessage('費用資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('費用資料', err)); setExpensesLoading(false) },
+      (err) => { logger.error('[GroupData] expenses error:', err); addToastRef.current(getSyncErrorMessage('費用資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('費用資料', err)); setExpensesLoading(false) },
     )
     return unsub
   }, [groupId])
@@ -119,7 +121,7 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     const q = query(collection(db, 'groups', groupId, 'members'), orderBy('sortOrder'))
     const unsub = onSnapshot(q,
       (snap) => { setMembers(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as FamilyMember)); setMembersLoading(false); setSyncError(null) },
-      (err) => { logger.error('[GroupData] members error:', err); addToast(getSyncErrorMessage('成員資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('成員資料', err)); setMembersLoading(false) },
+      (err) => { logger.error('[GroupData] members error:', err); addToastRef.current(getSyncErrorMessage('成員資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('成員資料', err)); setMembersLoading(false) },
     )
     return unsub
   }, [groupId])
@@ -130,7 +132,7 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     const q = query(collection(db, 'groups', groupId, 'settlements'), orderBy('date', 'desc'), limit(200))
     const unsub = onSnapshot(q,
       (snap) => { setSettlements(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Settlement)); setSettlementsLoading(false); setSyncError(null) },
-      (err) => { logger.error('[GroupData] settlements error:', err); addToast(getSyncErrorMessage('結算資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('結算資料', err)); setSettlementsLoading(false) },
+      (err) => { logger.error('[GroupData] settlements error:', err); addToastRef.current(getSyncErrorMessage('結算資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('結算資料', err)); setSettlementsLoading(false) },
     )
     return unsub
   }, [groupId])
@@ -141,7 +143,7 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     const q = query(collection(db, 'groups', groupId, 'categories'), orderBy('sortOrder'))
     const unsub = onSnapshot(q,
       (snap) => { setCategories(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Category)); setCategoriesLoading(false); setSyncError(null) },
-      (err) => { logger.error('[GroupData] categories error:', err); addToast(getSyncErrorMessage('分類資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('分類資料', err)); setCategoriesLoading(false) },
+      (err) => { logger.error('[GroupData] categories error:', err); addToastRef.current(getSyncErrorMessage('分類資料', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('分類資料', err)); setCategoriesLoading(false) },
     )
     return unsub
   }, [groupId])
@@ -157,7 +159,7 @@ export function GroupDataProvider({ children }: { children: ReactNode }) {
     )
     const unsub = onSnapshot(q,
       (snap) => { setNotifications(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AppNotification)); setNotificationsLoading(false); setSyncError(null) },
-      (err) => { logger.error('[GroupData] notifications error:', err.message); addToast(getSyncErrorMessage('通知', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('通知', err)); setNotificationsLoading(false) },
+      (err) => { logger.error('[GroupData] notifications error:', err.message); addToastRef.current(getSyncErrorMessage('通知', err), getSyncToastLevel(err)); setSyncError(getSyncErrorMessage('通知', err)); setNotificationsLoading(false) },
     )
     return unsub
   }, [groupId, user])

--- a/src/lib/services/split-calculator.ts
+++ b/src/lib/services/split-calculator.ts
@@ -2,7 +2,7 @@
 // Business logic is extracted to @family-ledger/domain (packages/family-ledger-domain/).
 // This file re-exports once Turbopack workspace support is resolved.
 
-import type { Expense, Settlement } from '@/lib/types'
+import type { Expense, Settlement, SplitDetail, FamilyMember } from '@/lib/types'
 import { logger } from '@/lib/logger'
 
 interface Debt {
@@ -14,6 +14,30 @@ interface Debt {
 }
 
 export type { Debt }
+
+/**
+ * Build equal splits for a list of members.
+ * Remainder goes to the LAST participant (consistent with expense-form.tsx behaviour).
+ * If amount is 0 or falsy, all shareAmounts are 0.
+ * Sets paidAmount for the payer to the full amount.
+ */
+export function buildEqualSplits(
+  amount: number,
+  members: FamilyMember[],
+  payerId: string,
+): SplitDetail[] {
+  if (members.length === 0) return []
+  const amt = amount || 0
+  const per = members.length > 0 ? Math.round(amt / members.length) : 0
+  const remainder = amt - per * members.length
+  return members.map((m, i) => ({
+    memberId: m.id,
+    memberName: m.name,
+    shareAmount: i === members.length - 1 ? per + remainder : per,
+    paidAmount: m.id === payerId ? amt : 0,
+    isParticipant: true,
+  }))
+}
 
 /** 計算每人淨餘額 */
 export function calculateNetBalances(


### PR DESCRIPTION
## Summary
經兩個獨立 Agent（Architecture + Bug Hunter）分析論證後確認的 6 個問題修復。

| Fix | 嚴重度 | 說明 |
|-----|--------|------|
| B1 | CRITICAL | `new Date(dateStr)` 解析為 UTC → 改用 local-time |
| B5 | HIGH | addToast stale closure → useRef 包裝 |
| B7 | MEDIUM | recurring payerId stale closure → functional updater |
| A2 | MEDIUM | 移除重複 Firestore subscription → 使用 hook |
| A8 | MEDIUM | buildSplits 統一到 split-calculator.ts |
| A3 | MEDIUM | getActor helper 取代 10+ 處重複 |

Closes #146

## Test plan
- [x] 132 tests pass
- [x] `tsc --noEmit` zero errors
- [ ] 手動測試：不同時區日期建立正確
- [ ] 手動測試：recurring 頁暫停/編輯/刪除正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)