### PR TITLE
feat(settings): 孤兒收據檔掃描與清理 (Closes #153)

### DIFF
--- a/__tests__/orphan-scanner.test.ts
+++ b/__tests__/orphan-scanner.test.ts
@@ -1,0 +1,49 @@
+jest.mock('@/lib/firebase', () => ({ db: {}, auth: {}, storage: {} }))
+jest.mock('firebase/firestore', () => ({ collection: jest.fn(), getDocs: jest.fn() }))
+jest.mock('firebase/storage', () => ({
+  ref: jest.fn(),
+  deleteObject: jest.fn(),
+  getMetadata: jest.fn(),
+  listAll: jest.fn(),
+}))
+
+import { computeOrphanPaths } from '@/lib/services/orphan-scanner'
+
+describe('computeOrphanPaths', () => {
+  it('returns storage paths not referenced by any expense', () => {
+    const storage = [
+      'receipts/g1/e1/a.jpg',
+      'receipts/g1/e1/b.jpg',
+      'receipts/g1/e2/c.jpg',
+      'receipts/g1/orphan/d.jpg',
+    ]
+    const referenced = new Set(['receipts/g1/e1/a.jpg', 'receipts/g1/e2/c.jpg'])
+    expect(computeOrphanPaths(storage, referenced)).toEqual([
+      'receipts/g1/e1/b.jpg',
+      'receipts/g1/orphan/d.jpg',
+    ])
+  })
+
+  it('returns all storage paths when nothing is referenced', () => {
+    const storage = ['receipts/g1/e1/a.jpg', 'receipts/g1/e2/b.jpg']
+    expect(computeOrphanPaths(storage, new Set())).toEqual(storage)
+  })
+
+  it('returns empty array when all storage paths are referenced', () => {
+    const storage = ['receipts/g1/e1/a.jpg']
+    const referenced = new Set(['receipts/g1/e1/a.jpg'])
+    expect(computeOrphanPaths(storage, referenced)).toEqual([])
+  })
+
+  it('handles empty storage list', () => {
+    expect(computeOrphanPaths([], new Set(['receipts/g1/e1/a.jpg']))).toEqual([])
+  })
+
+  it('treats paths with matching names under different groups as distinct', () => {
+    const storage = ['receipts/g1/e1/a.jpg', 'receipts/g2/e1/a.jpg']
+    const referenced = new Set(['receipts/g1/e1/a.jpg'])
+    // Scanner scopes input to a single group in practice, but the diff helper
+    // is path-exact — confirm no accidental substring matching.
+    expect(computeOrphanPaths(storage, referenced)).toEqual(['receipts/g2/e1/a.jpg'])
+  })
+})

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -14,6 +14,7 @@ import { addCategory, updateCategory } from '@/lib/services/category-service'
 import { addActivityLog } from '@/lib/services/activity-log-service'
 import { useRouter } from 'next/navigation'
 import { BudgetSection } from '@/components/budget-section'
+import { OrphanCleanupSection } from '@/components/orphan-cleanup-section'
 import type { FamilyMember, Category } from '@/lib/types'
 
 import { useToast } from '@/components/toast'
@@ -705,6 +706,12 @@ export default function SettingsPage() {
             </button>
           </div>
         </Section>
+
+        {group && user?.uid === group.ownerUid && (
+          <Section title="🧹 收據檔案維護">
+            <OrphanCleanupSection groupId={group.id} />
+          </Section>
+        )}
 
         <Section title="👤 帳號">
         <div className="flex items-center gap-4">

--- a/src/components/orphan-cleanup-section.tsx
+++ b/src/components/orphan-cleanup-section.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState } from 'react'
+import { scanOrphans, deleteOrphans, type OrphanFile } from '@/lib/services/orphan-scanner'
+import { useToast } from '@/components/toast'
+import { logger } from '@/lib/logger'
+
+interface OrphanCleanupSectionProps {
+  groupId: string
+}
+
+/** Exclude files uploaded within this window (race with in-flight uploads). */
+const RECENT_CUTOFF_MS = 60 * 60 * 1000 // 1 hour
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+function formatAge(timeCreated: string): string {
+  if (!timeCreated) return '未知'
+  const ageMs = Date.now() - new Date(timeCreated).getTime()
+  const days = Math.floor(ageMs / (24 * 60 * 60 * 1000))
+  if (days >= 1) return `${days} 天前`
+  const hours = Math.floor(ageMs / (60 * 60 * 1000))
+  if (hours >= 1) return `${hours} 小時前`
+  const minutes = Math.floor(ageMs / (60 * 1000))
+  return `${Math.max(minutes, 1)} 分鐘前`
+}
+
+export function OrphanCleanupSection({ groupId }: OrphanCleanupSectionProps) {
+  const [scanning, setScanning] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [scanned, setScanned] = useState(false)
+  const [orphans, setOrphans] = useState<OrphanFile[]>([])
+  const [recentSkipped, setRecentSkipped] = useState(0)
+  const { addToast } = useToast()
+
+  const totalSize = orphans.reduce((s, o) => s + o.size, 0)
+
+  async function handleScan() {
+    setScanning(true)
+    try {
+      const all = await scanOrphans(groupId)
+      const cutoff = Date.now() - RECENT_CUTOFF_MS
+      const stale: OrphanFile[] = []
+      let recent = 0
+      for (const o of all) {
+        const t = o.timeCreated ? new Date(o.timeCreated).getTime() : 0
+        if (t > cutoff) recent++
+        else stale.push(o)
+      }
+      setOrphans(stale)
+      setRecentSkipped(recent)
+      setScanned(true)
+      if (stale.length === 0 && recent === 0) {
+        addToast('沒有發現孤兒檔', 'success')
+      } else if (stale.length === 0) {
+        addToast(`發現 ${recent} 個近期檔案（已保護，不列出）`, 'success')
+      } else {
+        addToast(`發現 ${stale.length} 個孤兒檔`, 'success')
+      }
+    } catch (e) {
+      logger.error('[OrphanCleanup] scan failed', e)
+      addToast('掃描失敗，請稍後重試', 'error')
+    } finally {
+      setScanning(false)
+    }
+  }
+
+  async function handleDeleteAll() {
+    if (orphans.length === 0) return
+    if (!confirm(`確定要刪除 ${orphans.length} 個孤兒檔（${formatSize(totalSize)}）嗎？此操作無法復原。`)) {
+      return
+    }
+    setDeleting(true)
+    try {
+      const paths = orphans.map((o) => o.path)
+      const { succeeded, failed } = await deleteOrphans(paths)
+      if (failed.length === 0) {
+        addToast(`已刪除 ${succeeded.length} 個檔案`, 'success')
+        setOrphans([])
+      } else {
+        addToast(`刪除 ${succeeded.length} 成功、${failed.length} 失敗`, 'warning')
+        const failedSet = new Set(failed.map((f) => f.path))
+        setOrphans((prev) => prev.filter((o) => failedSet.has(o.path)))
+      }
+    } catch (e) {
+      logger.error('[OrphanCleanup] delete failed', e)
+      addToast('刪除失敗', 'error')
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-[var(--muted-foreground)]">
+        掃描 Storage 中未被任何支出引用的收據檔案（上傳後 Firestore 寫入失敗或其他中斷造成的殘留）。
+        為避免誤殺正在上傳的檔案，會自動排除最近 1 小時內建立的檔案。
+      </p>
+
+      <div className="flex gap-2">
+        <button
+          onClick={handleScan}
+          disabled={scanning || deleting}
+          className="px-4 py-2 rounded-lg text-sm font-medium border border-[var(--border)] hover:bg-[var(--muted)] disabled:opacity-50 transition-colors"
+        >
+          {scanning ? '掃描中…' : scanned ? '重新掃描' : '掃描孤兒檔'}
+        </button>
+        {orphans.length > 0 && (
+          <button
+            onClick={handleDeleteAll}
+            disabled={deleting}
+            className="px-4 py-2 rounded-lg text-sm font-medium text-white disabled:opacity-50 transition-colors"
+            style={{ backgroundColor: 'var(--destructive)' }}
+          >
+            {deleting ? '刪除中…' : `刪除全部（${formatSize(totalSize)}）`}
+          </button>
+        )}
+      </div>
+
+      {scanned && recentSkipped > 0 && (
+        <p className="text-xs text-[var(--muted-foreground)]">
+          已保護 {recentSkipped} 個近期檔案（1 小時內上傳），下次掃描會重新評估。
+        </p>
+      )}
+
+      {orphans.length > 0 && (
+        <div className="border border-[var(--border)] rounded-lg divide-y divide-[var(--border)] max-h-80 overflow-y-auto">
+          {orphans.map((o) => (
+            <div key={o.path} className="px-3 py-2 text-xs">
+              <div className="font-mono text-[var(--muted-foreground)] truncate" title={o.path}>
+                {o.path}
+              </div>
+              <div className="flex gap-3 mt-1 text-[var(--muted-foreground)]">
+                <span>{formatSize(o.size)}</span>
+                <span>{formatAge(o.timeCreated)}</span>
+                {o.expenseId && <span className="font-mono">expense: {o.expenseId}</span>}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {scanned && orphans.length === 0 && recentSkipped === 0 && (
+        <p className="text-sm text-[var(--muted-foreground)]">✅ 乾淨，沒有孤兒檔</p>
+      )}
+    </div>
+  )
+}

--- a/src/lib/services/orphan-scanner.ts
+++ b/src/lib/services/orphan-scanner.ts
@@ -1,0 +1,140 @@
+import { collection, getDocs } from 'firebase/firestore'
+import { deleteObject, getMetadata, listAll, ref as storageRef } from 'firebase/storage'
+import { db, storage } from '@/lib/firebase'
+import { logger } from '@/lib/logger'
+
+export interface OrphanFile {
+  /** Full storage path, e.g. receipts/g1/e1/123-0-uuid.jpg */
+  path: string
+  /** Derived from path segment; empty string if malformed */
+  expenseId: string
+  /** Bytes */
+  size: number
+  /** Storage object creation time (ISO string) */
+  timeCreated: string
+}
+
+export interface DeleteOrphansResult {
+  succeeded: string[]
+  failed: { path: string; error: unknown }[]
+}
+
+/**
+ * Fetch every receipt path referenced by a group's expenses (new `receiptPaths` +
+ * legacy singular `receiptPath`). Returned as a Set for O(1) membership checks.
+ */
+async function collectReferencedPaths(groupId: string): Promise<Set<string>> {
+  const snap = await getDocs(collection(db, 'groups', groupId, 'expenses'))
+  const paths = new Set<string>()
+  for (const d of snap.docs) {
+    const data = d.data() as { receiptPaths?: string[]; receiptPath?: string | null }
+    if (Array.isArray(data.receiptPaths)) {
+      for (const p of data.receiptPaths) {
+        if (typeof p === 'string' && p.length > 0) paths.add(p)
+      }
+    }
+    if (typeof data.receiptPath === 'string' && data.receiptPath.length > 0) {
+      paths.add(data.receiptPath)
+    }
+  }
+  return paths
+}
+
+/**
+ * Recursively walk all items under receipts/{groupId}/ in Storage.
+ * Firebase Storage listAll() follows sub-prefixes automatically when called on
+ * the parent, but Firebase JS SDK returns one level at a time — so we recurse.
+ */
+async function listAllReceipts(groupId: string): Promise<string[]> {
+  const paths: string[] = []
+  const root = storageRef(storage, `receipts/${groupId}`)
+  const rootList = await listAll(root)
+  for (const item of rootList.items) paths.push(item.fullPath)
+  for (const prefix of rootList.prefixes) {
+    const sub = await listAll(prefix)
+    for (const item of sub.items) paths.push(item.fullPath)
+    // Receipts use exactly 2 levels (groupId/expenseId/file), so no deeper recursion needed.
+  }
+  return paths
+}
+
+/** Extract `{expenseId}` from `receipts/{groupId}/{expenseId}/{fileName}`. */
+function parseExpenseId(path: string): string {
+  const parts = path.split('/')
+  return parts.length >= 3 ? parts[2] : ''
+}
+
+/**
+ * Compare all Storage objects under receipts/{groupId}/ against paths referenced
+ * by Firestore expense docs. Any Storage path NOT referenced is an orphan.
+ *
+ * Caller must be group owner (enforced by storage.rules `allow list`).
+ */
+export async function scanOrphans(groupId: string): Promise<OrphanFile[]> {
+  const [storagePaths, referenced] = await Promise.all([
+    listAllReceipts(groupId),
+    collectReferencedPaths(groupId),
+  ])
+  const orphanPaths = storagePaths.filter((p) => !referenced.has(p))
+  // Parallel metadata fetch; tolerate individual failures (e.g. object deleted
+  // mid-scan) by filtering them out.
+  const results = await Promise.allSettled(
+    orphanPaths.map(async (path): Promise<OrphanFile> => {
+      const meta = await getMetadata(storageRef(storage, path))
+      return {
+        path,
+        expenseId: parseExpenseId(path),
+        size: meta.size ?? 0,
+        timeCreated: meta.timeCreated ?? '',
+      }
+    }),
+  )
+  const orphans: OrphanFile[] = []
+  for (const [i, r] of results.entries()) {
+    if (r.status === 'fulfilled') {
+      orphans.push(r.value)
+    } else {
+      logger.warn('[orphan-scanner] getMetadata failed, skipping', {
+        path: orphanPaths[i],
+        err: r.reason,
+      })
+    }
+  }
+  // Oldest first — helps users focus on stale accumulations.
+  orphans.sort((a, b) => a.timeCreated.localeCompare(b.timeCreated))
+  return orphans
+}
+
+/**
+ * Delete the given storage paths. Best-effort: each deletion is independent,
+ * failures are collected rather than aborting the batch.
+ */
+export async function deleteOrphans(paths: string[]): Promise<DeleteOrphansResult> {
+  const results = await Promise.allSettled(
+    paths.map((p) => deleteObject(storageRef(storage, p))),
+  )
+  const succeeded: string[] = []
+  const failed: { path: string; error: unknown }[] = []
+  for (const [i, r] of results.entries()) {
+    if (r.status === 'fulfilled') {
+      succeeded.push(paths[i])
+    } else {
+      failed.push({ path: paths[i], error: r.reason })
+    }
+  }
+  if (failed.length > 0) {
+    logger.error('[orphan-scanner] Some deletions failed', {
+      totalRequested: paths.length,
+      failed: failed.length,
+    })
+  }
+  return { succeeded, failed }
+}
+
+/** Pure diff helper exposed for unit testing (avoids Storage SDK dependency). */
+export function computeOrphanPaths(
+  storagePaths: readonly string[],
+  referencedPaths: ReadonlySet<string>,
+): string[] {
+  return storagePaths.filter((p) => !referencedPaths.has(p))
+}

--- a/storage.rules
+++ b/storage.rules
@@ -6,34 +6,38 @@ service firebase.storage {
     //
     // 存取控制模型：
     //   - Firestore 為 source of truth：group membership、expense.createdBy、ownerUid。
-    //   - Storage rules 透過 firestore.get() 跨服務驗證，避免信任 client metadata。
+    //   - Storage rules 透過 firestore.get()/exists() 跨服務驗證，避免信任 client metadata。
     //   - receiptPaths 數量上限（10）由 firestore.rules 強制（見 expense schema）。
     //   - MIME 型別與檔案大小在此強制；magic bytes 檢查需 Cloud Function（Issue #152 MEDIUM，延後）。
 
+    // 列出群組下所有收據（for Settings 孤兒檔掃描，Issue #153）— 僅 group owner
+    match /receipts/{groupId}/{allPaths=**} {
+      allow list: if request.auth != null
+        && firestore.get(/databases/(default)/documents/groups/$(groupId)).data.ownerUid == request.auth.uid;
+    }
+
     match /receipts/{groupId}/{expenseId}/{fileName} {
       // 讀取：必須是 group 成員（透過 Firestore 驗證）。
-      // 取代原本「任何登入者可讀」的寬鬆條件。
       allow read: if request.auth != null
         && request.auth.uid in
           firestore.get(/databases/(default)/documents/groups/$(groupId)).data.memberUids;
 
       // 寫入（create/update）：
-      //   - 已登入
-      //   - 必須是 group 成員（透過 Firestore 驗證，取代可偽造的 customMetadata.uploadedBy）
-      //   - 檔案 < 10MB
-      //   - MIME 為 image/*
+      //   - 已登入 + 必須是 group 成員（取代可偽造的 customMetadata.uploadedBy）
+      //   - 檔案 < 10MB + MIME 為 image/*
       allow write: if request.auth != null
         && request.auth.uid in
           firestore.get(/databases/(default)/documents/groups/$(groupId)).data.memberUids
         && request.resource.size < 10 * 1024 * 1024
         && request.resource.contentType.matches('image/.*');
 
-      // 刪除：expense 建立者或 group owner（貼合 firestore.rules 的 expense delete 權限）。
-      // 取代原本信任 customMetadata.uploadedBy 的條件。
+      // 刪除：group owner（優先，可刪孤兒檔）或 expense 建立者（僅當 expense doc 仍存在）。
+      // owner 分支放前面短路避免對不存在的 expense doc 取 .data 拋錯（Issue #153）。
       allow delete: if request.auth != null
         && (
-          firestore.get(/databases/(default)/documents/groups/$(groupId)/expenses/$(expenseId)).data.createdBy == request.auth.uid
-          || firestore.get(/databases/(default)/documents/groups/$(groupId)).data.ownerUid == request.auth.uid
+          firestore.get(/databases/(default)/documents/groups/$(groupId)).data.ownerUid == request.auth.uid
+          || (firestore.exists(/databases/(default)/documents/groups/$(groupId)/expenses/$(expenseId))
+              && firestore.get(/databases/(default)/documents/groups/$(groupId)/expenses/$(expenseId)).data.createdBy == request.auth.uid)
         );
     }
 


### PR DESCRIPTION
## Summary

在 Settings 新增「🧹 收據檔案維護」卡片（僅 **group owner** 可見），讓管理員手動偵測與清除 Firebase Storage 中未被任何 expense 引用的殘留收據檔（PR #151 silent rollback 失敗的後續補網）。

## Scope 變更（見 issue #153 comment）

原 issue 建議 C + D 混合。技術評估後收斂為 **D only**：

- ❌ **C (staging prefix)**：Firebase JS SDK 沒暴露 \`copy\`/\`rewriteTo\`/\`customTime\`，純 client 實作要雙上傳（2× 頻寬），對家庭用戶每次存支出都多付成本
- ❌ **A/B (Cloud Function)**：需升 Blaze 計費 + 新 functions/ 基礎設施
- ✅ **D (手動掃描)**：零基礎設施、owner 點一下就清、符合家庭帳本低頻維護模型

## 實作

| 新檔 | 說明 |
|------|------|
| \`src/lib/services/orphan-scanner.ts\` | scanOrphans/deleteOrphans + 純函式 computeOrphanPaths |
| \`src/components/orphan-cleanup-section.tsx\` | UI 卡片：掃描/清單/全部刪除 |
| \`__tests__/orphan-scanner.test.ts\` | 5 個 diff 邏輯測試 |

## UX 防呆

- **Race condition 保護**：排除最近 1 小時內建立的檔案，避免誤殺家人正在上傳但 Firestore 還沒 commit 的 in-flight 檔
- **刪除前二次確認**：confirm 顯示數量與總容量
- **部分失敗處理**：deleteOrphans 用 allSettled，toast 顯示成功/失敗計數，列表只保留失敗項供重試

## storage.rules 配套修正

- 新增 \`list\` 權限在 \`match /receipts/{groupId}/{allPaths=**}\`（僅 owner）
- delete 分支重排：**owner 放前面短路 + exists() 保護**，讓孤兒檔（expense doc 已不存在）的刪除可行。原本 #152 的規則會因 \`firestore.get(expense).data.createdBy\` 對不存在 doc 拋錯

## Verification

- ✅ \`npm run build\` 通過
- ✅ \`npm run test\` 341/341 通過（+5 新測試）
- ✅ \`firebase deploy --dry-run\` storage.rules 編譯通過

## Test plan

- [ ] Owner 登入：設定頁可見「收據檔案維護」卡片，掃描無孤兒時顯示「✅ 乾淨」
- [ ] 非 owner 成員：卡片不可見
- [ ] 人工製造孤兒（用 Storage console 直接上傳檔到不存在的 expenseId 下）→ 掃描後出現
- [ ] 點「全部刪除」→ 二次確認 → 成功刪除
- [ ] 近 1 小時內上傳的檔案不出現在孤兒清單中（顯示保護計數）

Closes #153
Related: PR #151, PR #156（#152）