### PR TITLE
feat(settings): 類別名稱輸入加 maxLength + 字數計數器 (Closes #168)

### DIFF
--- a/src/app/(auth)/settings/categories/page.tsx
+++ b/src/app/(auth)/settings/categories/page.tsx
@@ -66,6 +66,14 @@ export default function CategoriesPage() {
 
   async function handleSave() {
     if (!form.name.trim() || !group) return
+    // Guard for legacy data that may exceed the current cap — maxLength only
+    // prevents further typing, it does not truncate pre-existing values loaded
+    // into the edit form. Without this the write would be silently rejected by
+    // firestore.rules (name.size() <= 30).
+    if (form.name.length > MAX_NAME_LENGTH) {
+      addToast(`名稱不能超過 ${MAX_NAME_LENGTH} 字，目前有 ${form.name.length} 字`, 'warning')
+      return
+    }
     setSaving(true)
     try {
       if (editing?.id) {
@@ -232,7 +240,10 @@ export default function CategoriesPage() {
             <div>
               <div className="flex items-baseline justify-between mb-1">
                 <label htmlFor="category-name-input" className="text-xs text-[var(--muted-foreground)]">名稱</label>
+                {/* 視覺計數器保持靜音，避免每次擊鍵都朗讀；下方獨立 live region 只在
+                    達到上限時公告一次，降低螢幕閱讀器噪音。 */}
                 <span
+                  aria-hidden="true"
                   className="text-xs tabular-nums"
                   style={{
                     color: form.name.length >= MAX_NAME_LENGTH
@@ -241,7 +252,6 @@ export default function CategoriesPage() {
                         ? 'var(--primary)'
                         : 'var(--muted-foreground)',
                   }}
-                  aria-live="polite"
                 >
                   {form.name.length}/{MAX_NAME_LENGTH}
                 </span>
@@ -256,6 +266,9 @@ export default function CategoriesPage() {
                 placeholder="例如：餐飲"
                 autoFocus
               />
+              <span role="status" aria-live="polite" className="sr-only">
+                {form.name.length >= MAX_NAME_LENGTH ? `已達字數上限 ${MAX_NAME_LENGTH} 字` : ''}
+              </span>
             </div>
 
             <div>

--- a/src/app/(auth)/settings/categories/page.tsx
+++ b/src/app/(auth)/settings/categories/page.tsx
@@ -12,6 +12,13 @@ import { useToast } from '@/components/toast'
 
 const ICONS = ['🍜', '🚗', '🛒', '🏠', '💡', '🏥', '🎬', '💰', '📚', '👶', '🧴', '📱', '✈️', '🎁', '其他']
 
+/**
+ * Max UTF-16 units for a category name. Must stay in sync with the
+ * `categories` and `transactionRules` collection rules in firestore.rules
+ * (both enforce `name.size() <= 30` / `category.size() <= 30`).
+ */
+const MAX_NAME_LENGTH = 30
+
 interface CategoryFormData {
   name: string
   icon: string
@@ -223,11 +230,28 @@ export default function CategoriesPage() {
             </h2>
 
             <div>
-              <label className="text-xs text-[var(--muted-foreground)] mb-1 block">名稱</label>
+              <div className="flex items-baseline justify-between mb-1">
+                <label htmlFor="category-name-input" className="text-xs text-[var(--muted-foreground)]">名稱</label>
+                <span
+                  className="text-xs tabular-nums"
+                  style={{
+                    color: form.name.length >= MAX_NAME_LENGTH
+                      ? 'var(--destructive)'
+                      : form.name.length >= MAX_NAME_LENGTH - 3
+                        ? 'var(--primary)'
+                        : 'var(--muted-foreground)',
+                  }}
+                  aria-live="polite"
+                >
+                  {form.name.length}/{MAX_NAME_LENGTH}
+                </span>
+              </div>
               <input
+                id="category-name-input"
                 type="text"
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
+                maxLength={MAX_NAME_LENGTH}
                 className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                 placeholder="例如：餐飲"
                 autoFocus


### PR DESCRIPTION
## Problem

\`settings/categories\` 新增/編輯對話框的名稱輸入框**沒有 maxLength**。使用者可輸入 >30 字，Firestore rules（\`categories\` create rule \`name.size() <= 30\`）會在儲存時靜默拒絕，使用者看到的是「點儲存 → 沒反應」。

由 PR #166 的 code-reviewer 發現為 pre-existing UX gap。為 loop 第 4 次迭代產出。

## Changes

| 改動 | 效果 |
|------|------|
| \`maxLength={30}\` | 瀏覽器直接阻止超字輸入 |
| \`MAX_NAME_LENGTH = 30\` 常數 + JSDoc | 明確記錄必須與 firestore.rules 同步（categories / transactionRules 都用 30）|
| 字數計數器 \`{length}/{MAX}\` | 使用者看得到剩餘空間 |
| 三段顏色 | \< 27: muted; 27–29: primary; = 30: destructive |
| \`htmlFor\` + \`id\` + \`aria-live="polite"\` | a11y：螢幕閱讀器可關聯 label、即時朗讀字數變化 |

## 截圖路徑

- \`src/app/(auth)/settings/categories/page.tsx\`
- 進入路徑：設定 → 類別管理 → 新增類別 / 點既有類別編輯

## Verification

- ✅ \`npm run build\` 通過
- ✅ \`npm run test\` 81/81 通過（無改動測試）
- ✅ \`npm run lint\` 0 errors

## Test plan

- [ ] 打開新增類別對話框 → 輸入超過 30 字 → 瀏覽器阻擋到第 30 字
- [ ] 輸入到第 27 字 → 計數器變 primary 色；第 30 字 → destructive 色
- [ ] 編輯既有類別 → 計數器顯示當前字數
- [ ] 螢幕閱讀器（VoiceOver）：輸入時字數變化會被朗讀

## Scope 說明

**Out of scope**：Members、Groups 等其他同樣 30 字上限欄位有相同 pre-existing 問題，未來可開 umbrella issue 一次處理（或各自開小 PR）。本 PR 只處理 categories。

Closes #168
Related: PR #166（發現此問題的 reviewer）