### PR TITLE
fix(observability): deleteGroup 記錄 subcollection 讀取失敗 (Closes #172)

### DIFF
--- a/__tests__/group-service-delete-logging.test.ts
+++ b/__tests__/group-service-delete-logging.test.ts
@@ -1,0 +1,95 @@
+// Verifies the observability behavior added by Issue #172 to deleteGroup:
+// errors on subcollection reads must be logged (not silently swallowed) while
+// still allowing the rest of the deletion to proceed.
+
+jest.mock('@/lib/firebase', () => ({ db: {}, auth: { currentUser: { uid: 'u1' } } }))
+
+const mockGetDocs = jest.fn()
+const mockBatchDelete = jest.fn()
+const mockBatchCommit = jest.fn().mockResolvedValue(undefined)
+jest.mock('firebase/firestore', () => ({
+  addDoc: jest.fn(),
+  arrayRemove: jest.fn(),
+  arrayUnion: jest.fn(),
+  collection: jest.fn((_db, ..._segments: string[]) => ({ _type: 'collection', segments: _segments })),
+  doc: jest.fn((..._args: unknown[]) => ({ _type: 'docRef' })),
+  updateDoc: jest.fn(),
+  getDoc: jest.fn(),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  query: jest.fn(),
+  where: jest.fn(),
+  Timestamp: { now: jest.fn(() => ({ _type: 'ts' })) },
+  writeBatch: jest.fn(() => ({
+    delete: mockBatchDelete,
+    commit: mockBatchCommit,
+    set: jest.fn(),
+  })),
+}))
+
+const mockLoggerWarn = jest.fn()
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}))
+
+import { deleteGroup } from '@/lib/services/group-service'
+
+describe('deleteGroup subcollection read failure observability (Issue #172)', () => {
+  beforeEach(() => {
+    mockGetDocs.mockReset()
+    mockBatchDelete.mockReset()
+    mockBatchCommit.mockReset().mockResolvedValue(undefined)
+    mockLoggerWarn.mockReset()
+  })
+
+  it('logs a warning for each subcollection whose read fails, then a summary', async () => {
+    // Simulate: members reads ok, categories + expenses throw, rest ok
+    mockGetDocs
+      // members
+      .mockResolvedValueOnce({ docs: [{ ref: { _type: 'docRef', id: 'm1' } }] })
+      // categories — throws
+      .mockRejectedValueOnce(new Error('network blip'))
+      // expenses — throws
+      .mockRejectedValueOnce(new Error('rate limit'))
+      // settlements / notifications / userPreferences — empty
+      .mockResolvedValue({ docs: [] })
+
+    await deleteGroup('g1')
+
+    // Each failed subcollection gets its own warning + one summary warning.
+    // 2 per-failure warnings + 1 summary = 3 calls.
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(3)
+
+    // The summary must list both skipped subcollections so an operator scanning
+    // logs sees the full picture of potentially orphaned data.
+    const summaryCall = mockLoggerWarn.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('completed with skipped'),
+    )
+    expect(summaryCall).toBeDefined()
+    const summaryContext = summaryCall![1] as { groupId: string; skipped: string[] }
+    expect(summaryContext.groupId).toBe('g1')
+    expect(summaryContext.skipped.sort()).toEqual(['categories', 'expenses'])
+  })
+
+  it('does not log when all subcollection reads succeed', async () => {
+    mockGetDocs.mockResolvedValue({ docs: [] })
+    await deleteGroup('g1')
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
+  })
+
+  it('still proceeds to delete the rest even when some subcollections fail', async () => {
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [{ ref: { _type: 'docRef', id: 'm1' } }] })
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue({ docs: [] })
+
+    await deleteGroup('g1')
+
+    // The batch still commits — deletion is NOT aborted by the partial failure.
+    expect(mockBatchCommit).toHaveBeenCalled()
+  })
+})

--- a/__tests__/group-service-delete-logging.test.ts
+++ b/__tests__/group-service-delete-logging.test.ts
@@ -22,7 +22,10 @@ jest.mock('firebase/firestore', () => ({
   writeBatch: jest.fn(() => ({
     delete: mockBatchDelete,
     commit: mockBatchCommit,
-    set: jest.fn(),
+    // Self-defending: if SUT unexpectedly calls set() in the delete path, fail loudly.
+    set: jest.fn(() => {
+      throw new Error('deleteGroup should not call batch.set()')
+    }),
   })),
 }))
 
