### PR TITLE
fix(security): storage rules 改用 firestore.get() 驗證 (Closes #152)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -110,6 +110,9 @@ service cloud.firestore {
           && request.resource.data.payerId is string
           && request.resource.data.payerName is string
           && request.resource.data.createdBy == request.auth.uid
+          && (!('receiptPaths' in request.resource.data)
+              || (request.resource.data.receiptPaths is list
+                  && request.resource.data.receiptPaths.size() <= 10))
           && hasReasonableSize();
 
         // 更新：僅建立者或群組 owner（防止成員任意修改他人支出）
@@ -121,6 +124,9 @@ service cloud.firestore {
           && request.resource.data.amount is number
           && request.resource.data.amount > 0
           && request.resource.data.amount < 100000000
+          && (!('receiptPaths' in request.resource.data)
+              || (request.resource.data.receiptPaths is list
+                  && request.resource.data.receiptPaths.size() <= 10))
           && hasReasonableSize();
 
         // 刪除：僅建立者或群組 owner

--- a/storage.rules
+++ b/storage.rules
@@ -5,30 +5,36 @@ service firebase.storage {
     // ─── 收據 ───
     //
     // 存取控制模型：
-    //   - Firestore expense doc 是 source of truth（group membership 在 firestore.rules）
-    //   - Storage 只做粗粒度驗證：已登入、檔案大小、MIME、uploadedBy metadata
-    //   - 細粒度 group membership 驗證無法在 Storage rules 跨服務取得 — 此為 Firebase
-    //     Storage 限制，只能透過 Cloud Function 強化。追蹤於 Issue #152。
+    //   - Firestore 為 source of truth：group membership、expense.createdBy、ownerUid。
+    //   - Storage rules 透過 firestore.get() 跨服務驗證，避免信任 client metadata。
+    //   - receiptPaths 數量上限（10）由 firestore.rules 強制（見 expense schema）。
+    //   - MIME 型別與檔案大小在此強制；magic bytes 檢查需 Cloud Function（Issue #152 MEDIUM，延後）。
 
     match /receipts/{groupId}/{expenseId}/{fileName} {
-      // 讀取：已登入（受 Firestore expense doc 規則限制）
-      allow read: if request.auth != null;
+      // 讀取：必須是 group 成員（透過 Firestore 驗證）。
+      // 取代原本「任何登入者可讀」的寬鬆條件。
+      allow read: if request.auth != null
+        && request.auth.uid in
+          firestore.get(/databases/(default)/documents/groups/$(groupId)).data.memberUids;
 
       // 寫入（create/update）：
       //   - 已登入
+      //   - 必須是 group 成員（透過 Firestore 驗證，取代可偽造的 customMetadata.uploadedBy）
       //   - 檔案 < 10MB
       //   - MIME 為 image/*
-      //   - customMetadata.uploadedBy 必須存在且等於 auth.uid（防止假冒他人）
       allow write: if request.auth != null
+        && request.auth.uid in
+          firestore.get(/databases/(default)/documents/groups/$(groupId)).data.memberUids
         && request.resource.size < 10 * 1024 * 1024
-        && request.resource.contentType.matches('image/.*')
-        && request.resource.metadata.uploadedBy == request.auth.uid;
+        && request.resource.contentType.matches('image/.*');
 
-      // 刪除：只允許 uploadedBy 本人
-      // Cross-service check (group owner override) 無法在 Storage rules 表達，
-      // 因此此處放寬：只要當初是你上傳的就能刪。
+      // 刪除：expense 建立者或 group owner（貼合 firestore.rules 的 expense delete 權限）。
+      // 取代原本信任 customMetadata.uploadedBy 的條件。
       allow delete: if request.auth != null
-        && resource.metadata.uploadedBy == request.auth.uid;
+        && (
+          firestore.get(/databases/(default)/documents/groups/$(groupId)/expenses/$(expenseId)).data.createdBy == request.auth.uid
+          || firestore.get(/databases/(default)/documents/groups/$(groupId)).data.ownerUid == request.auth.uid
+        );
     }
 
     // ─── 其他路徑：全部拒絕 ───


### PR DESCRIPTION
## Summary

- 移除 `storage.rules` 對 client-controlled `customMetadata.uploadedBy` 的信任（CRITICAL：可偽造 UID，既能自保 delete 權也能封鎖他人刪除）
- storage.rules read 改用 `firestore.get(groups/{g}).memberUids` 驗證成員（HIGH：取代「任何登入者可讀」的跨 group 漏洞）
- firestore.rules expense create/update 新增 `receiptPaths.size() <= 10` 上限（HIGH：原本只在 client 強制，繞過 UI 直呼 SDK 可無限附加）

## Design decisions

| 決策點 | 選擇 | 理由 |
|-------|------|------|
| 讀取驗證 | 嚴格（+1 Firestore read/image） | 家庭帳本讀圖頻率低，安全 > 成本 |
| delete 權限 | expense.createdBy OR group owner | 貼合 firestore.rules 既有權限模型 |
| count cap 位置 | Firestore（非 Storage） | Storage 無法 count prefix；orphan 交給 #153 |
| MIME spoofing（MEDIUM） | 延後 | 需 Cloud Function 檢查 magic bytes |

## Verification

- ✅ `firebase deploy --dry-run` storage.rules 編譯通過
- ✅ `firebase deploy --dry-run` firestore.rules 編譯通過
- ✅ `npm run test` 336/336 通過
- ✅ `npm run lint` 僅 pre-existing warnings（與此 PR 無關）

## Test plan

- [ ] 合併後 `deploy-rules.yml` 自動部署生效
- [ ] 人工驗證：成員可正常上傳/讀/刪 expense 收據
- [ ] 人工驗證：非成員 UID 無法透過 SDK 直呼讀取/刪除他人收據
- [ ] 人工驗證：直接寫 receiptPaths 11 筆會被 firestore.rules 拒絕

Closes #152
Related: PR #151, Issue #153（orphan 清理）