### PR TITLE
fix: review follow-up for #156/#157 (Closes #158)

### DIFF
--- a/__tests__/orphan-scanner.test.ts
+++ b/__tests__/orphan-scanner.test.ts
@@ -1,13 +1,18 @@
 jest.mock('@/lib/firebase', () => ({ db: {}, auth: {}, storage: {} }))
-jest.mock('firebase/firestore', () => ({ collection: jest.fn(), getDocs: jest.fn() }))
+const mockGetDocs = jest.fn()
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+}))
+const mockDeleteObject = jest.fn()
 jest.mock('firebase/storage', () => ({
-  ref: jest.fn(),
-  deleteObject: jest.fn(),
+  ref: jest.fn((_storage, path: string) => ({ fullPath: path })),
+  deleteObject: (...args: unknown[]) => mockDeleteObject(...args),
   getMetadata: jest.fn(),
   listAll: jest.fn(),
 }))
 
-import { computeOrphanPaths } from '@/lib/services/orphan-scanner'
+import { computeOrphanPaths, deleteOrphans } from '@/lib/services/orphan-scanner'
 
 describe('computeOrphanPaths', () => {
   it('returns storage paths not referenced by any expense', () => {
@@ -45,5 +50,58 @@ describe('computeOrphanPaths', () => {
     // Scanner scopes input to a single group in practice, but the diff helper
     // is path-exact — confirm no accidental substring matching.
     expect(computeOrphanPaths(storage, referenced)).toEqual(['receipts/g2/e1/a.jpg'])
+  })
+})
+
+describe('deleteOrphans', () => {
+  beforeEach(() => {
+    mockGetDocs.mockReset()
+    mockDeleteObject.mockReset()
+  })
+
+  function stubGetDocs(expenses: Array<{ receiptPaths?: string[]; receiptPath?: string | null }>) {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: expenses.map((e) => ({ data: () => e })),
+    })
+  }
+
+  it('deletes paths that are still orphans', async () => {
+    stubGetDocs([{ receiptPaths: [] }])
+    mockDeleteObject.mockResolvedValue(undefined)
+    const result = await deleteOrphans('g1', ['receipts/g1/e1/a.jpg', 'receipts/g1/e2/b.jpg'])
+    expect(result.succeeded).toHaveLength(2)
+    expect(result.failed).toEqual([])
+    expect(result.adopted).toEqual([])
+    expect(mockDeleteObject).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips paths adopted by an expense between scan and delete', async () => {
+    // 'a.jpg' got adopted after the scan
+    stubGetDocs([{ receiptPaths: ['receipts/g1/e1/a.jpg'] }])
+    mockDeleteObject.mockResolvedValue(undefined)
+    const result = await deleteOrphans('g1', ['receipts/g1/e1/a.jpg', 'receipts/g1/e2/b.jpg'])
+    expect(result.adopted).toEqual(['receipts/g1/e1/a.jpg'])
+    expect(result.succeeded).toEqual(['receipts/g1/e2/b.jpg'])
+    // Only the still-orphan path hits deleteObject.
+    expect(mockDeleteObject).toHaveBeenCalledTimes(1)
+  })
+
+  it('collects per-path failures without aborting the batch', async () => {
+    stubGetDocs([{ receiptPaths: [] }])
+    mockDeleteObject
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined)
+    const result = await deleteOrphans('g1', ['receipts/g1/e1/a.jpg', 'receipts/g1/e2/b.jpg'])
+    expect(result.succeeded).toEqual(['receipts/g1/e2/b.jpg'])
+    expect(result.failed).toHaveLength(1)
+    expect(result.failed[0].path).toBe('receipts/g1/e1/a.jpg')
+  })
+
+  it('recognizes legacy receiptPath (singular) as adopting a path', async () => {
+    stubGetDocs([{ receiptPath: 'receipts/g1/e1/legacy.jpg' }])
+    const result = await deleteOrphans('g1', ['receipts/g1/e1/legacy.jpg'])
+    expect(result.adopted).toEqual(['receipts/g1/e1/legacy.jpg'])
+    expect(result.succeeded).toEqual([])
+    expect(mockDeleteObject).not.toHaveBeenCalled()
   })
 })

