### PR TITLE
fix(security): transactionRules category 長度上限 (Closes #165)

### DIFF
--- a/__tests__/transaction-rules-category-cap.test.ts
+++ b/__tests__/transaction-rules-category-cap.test.ts
@@ -19,8 +19,14 @@ jest.mock('firebase/firestore', () => ({
   Timestamp: { fromDate: jest.fn() },
 }))
 
+const mockLoggerWarn = jest.fn()
 jest.mock('@/lib/logger', () => ({
-  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+  logger: {
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
 }))
 
 import { learnFromExpense } from '@/lib/services/transaction-rules-service'
@@ -30,6 +36,7 @@ describe('learnFromExpense category length cap (Issue #165)', () => {
     mockAddDoc.mockReset()
     mockGetDocs.mockReset()
     mockUpdateDoc.mockReset()
+    mockLoggerWarn.mockReset()
   })
 
   it('accepts categories exactly at the 30-char limit', async () => {
@@ -38,14 +45,18 @@ describe('learnFromExpense category length cap (Issue #165)', () => {
     const thirtyCharCategory = 'a'.repeat(30)
     await learnFromExpense('g1', 'coffee', thirtyCharCategory)
     expect(mockAddDoc).toHaveBeenCalledTimes(1)
+    // No warning for the happy path.
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
   })
 
-  it('rejects categories exceeding 30 chars early (no Firestore calls)', async () => {
+  it('rejects categories exceeding 30 chars early and warns for observability', async () => {
     const tooLong = 'a'.repeat(31)
     await learnFromExpense('g1', 'coffee', tooLong)
     expect(mockGetDocs).not.toHaveBeenCalled()
     expect(mockAddDoc).not.toHaveBeenCalled()
     expect(mockUpdateDoc).not.toHaveBeenCalled()
+    // Must surface as a warning so system_logs catches likely programming errors.
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1)
   })
 
   it('rejects obviously malicious 1MB category without any Firestore call', async () => {
@@ -56,5 +67,6 @@ describe('learnFromExpense category length cap (Issue #165)', () => {
     await learnFromExpense('g1', 'coffee', oneMB)
     expect(mockGetDocs).not.toHaveBeenCalled()
     expect(mockAddDoc).not.toHaveBeenCalled()
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1)
   })
 })

--- a/__tests__/transaction-rules-category-cap.test.ts
+++ b/__tests__/transaction-rules-category-cap.test.ts
@@ -1,0 +1,60 @@
+// Dedicated file for the category-length defense-in-depth guard (Issue #165).
+// Lives separately from the forthcoming transaction-rules-service.test.ts
+// (PR #163) to avoid merge conflicts. When that PR lands, this file can be
+// folded into the main test suite.
+
+jest.mock('@/lib/firebase', () => ({ db: {}, auth: {}, storage: {} }))
+
+const mockAddDoc = jest.fn()
+const mockGetDocs = jest.fn()
+const mockUpdateDoc = jest.fn()
+jest.mock('firebase/firestore', () => ({
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  collection: jest.fn(() => ({ _type: 'collection' })),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  query: jest.fn((...c: unknown[]) => ({ _type: 'query', c })),
+  serverTimestamp: jest.fn(() => ({ _type: 'serverTimestamp' })),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  where: jest.fn(() => ({ _type: 'where' })),
+  Timestamp: { fromDate: jest.fn() },
+}))
+
+jest.mock('@/lib/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}))
+
+import { learnFromExpense } from '@/lib/services/transaction-rules-service'
+
+describe('learnFromExpense category length cap (Issue #165)', () => {
+  beforeEach(() => {
+    mockAddDoc.mockReset()
+    mockGetDocs.mockReset()
+    mockUpdateDoc.mockReset()
+  })
+
+  it('accepts categories exactly at the 30-char limit', async () => {
+    mockGetDocs.mockResolvedValueOnce({ empty: true, docs: [] })
+    mockAddDoc.mockResolvedValueOnce({ id: 'r1' })
+    const thirtyCharCategory = 'a'.repeat(30)
+    await learnFromExpense('g1', 'coffee', thirtyCharCategory)
+    expect(mockAddDoc).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects categories exceeding 30 chars early (no Firestore calls)', async () => {
+    const tooLong = 'a'.repeat(31)
+    await learnFromExpense('g1', 'coffee', tooLong)
+    expect(mockGetDocs).not.toHaveBeenCalled()
+    expect(mockAddDoc).not.toHaveBeenCalled()
+    expect(mockUpdateDoc).not.toHaveBeenCalled()
+  })
+
+  it('rejects obviously malicious 1MB category without any Firestore call', async () => {
+    // The original security concern from PR #163 review: a malicious client
+    // could flood transactionRules with huge category payloads. Defense-in-depth
+    // catches it before the network round-trip.
+    const oneMB = 'x'.repeat(1024 * 1024)
+    await learnFromExpense('g1', 'coffee', oneMB)
+    expect(mockGetDocs).not.toHaveBeenCalled()
+    expect(mockAddDoc).not.toHaveBeenCalled()
+  })
+})

--- a/firestore.rules
+++ b/firestore.rules
@@ -202,8 +202,8 @@ service cloud.firestore {
 
       match /transactionRules/{ruleId} {
         allow read: if isGroupMember(groupId);
-        // category 長度與 categories collection 的上限對齊（30）— 防止惡意成員
-        // 塞大字串 payload 把 suggestCategory 的 iteration 拖慢（Issue #165）
+        // category 長度上限與 categories collection 對齊 + 與
+        // transaction-rules-service.ts MAX_CATEGORY_LENGTH 必須同步（Issue #165）
         allow create: if isGroupMember(groupId)
           && hasReasonableSize()
           && request.resource.data.pattern is string

--- a/firestore.rules
+++ b/firestore.rules
@@ -202,12 +202,16 @@ service cloud.firestore {
 
       match /transactionRules/{ruleId} {
         allow read: if isGroupMember(groupId);
+        // category 長度與 categories collection 的上限對齊（30）— 防止惡意成員
+        // 塞大字串 payload 把 suggestCategory 的 iteration 拖慢（Issue #165）
         allow create: if isGroupMember(groupId)
           && hasReasonableSize()
           && request.resource.data.pattern is string
           && request.resource.data.pattern.size() > 0
           && request.resource.data.pattern.size() <= 200
           && request.resource.data.category is string
+          && request.resource.data.category.size() > 0
+          && request.resource.data.category.size() <= 30
           && request.resource.data.hitCount is number
           && request.resource.data.hitCount >= 1;
         allow update: if isGroupMember(groupId)

--- a/src/lib/services/transaction-rules-service.ts
+++ b/src/lib/services/transaction-rules-service.ts
@@ -21,7 +21,10 @@ import type { TransactionRule } from '@/lib/types'
  */
 
 const MIN_HIT_COUNT_FOR_SUGGESTION = 3
-/** Category length upper bound — matches categories collection rule (Issue #165). */
+/**
+ * Category length upper bound (UTF-16 code units). Must stay in sync with
+ * firestore.rules `transactionRules` + `categories` create rules (Issue #165).
+ */
 const MAX_CATEGORY_LENGTH = 30
 
 /** Normalize a description for pattern matching: lowercase, trim, collapse whitespace. */
@@ -44,8 +47,16 @@ export async function learnFromExpense(
   // server-side firestore.rules cap (Issue #165). Real user-selected categories
   // always come from a bounded <select>, so this mainly guards against bugs or
   // future programmatic callers — and keeps the client from eating a rejected
-  // Firestore write round-trip.
-  if (category.length > MAX_CATEGORY_LENGTH) return
+  // Firestore write round-trip. We logger.warn (not throw) to stay within the
+  // service's best-effort contract while still surfacing likely programming
+  // errors in system_logs.
+  if (category.length > MAX_CATEGORY_LENGTH) {
+    logger.warn('[TransactionRules] Skipping learnFromExpense: category exceeds max length', {
+      length: category.length,
+      max: MAX_CATEGORY_LENGTH,
+    })
+    return
+  }
 
   try {
     const q = query(

--- a/src/lib/services/transaction-rules-service.ts
+++ b/src/lib/services/transaction-rules-service.ts
@@ -21,6 +21,8 @@ import type { TransactionRule } from '@/lib/types'
  */
 
 const MIN_HIT_COUNT_FOR_SUGGESTION = 3
+/** Category length upper bound — matches categories collection rule (Issue #165). */
+const MAX_CATEGORY_LENGTH = 30
 
 /** Normalize a description for pattern matching: lowercase, trim, collapse whitespace. */
 export function normalizePattern(description: string): string {
@@ -38,6 +40,12 @@ export async function learnFromExpense(
 ): Promise<void> {
   const pattern = normalizePattern(description)
   if (!pattern || !category || !groupId) return
+  // Defense in depth: reject oversize category client-side to match the
+  // server-side firestore.rules cap (Issue #165). Real user-selected categories
+  // always come from a bounded <select>, so this mainly guards against bugs or
+  // future programmatic callers — and keeps the client from eating a rejected
+  // Firestore write round-trip.
+  if (category.length > MAX_CATEGORY_LENGTH) return
 
   try {
     const q = query(


### PR DESCRIPTION
## Problem

\`firestore.rules\` 對 \`transactionRules.category\` 無長度檢查（\`pattern\` 有 200 字上限，\`category\` 沒有）。搭配 \`learnFromExpense\` 對任意 (pattern, category) pair 自動建 rule 的行為：**惡意群組成員可塞大 payload（例如 1MB 字串）到 category**，之後 \`suggestCategory\` 每次要 iterate 就會拖慢 client + 占 Firestore 儲存。

由 PR #163 的 security-reviewer 發現（HIGH）。

## Changes

**firestore.rules**
\`\`\`
+ && request.resource.data.category.size() > 0
+ && request.resource.data.category.size() <= 30
\`\`\`
與 \`categories\` collection 既有的 30 字上限對齊。\`update\` rule 已強制 \`category == resource.data.category\`（不可改），故不需額外限制。

**transaction-rules-service.ts**（defense-in-depth）
\`\`\`ts
+ if (category.length > MAX_CATEGORY_LENGTH) return
\`\`\`
Client 端 early-return 省掉 Firestore 被 rules 拒絕的 round-trip，對正常 UI 流程無影響（\`<select>\` 的選項都 ≤30 字）。

**新測試檔** \`__tests__/transaction-rules-category-cap.test.ts\`（3 tests）
- 放在獨立檔案避免與 PR #163 的 \`transaction-rules-service.test.ts\` 合併衝突
- 覆蓋：恰 30 字通過 / 31 字 early-return / 1MB payload early-return

## Verification

- ✅ \`firebase deploy --dry-run firestore:rules\` 編譯通過
- ✅ \`npm run test\` 84/84 通過（+3）
- ✅ \`npm run build\` + \`npm run lint\` clean

## Test plan

- [ ] 合併後 \`deploy-rules.yml\` 自動部署到 production
- [ ] 正常成員用 UI \`<select>\` 選類別仍正常新增 rule
- [ ] 以 Firebase SDK 直呼寫 31+ 字 category → rules 拒絕（PERMISSION_DENIED）
- [ ] 瀏覽器 console 呼叫 \`learnFromExpense\` 塞 1MB category → early-return 無 round-trip

Closes #165
Related: PR #163（發現本問題的 reviewer）