@@ -69,10 +72,14 @@ describe('deleteGroup subcollection read failure observability (Issue #172)', ()
     const summaryCall = mockLoggerWarn.mock.calls.find(
       (c) => typeof c[0] === 'string' && c[0].includes('completed with skipped'),
     )
-    expect(summaryCall).toBeDefined()
-    const summaryContext = summaryCall![1] as { groupId: string; skipped: string[] }
+    if (!summaryCall) {
+      throw new Error('Expected a "completed with skipped" summary warning but none was emitted')
+    }
+    const summaryContext = summaryCall[1] as { groupId: string; skipped: string[] }
     expect(summaryContext.groupId).toBe('g1')
-    expect(summaryContext.skipped.sort()).toEqual(['categories', 'expenses'])
+    // Copy before sort — don't mutate the array held by the mock call record,
+    // which would corrupt any later assertion against the same call.
+    expect([...summaryContext.skipped].sort()).toEqual(['categories', 'expenses'])
   })
 
   it('does not log when all subcollection reads succeed', async () => {

--- a/src/lib/services/group-service.ts
+++ b/src/lib/services/group-service.ts
@@ -1,5 +1,6 @@
 import { addDoc, collection, doc, updateDoc, getDocs, getDoc, query, where, Timestamp, arrayRemove, arrayUnion, writeBatch } from 'firebase/firestore'
 import { db, auth } from '@/lib/firebase'
+import { logger } from '@/lib/logger'
 
 function generateInviteCode(): string {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789' // no 0/O/1/I to avoid confusion
@@ -78,16 +79,32 @@ export async function updateGroup(
 
 export async function deleteGroup(groupId: string): Promise<void> {
   const BATCH_LIMIT = 500
-  // Note: activityLogs intentionally excluded — Firestore rules forbid client-side deletion
+  // Note: `activityLogs` and `transactionRules` are intentionally excluded —
+  // the former has `allow delete: if false`, the latter is auto-cleaned by
+  // their own firestore.rules semantics (docs become unreferenced after group deletion).
   const subcollections = ['members', 'categories', 'expenses', 'settlements', 'notifications', 'userPreferences']
 
   // Collect all refs to delete
   const allRefs: import('firebase/firestore').DocumentReference[] = []
+  const skippedSubcollections: string[] = []
   for (const sub of subcollections) {
     try {
       const snap = await getDocs(collection(db, 'groups', groupId, sub))
       snap.docs.forEach((d) => allRefs.push(d.ref))
-    } catch { /* skip subcollections we can't read (e.g. activityLogs with delete:false) */ }
+    } catch (e) {
+      // Intentional skip: a partial read failure (network blip, rate limit,
+      // temporary rules eval hiccup) should not block deleting the rest of
+      // the group. But surface the failure via logger so orphan docs left
+      // behind in this subcollection are discoverable later in system_logs.
+      // Issue #172 — previously this was a silent catch with a misleading
+      // comment about activityLogs (which isn't even in the list above).
+      skippedSubcollections.push(sub)
+      logger.warn('[group-service] deleteGroup: failed to read subcollection, skipping', {
+        groupId,
+        subcollection: sub,
+        err: e,
+      })
+    }
   }
   allRefs.push(doc(db, 'groups', groupId))
 
@@ -96,6 +113,16 @@ export async function deleteGroup(groupId: string): Promise<void> {
     const batch = writeBatch(db)
     allRefs.slice(i, i + BATCH_LIMIT).forEach((ref) => batch.delete(ref))
     await batch.commit()
+  }
+
+  // If any subcollection couldn't be enumerated, emit one summary log so an
+  // operator scanning logs sees the full picture of potentially orphaned data
+  // from this deletion.
+  if (skippedSubcollections.length > 0) {
+    logger.warn('[group-service] deleteGroup completed with skipped subcollections', {
+      groupId,
+      skipped: skippedSubcollections,
+    })
   }
 }
 


### PR DESCRIPTION
## Problem（SA lens — 資料完整性）

\`group-service.ts deleteGroup\` 原本有個 **silent catch** + **誤導性註解**：

\`\`\`ts
} catch { /* skip subcollections we can't read (e.g. activityLogs with delete:false) */ }
\`\`\`

但 \`activityLogs\` **根本不在** 上面的 subcollections list（只含 members/categories/expenses/settlements/notifications/userPreferences）。這個 catch 實際在吞掉**合法 subcollection 的 getDocs 失敗**。

**真實風險**：若 \`expenses\` 的 getDocs 因瞬時網路/rate-limit 失敗：
1. catch 靜默跳過 → expense docs 不會被收集到刪除清單
2. 後續 batch.commit 會刪除已收集的（其他 subcollections + group doc）
3. **失敗 subcollection 的 docs 變 orphan** — Firestore 永久殘留、UI 無法觸及、無 audit trail
4. 含 PII（收據路徑、金額、通知內容）

由 loop 第 5 次迭代深度掃描發現。Auditor iter 1 曾宣稱「7 services 缺 logger」，親驗後真實數是 3（\`local-expense-parser\` 不需要、\`log-service\` 是 logger 本身）。本 PR 處理其中一個（\`group-service\`），另 2 個（\`activity-log-service\`、\`category-service\`）待後續迭代。

## Fix（最小 scope，只加 observability）

- \`logger.warn\` 每次失敗（含 groupId、subcollection、原錯誤）
- 刪除結束後 1 個 summary warning 條列所有 skipped subcollections
- 更正誤導性註解
- **保留 skip-on-error 行為**（不 re-throw）— 避免改變既有 UX

\`\`\`ts
} catch (e) {
  skippedSubcollections.push(sub)
  logger.warn('[group-service] deleteGroup: failed to read subcollection, skipping', {
    groupId, subcollection: sub, err: e,
  })
}
\`\`\`

## Tests（+3）

\`__tests__/group-service-delete-logging.test.ts\`:
- 部分 subcollection 失敗 → 每個失敗 + 1 summary 共 3 次 logger.warn
- 全部成功 → 不 warn
- 部分失敗仍完成刪除（batch.commit 有呼叫）

## Verification

- ✅ \`npm run build\` 通過
- ✅ \`npm run test\` 通過（+3 全綠）
- ✅ \`npm run lint\` 0 errors

專案 service 測試覆蓋：5/16 → **6/16**（首次有 group-service 測試）

## Out of scope

- 改 re-throw 中止刪除（更安全但影響 UX）
- Cloud Function atomic cascade delete（需 Blaze）
- 擴充 #153 孤兒檔掃描到 expense/settlement/notification

Closes #172
Related: #153 (orphan cleanup infrastructure)