--- a/src/components/orphan-cleanup-section.tsx
+++ b/src/components/orphan-cleanup-section.tsx
@@ -18,6 +18,30 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
 }
 
+/**
+ * Map Firebase error codes to user-facing Traditional Chinese messages.
+ * Falls back to a generic message when the code is unknown; the raw error
+ * still goes to logger for debugging.
+ */
+function mapFirebaseError(err: unknown, fallback: string): string {
+  const code = (err as { code?: string } | null)?.code
+  switch (code) {
+    case 'storage/unauthorized':
+    case 'permission-denied':
+      return '權限不足（僅群組擁有者可執行此操作）'
+    case 'storage/unauthenticated':
+    case 'unauthenticated':
+      return '登入已過期，請重新登入後再試'
+    case 'storage/retry-limit-exceeded':
+    case 'storage/canceled':
+      return '網路連線不穩，請稍後重試'
+    case 'unavailable':
+      return 'Firebase 服務暫時無法使用，請稍後重試'
+    default:
+      return fallback
+  }
+}
+
 function formatAge(timeCreated: string): string {
   if (!timeCreated) return '未知'
   const ageMs = Date.now() - new Date(timeCreated).getTime()
@@ -63,7 +87,7 @@ export function OrphanCleanupSection({ groupId }: OrphanCleanupSectionProps) {
       }
     } catch (e) {
       logger.error('[OrphanCleanup] scan failed', e)
-      addToast('掃描失敗，請稍後重試', 'error')
+      addToast(mapFirebaseError(e, '掃描失敗，請稍後重試'), 'error')
     } finally {
       setScanning(false)
     }
@@ -76,19 +100,21 @@ export function OrphanCleanupSection({ groupId }: OrphanCleanupSectionProps) {
     }
     setDeleting(true)
     try {
+      // Snapshot current orphan set — closures are stable across the await.
       const paths = orphans.map((o) => o.path)
-      const { succeeded, failed } = await deleteOrphans(paths)
-      if (failed.length === 0) {
-        addToast(`已刪除 ${succeeded.length} 個檔案`, 'success')
-        setOrphans([])
-      } else {
-        addToast(`刪除 ${succeeded.length} 成功、${failed.length} 失敗`, 'warning')
-        const failedSet = new Set(failed.map((f) => f.path))
-        setOrphans((prev) => prev.filter((o) => failedSet.has(o.path)))
-      }
+      const { succeeded, failed, adopted } = await deleteOrphans(groupId, paths)
+      // Keep only items that still need attention (failed to delete).
+      // Successfully deleted and adopted-since-scan are removed from the list.
+      const failedSet = new Set(failed.map((f) => f.path))
+      setOrphans((prev) => prev.filter((o) => failedSet.has(o.path)))
+      const parts: string[] = []
+      if (succeeded.length > 0) parts.push(`已刪除 ${succeeded.length}`)
+      if (adopted.length > 0) parts.push(`跳過 ${adopted.length}（已被支出引用）`)
+      if (failed.length > 0) parts.push(`${failed.length} 失敗`)
+      addToast(parts.join('、') || '沒有可刪除的檔案', failed.length > 0 ? 'warning' : 'success')
     } catch (e) {
       logger.error('[OrphanCleanup] delete failed', e)
-      addToast('刪除失敗', 'error')
+      addToast(mapFirebaseError(e, '刪除失敗'), 'error')
     } finally {
       setDeleting(false)
     }
