### PR TITLE
fix: split 邏輯不一致、toDate 靜默錯誤、debounce cleanup、timestamp 統一

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -192,10 +192,12 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
       setAutoCategoryFilled(false)
       return
     }
+    let cancelled = false
     const trimmed = description.trim()
     const handle = setTimeout(() => {
       suggestCategory(group.id, trimmed)
         .then((suggested) => {
+          if (cancelled) return
           if (suggested && categoryList.includes(suggested)) {
             setCategory(suggested)
             setAutoCategoryFilled(true)
@@ -203,7 +205,7 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         })
         .catch(() => { /* silent */ })
     }, 300)
-    return () => clearTimeout(handle)
+    return () => { clearTimeout(handle); cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [description, group?.id, isEditing])
 

--- a/src/lib/services/expense-service.ts
+++ b/src/lib/services/expense-service.ts
@@ -1,4 +1,4 @@
-import { collection, doc, setDoc, deleteDoc, Timestamp, getDoc, getDocs, query, orderBy, limit, startAfter, DocumentSnapshot } from 'firebase/firestore'
+import { collection, doc, setDoc, deleteDoc, Timestamp, getDoc, getDocs, query, orderBy, limit, startAfter, DocumentSnapshot, serverTimestamp } from 'firebase/firestore'
 import { db, auth } from '@/lib/firebase'
 import { addActivityLog } from './activity-log-service'
 import { addNotification } from './notification-service'
@@ -34,7 +34,6 @@ export interface ExpenseInput {
 
 export async function addExpense(groupId: string, input: ExpenseInput, actor?: Actor): Promise<string> {
   const id = genId()
-  const now = Timestamp.now()
   const ref = doc(collection(db, 'groups', groupId, 'expenses'), id)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { receiptPaths: _receiptPaths, note, ...rest } = input
@@ -43,8 +42,8 @@ export async function addExpense(groupId: string, input: ExpenseInput, actor?: A
     date: Timestamp.fromDate(input.date),
     receiptPath: input.receiptPaths[0] ?? null,
     ...(note !== undefined ? { note } : {}),
-    createdAt: now,
-    updatedAt: now,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
   })
   if (actor) {
     try {
@@ -90,7 +89,7 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
   const ref = doc(db, 'groups', groupId, 'expenses', expenseId)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { receiptPaths: _rp, note, ...rest } = input
-  const data: Record<string, unknown> = { ...rest, updatedAt: Timestamp.now() }
+  const data: Record<string, unknown> = { ...rest, updatedAt: serverTimestamp() }
   if (note !== undefined) data.note = note
   if (input.date) data.date = Timestamp.fromDate(input.date)
   if (input.receiptPaths) data.receiptPath = input.receiptPaths[0] ?? null

--- a/src/lib/services/recurring-generator.ts
+++ b/src/lib/services/recurring-generator.ts
@@ -1,4 +1,4 @@
-import { collection, doc, getDocs, writeBatch, Timestamp, getDoc, setDoc } from 'firebase/firestore'
+import { collection, doc, getDocs, writeBatch, Timestamp, getDoc, setDoc, serverTimestamp } from 'firebase/firestore'
 import { db, auth } from '@/lib/firebase'
 import { logger } from '@/lib/logger'
 import type { RecurringExpense } from '@/lib/types'
@@ -128,19 +128,21 @@ export async function generatePendingRecurring(groupId: string): Promise<number>
       const dateKey = date.toISOString().split('T')[0]
       const expenseId = `${template.id}_${dateKey}`
       const expenseRef = doc(db, 'groups', groupId, 'expenses', expenseId)
-      const nowTs = Timestamp.now()
 
-      // C2: recompute equal splits based on the actual template amount
+
+      // C2: recompute equal splits — match buildEqualSplits() remainder-to-LAST logic
       const amount = template.amount
       const participants = template.splits.filter((s) => s.isParticipant)
-      const perPerson = participants.length > 0 ? Math.round(amount / participants.length) : 0
-      const remainder = participants.length > 0 ? amount - perPerson * (participants.length - 1) : 0
+      const per = participants.length > 0 ? Math.round(amount / participants.length) : 0
+      const remainder = participants.length > 0 ? amount - per * participants.length : 0
       let participantIndex = 0
+      const participantCount = participants.length
       const computedSplits = template.splits.map((s) => {
         if (!s.isParticipant) {
           return { ...s, shareAmount: 0, paidAmount: s.memberId === template.payerId ? amount : 0 }
         }
-        const shareAmount = participantIndex === 0 ? remainder : perPerson
+        const isLast = participantIndex === participantCount - 1
+        const shareAmount = isLast ? per + remainder : per
         participantIndex++
         return {
           ...s,
@@ -165,8 +167,8 @@ export async function generatePendingRecurring(groupId: string): Promise<number>
         recurringId: template.id,
         pendingConfirm: true,
         createdBy: currentUid,
-        createdAt: nowTs,
-        updatedAt: nowTs,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
       })
 
       batchCount++
@@ -210,5 +212,5 @@ export async function generatePendingRecurring(groupId: string): Promise<number>
 /** Confirm a pending auto-generated expense (set pendingConfirm = false). */
 export async function confirmPendingExpense(groupId: string, expenseId: string): Promise<void> {
   const ref = doc(db, 'groups', groupId, 'expenses', expenseId)
-  await setDoc(ref, { pendingConfirm: false, updatedAt: Timestamp.now() }, { merge: true })
+  await setDoc(ref, { pendingConfirm: false, updatedAt: serverTimestamp() }, { merge: true })
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,11 +12,11 @@ export function signedCurrency(amount: number): string {
   return `${sign}NT$ ${Math.round(amount).toLocaleString()}`
 }
 
-/** Firestore Timestamp → Date */
+/** Firestore Timestamp → Date. Returns epoch (1970-01-01) for undefined to avoid silently polluting current-month data. */
 export function toDate(ts: Timestamp | Date | undefined): Date {
   if (!ts) {
-    logger.warn('[toDate] Received undefined timestamp, falling back to current date')
-    return new Date()
+    logger.error('[toDate] Received undefined timestamp — data integrity issue, returning epoch')
+    return new Date(0)
   }
   if (ts instanceof Date) return ts
   return ts.toDate()


### PR DESCRIPTION
## Summary
- **Split 邏輯統一**：`recurring-generator.ts` 餘數分配改為 LAST participant，與 `buildEqualSplits()` 一致，避免手動 vs 自動建立的支出分帳不同
- **toDate() 安全化**：undefined timestamp 回傳 epoch (1970-01-01) 而非當前時間，避免汙染當月統計數據
- **Debounce cleanup**：`expense-form.tsx` 的 `suggestCategory` 加 cancelled flag，防止 component unmount 後 setState
- **Timestamp 統一**：`expense-service.ts` + `recurring-generator.ts` 的 `createdAt`/`updatedAt` 改用 `serverTimestamp()`，消除 client clock skew 風險

Closes #148

## Test plan
- [x] 132 unit tests pass
- [x] Production build clean
- [x] Code review (Opus agent) — no CRITICAL issues
- [x] Security review (Opus agent) — no CRITICAL/HIGH issues
- [ ] Manual: 建立手動支出 → 確認 split 分配正確
- [ ] Manual: 觸發 recurring sweep → 確認自動支出 split 與手動一致
- [ ] Manual: 切換群組 → 確認無 stale toast 或 state 殘留