### PR TITLE
fix(lint): remove unused _ignored destructure alias

### DIFF
--- a/src/lib/services/recurring-expense-service.ts
+++ b/src/lib/services/recurring-expense-service.ts
@@ -35,7 +35,10 @@ export async function addRecurringExpense(groupId: string, input: RecurringExpen
   const now = Timestamp.now()
   const ref = doc(collection(db, 'groups', groupId, 'recurringExpenses'), id)
 
-  const { startDate, endDate, createdBy: _ignored, ...rest } = input
+  // Strip createdBy from input (server overwrites with authenticated uid below)
+  // and split out Date fields that need Timestamp conversion.
+  const { startDate, endDate, createdBy: _createdByIgnored, ...rest } = input
+  void _createdByIgnored
   // Filter out undefined values — Firestore rejects them
   const cleaned = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined))
   await setDoc(ref, {


### PR DESCRIPTION
Closes #154

## Summary
Pre-existing ESLint error at \`src/lib/services/recurring-expense-service.ts:38\` has been blocking CI \`Lint & Unit Tests\` for every PR since #137 was merged. Uses \`void\` on the destructured value to silence the unused-var rule — behavior unchanged.

## Why this matters
PR #151 (multi-image upload) can't merge until CI is green. This is the minimum diff to unblock it.

## Test plan
- [x] \`npm run lint\` — 0 errors (was 1)
- [x] \`npm test\` — existing tests unchanged
- [x] Zero behavior change (pure lint cleanup)