@@ -112,7 +138,7 @@ export function OrphanCleanupSection({ groupId }: OrphanCleanupSectionProps) {
         {orphans.length > 0 && (
           <button
             onClick={handleDeleteAll}
-            disabled={deleting}
+            disabled={deleting || scanning}
             className="px-4 py-2 rounded-lg text-sm font-medium text-white disabled:opacity-50 transition-colors"
             style={{ backgroundColor: 'var(--destructive)' }}
           >
@@ -121,32 +147,38 @@ export function OrphanCleanupSection({ groupId }: OrphanCleanupSectionProps) {
         )}
       </div>
 
-      {scanned && recentSkipped > 0 && (
-        <p className="text-xs text-[var(--muted-foreground)]">
-          已保護 {recentSkipped} 個近期檔案（1 小時內上傳），下次掃描會重新評估。
-        </p>
-      )}
+      {/*
+        role="status" + aria-live="polite" lets screen readers announce scan
+        and delete outcomes as they happen. Results appear inside this region.
+      */}
+      <div role="status" aria-live="polite" className="space-y-3">
+        {scanned && recentSkipped > 0 && (
+          <p className="text-xs text-[var(--muted-foreground)]">
+            已保護 {recentSkipped} 個近期檔案（1 小時內上傳），下次掃描會重新評估。
+          </p>
+        )}
 
-      {orphans.length > 0 && (
-        <div className="border border-[var(--border)] rounded-lg divide-y divide-[var(--border)] max-h-80 overflow-y-auto">
-          {orphans.map((o) => (
-            <div key={o.path} className="px-3 py-2 text-xs">
-              <div className="font-mono text-[var(--muted-foreground)] truncate" title={o.path}>
-                {o.path}
+        {orphans.length > 0 && (
+          <div className="border border-[var(--border)] rounded-lg divide-y divide-[var(--border)] max-h-80 overflow-y-auto">
+            {orphans.map((o) => (
+              <div key={o.path} className="px-3 py-2 text-xs">
+                <div className="font-mono text-[var(--muted-foreground)] truncate" title={o.path}>
+                  {o.path}
+                </div>
+                <div className="flex gap-3 mt-1 text-[var(--muted-foreground)]">
+                  <span>{formatSize(o.size)}</span>
+                  <span>{formatAge(o.timeCreated)}</span>
+                  {o.expenseId && <span className="font-mono">費用 ID：{o.expenseId}</span>}
+                </div>
               </div>
-              <div className="flex gap-3 mt-1 text-[var(--muted-foreground)]">
-                <span>{formatSize(o.size)}</span>
-                <span>{formatAge(o.timeCreated)}</span>
-                {o.expenseId && <span className="font-mono">expense: {o.expenseId}</span>}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+            ))}
+          </div>
+        )}
 
-      {scanned && orphans.length === 0 && recentSkipped === 0 && (
-        <p className="text-sm text-[var(--muted-foreground)]">✅ 乾淨，沒有孤兒檔</p>
-      )}
+        {scanned && orphans.length === 0 && recentSkipped === 0 && (
+          <p className="text-sm text-[var(--muted-foreground)]">✅ 乾淨，沒有孤兒檔</p>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/lib/services/orphan-scanner.ts
+++ b/src/lib/services/orphan-scanner.ts
@@ -17,6 +17,11 @@ export interface OrphanFile {
 export interface DeleteOrphansResult {
   succeeded: string[]
   failed: { path: string; error: unknown }[]
+  /**
+   * Paths skipped because they were adopted by an expense between scan-time and
+   * delete-time. Safety net against the scan→delete race window.
+   */
+  adopted: string[]
 }
 
 /**
@@ -53,7 +58,15 @@ async function listAllReceipts(groupId: string): Promise<string[]> {
   for (const prefix of rootList.prefixes) {
     const sub = await listAll(prefix)
     for (const item of sub.items) paths.push(item.fullPath)
-    // Receipts use exactly 2 levels (groupId/expenseId/file), so no deeper recursion needed.
+    // Expected structure: receipts/{groupId}/{expenseId}/{fileName} (exactly 2 levels deep).
+    // Warn if deeper nesting appears — those files would be silently excluded and
+    // never marked as orphan. This guards against future path format drift.
+    if (sub.prefixes.length > 0) {
+      logger.warn('[orphan-scanner] Unexpected deeper nesting under receipt prefix', {
+        prefix: prefix.fullPath,
+        deeperPrefixCount: sub.prefixes.length,
+      })
+    }
   }
   return paths
 }
@@ -106,20 +119,33 @@ export async function scanOrphans(groupId: string): Promise<OrphanFile[]> {
 }
 
 /**
- * Delete the given storage paths. Best-effort: each deletion is independent,
- * failures are collected rather than aborting the batch.
+ * Delete the given storage paths. Re-verifies against Firestore immediately
+ * before deletion to skip paths that were adopted by an expense since the scan
+ * (closes the scan→delete race window). Per-file failures are collected rather
+ * than aborting the batch.
  */
-export async function deleteOrphans(paths: string[]): Promise<DeleteOrphansResult> {
+export async function deleteOrphans(
+  groupId: string,
+  paths: string[],
+): Promise<DeleteOrphansResult> {
+  // Safety re-check: refuse to delete anything currently referenced by an expense.
+  const referenced = await collectReferencedPaths(groupId)
+  const stillOrphan: string[] = []
+  const adopted: string[] = []
+  for (const p of paths) {
+    if (referenced.has(p)) adopted.push(p)
+    else stillOrphan.push(p)
+  }
   const results = await Promise.allSettled(
-    paths.map((p) => deleteObject(storageRef(storage, p))),
+    stillOrphan.map((p) => deleteObject(storageRef(storage, p))),
   )
   const succeeded: string[] = []
   const failed: { path: string; error: unknown }[] = []
   for (const [i, r] of results.entries()) {
     if (r.status === 'fulfilled') {
-      succeeded.push(paths[i])
+      succeeded.push(stillOrphan[i])
     } else {
-      failed.push({ path: paths[i], error: r.reason })
+      failed.push({ path: stillOrphan[i], error: r.reason })
     }
   }
   if (failed.length > 0) {
@@ -128,7 +154,12 @@ export async function deleteOrphans(paths: string[]): Promise<DeleteOrphansResul
       failed: failed.length,
     })
   }
-  return { succeeded, failed }
+  if (adopted.length > 0) {
+    logger.warn('[orphan-scanner] Skipped paths adopted between scan and delete', {
+      adoptedCount: adopted.length,
+    })
+  }
+  return { succeeded, failed, adopted }
 }
 
 /** Pure diff helper exposed for unit testing (avoids Storage SDK dependency). */


### PR DESCRIPTION
## Summary

修正 PR #156/#157 merge 後 code-reviewer + security-reviewer 發現的 **2 HIGH + 3 MEDIUM + 1 LOW** 問題。0 CRITICAL，rules 權限模型本身無瑕疵。

## HIGH

- **`listAllReceipts` 深度漂移守衛** — 若未來 Storage 路徑結構出現非預期的第 3 層（目前是 `receipts/{g}/{e}/{file}` 兩層），新增 `logger.warn` 防止靜默漏掃（`orphan-scanner.ts:59`）
- **Storage error UX** — 新增 `mapFirebaseError` helper，把 FirebaseError.code 映射到繁中錯誤訊息（權限不足 / 登入過期 / 網路不穩 / 服務暫不可用），取代一律「掃描失敗」泛訊息（`orphan-cleanup-section.tsx:12`）

## MEDIUM

- **scan→delete race net** — `deleteOrphans` 新增簽名 `(groupId, paths)`，刪除前重跑 `collectReferencedPaths`，若路徑已被新 expense adopt 就跳過並回傳 `adopted[]`，關閉 race window
- **刪除按鈕 concurrency** — 同時 disable 在 `scanning` + `deleting`
- **a11y** — 結果區塊新增 `role="status"` + `aria-live="polite"`
- **i18n nit** — "expense:" → 「費用 ID：」

## 不採納（理由附在 #158）

- **receiptPaths 跨 group 污染**（security reviewer MEDIUM）：實際分析 scanner 只查當前 group expenses，不會污染別組；Firestore rules 不支援 array iteration；Storage rules 獨立 gate 讀取。接受風險。
- **非 owner 不限次 getDocs**：pre-existing

## Verification

- ✅ `npm run build` 通過
- ✅ `npm run test` 345/345 通過（+4 新 `deleteOrphans` 測試：still-orphan / adopted 跳過 / 局部失敗 / legacy path adoption）
- ✅ `npm run lint` 0 errors

## Test plan

- [ ] Owner 登入 settings → 掃描，無孤兒時顯示「✅ 乾淨」
- [ ] 人工製造孤兒 → 掃描 → 同時用另一個瀏覽器把其中一個 path 加入新 expense → 點「刪除全部」 → toast 顯示「跳過 1（已被支出引用）」
- [ ] 斷網模擬 → 掃描 → toast 顯示「網路連線不穩，請稍後重試」（非泛訊息）
- [ ] 掃描進行中「刪除全部」按鈕也 disable
- [ ] 螢幕閱讀器（VoiceOver）：掃描完成後自動朗讀結果

Closes #158
Related: PR #156, PR #157