### PR TITLE
fix(security): transaction-rules SUT 對 auth errors re-throw (Closes #164)

### DIFF
--- a/__tests__/transaction-rules-service.test.ts
+++ b/__tests__/transaction-rules-service.test.ts
@@ -23,6 +23,7 @@ import {
   normalizePattern,
   learnFromExpense,
   suggestCategory,
+  isAuthError,
   TRANSACTION_RULE_MIN_HITS,
 } from '@/lib/services/transaction-rules-service'
 
@@ -236,5 +237,81 @@ describe('suggestCategory', () => {
   it('swallows Firestore errors and returns null', async () => {
     mockGetDocs.mockRejectedValueOnce(new Error('firestore unavailable'))
     await expect(suggestCategory('g1', 'coffee')).resolves.toBeNull()
+  })
+
+  // --- Issue #164: re-throw auth errors -----------------------------------
+
+  it('re-throws Firebase PERMISSION_DENIED (Issue #164)', async () => {
+    const err = Object.assign(new Error('permission denied'), { code: 'permission-denied' })
+    mockGetDocs.mockRejectedValueOnce(err)
+    await expect(suggestCategory('g1', 'coffee')).rejects.toBe(err)
+  })
+
+  it('re-throws Firebase UNAUTHENTICATED (Issue #164)', async () => {
+    const err = Object.assign(new Error('unauthenticated'), { code: 'unauthenticated' })
+    mockGetDocs.mockRejectedValueOnce(err)
+    await expect(suggestCategory('g1', 'coffee')).rejects.toBe(err)
+  })
+})
+
+// --- isAuthError -----------------------------------------------------------
+
+describe('isAuthError', () => {
+  it('returns true for permission-denied code', () => {
+    expect(isAuthError({ code: 'permission-denied' })).toBe(true)
+  })
+
+  it('returns true for unauthenticated code', () => {
+    expect(isAuthError({ code: 'unauthenticated' })).toBe(true)
+  })
+
+  it('returns false for unrelated Firestore codes', () => {
+    expect(isAuthError({ code: 'unavailable' })).toBe(false)
+    expect(isAuthError({ code: 'not-found' })).toBe(false)
+  })
+
+  it('returns false for non-objects', () => {
+    expect(isAuthError(null)).toBe(false)
+    expect(isAuthError(undefined)).toBe(false)
+    expect(isAuthError('permission-denied')).toBe(false)
+    expect(isAuthError(42)).toBe(false)
+  })
+
+  it('returns false for Error without code', () => {
+    expect(isAuthError(new Error('boom'))).toBe(false)
+  })
+
+  it('returns false for object with non-string code', () => {
+    expect(isAuthError({ code: 403 })).toBe(false)
+  })
+})
+
+// --- learnFromExpense auth re-throw ---------------------------------------
+
+describe('learnFromExpense auth re-throw (Issue #164)', () => {
+  beforeEach(() => {
+    mockAddDoc.mockReset()
+    mockGetDocs.mockReset()
+    mockUpdateDoc.mockReset()
+  })
+
+  it('re-throws PERMISSION_DENIED on getDocs path', async () => {
+    const err = Object.assign(new Error('permission denied'), { code: 'permission-denied' })
+    mockGetDocs.mockRejectedValueOnce(err)
+    await expect(learnFromExpense('g1', 'coffee', '餐飲')).rejects.toBe(err)
+  })
+
+  it('re-throws UNAUTHENTICATED on addDoc path', async () => {
+    mockGetDocs.mockResolvedValueOnce({ empty: true, docs: [] })
+    const err = Object.assign(new Error('session gone'), { code: 'unauthenticated' })
+    mockAddDoc.mockRejectedValueOnce(err)
+    await expect(learnFromExpense('g1', 'coffee', '餐飲')).rejects.toBe(err)
+  })
+
+  it('still swallows non-auth errors (best-effort contract preserved)', async () => {
+    mockGetDocs.mockRejectedValueOnce(
+      Object.assign(new Error('network blip'), { code: 'unavailable' }),
+    )
+    await expect(learnFromExpense('g1', 'coffee', '餐飲')).resolves.toBeUndefined()
   })
 })

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/lib/services/image-upload'
 import { buildEqualSplits } from '@/lib/services/split-calculator'
 import { addRecurringExpense } from '@/lib/services/recurring-expense-service'
-import { learnFromExpense, suggestCategory } from '@/lib/services/transaction-rules-service'
+import { learnFromExpense, suggestCategory, isAuthError } from '@/lib/services/transaction-rules-service'
 import { useAuth, getActor } from '@/lib/auth'
 import { toDate } from '@/lib/utils'
 import { saveButtonLabel, type UploadProgress } from '@/lib/save-button-label'
@@ -299,7 +299,15 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
             setAutoCategoryFilled(true)
           }
         })
-        .catch(() => { /* silent */ })
+        .catch((e) => {
+          // Auth errors surface to system_logs so ops can see session/membership
+          // issues; the main expense save path will also fail visibly in that
+          // state, so no inline toast needed here. Non-auth errors stay silent
+          // (best-effort suggestion). Issue #164.
+          if (isAuthError(e)) {
+            logger.error('[ExpenseForm] suggestCategory auth error', e)
+          }
+        })
     }, 300)
     return () => { clearTimeout(handle); cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -501,7 +509,11 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         }).catch(() => { /* silent — template creation is non-critical */ })
       }
       // Learn from this save to improve future auto-categorization
-      learnFromExpense(group.id, input.description, input.category).catch(() => { /* silent */ })
+      learnFromExpense(group.id, input.description, input.category).catch((e) => {
+        // Auth errors go to system_logs (Issue #164); other errors stay silent
+        // since rule learning is best-effort and must never block save UX.
+        if (isAuthError(e)) logger.error('[ExpenseForm] learnFromExpense auth error', e)
+      })
       // Clear draft after successful save
       if (draftKey && typeof window !== 'undefined') {
         sessionStorage.removeItem(draftKey)

--- a/src/components/quick-add-bar.tsx
+++ b/src/components/quick-add-bar.tsx
@@ -9,7 +9,7 @@ import { useCurrentMember } from '@/lib/hooks/use-current-member'
 import { useAuth } from '@/lib/auth'
 import { addExpense, type ExpenseInput } from '@/lib/services/expense-service'
 import { parseExpense } from '@/lib/services/local-expense-parser'
-import { learnFromExpense, suggestCategory } from '@/lib/services/transaction-rules-service'
+import { learnFromExpense, suggestCategory, isAuthError } from '@/lib/services/transaction-rules-service'
 import { useToast } from '@/components/toast'
 import { logger } from '@/lib/logger'
 
@@ -53,7 +53,15 @@ export function QuickAddBar() {
               setAutoFilled(true)
             }
           })
-          .catch(() => { /* silent */ })
+          .catch((e) => {
+            // Auth errors (PERMISSION_DENIED / UNAUTHENTICATED) surface as toast —
+            // the user likely needs to re-auth or has lost group membership. Other
+            // errors remain silent (best-effort suggestion). Issue #164.
+            if (isAuthError(e)) {
+              logger.error('[QuickAdd] suggestCategory auth error', e)
+              addToast('登入狀態失效，請重新整理或重新登入', 'error')
+            }
+          })
       }
     }
   }
@@ -114,8 +122,15 @@ export function QuickAddBar() {
     setSaving(true)
     try {
       await addExpense(group.id, input, { id: payerId, name: payerName })
-      // Learn the (description, category) pair for future auto-fill suggestions
-      learnFromExpense(group.id, description.trim(), input.category).catch(() => { /* silent */ })
+      // Learn the (description, category) pair for future auto-fill suggestions.
+      // Non-fatal by design — except for auth errors, which surface to the user
+      // so they can re-authenticate (Issue #164).
+      learnFromExpense(group.id, description.trim(), input.category).catch((e) => {
+        if (isAuthError(e)) {
+          logger.error('[QuickAdd] learnFromExpense auth error', e)
+          addToast('登入狀態失效，規則學習已停止', 'warning')
+        }
+      })
       addToast(`已記錄 ${description.trim()} $${amt}`, 'success')
       setDescription('')
       setAmount('')

--- a/src/lib/services/transaction-rules-service.ts
+++ b/src/lib/services/transaction-rules-service.ts
@@ -83,7 +83,11 @@ export async function learnFromExpense(
       })
     }
   } catch (e) {
-    // Non-fatal: rule learning is best-effort, don't block the expense save path
+    // Auth errors (PERMISSION_DENIED / UNAUTHENTICATED) must not be silently
+    // swallowed — the caller may need to trigger a re-auth or membership flow.
+    // Everything else (network blips, rate limits) stays best-effort.
+    // Issue #164.
+    if (isAuthError(e)) throw e
     logger.warn('[TransactionRules] Failed to learn rule:', e)
   }
 }
@@ -127,6 +131,7 @@ export async function suggestCategory(
     }
     return best?.category ?? null
   } catch (e) {
+    if (isAuthError(e)) throw e
     logger.warn('[TransactionRules] Failed to fetch suggestion:', e)
     return null
   }
@@ -145,3 +150,27 @@ export const TRANSACTION_RULE_MIN_HITS = MIN_HIT_COUNT_FOR_SUGGESTION
 
 // Re-export Timestamp for test utilities if needed
 export { Timestamp }
+
+/**
+ * Firebase Firestore error codes that indicate the current session cannot
+ * perform the operation regardless of retries — either the user lost
+ * membership, was signed out, or the security rules reject the request.
+ * These must not be swallowed by the best-effort contract; the caller
+ * needs to know so it can surface a re-auth / membership prompt.
+ *
+ * Reference: https://firebase.google.com/docs/reference/js/firestore_.firestoreerror
+ * Issue #164.
+ */
+const AUTH_ERROR_CODES = new Set(['permission-denied', 'unauthenticated'])
+
+/**
+ * Returns true if `err` is a Firebase auth/permission error that should NOT
+ * be silently swallowed (e.g. PERMISSION_DENIED / UNAUTHENTICATED). Non-auth
+ * errors (network blips, rate limits) remain best-effort and are swallowed
+ * by the caller.
+ */
+export function isAuthError(err: unknown): boolean {
+  if (err === null || typeof err !== 'object') return false
+  const code = (err as { code?: unknown }).code
+  return typeof code === 'string' && AUTH_ERROR_CODES.has(code)
+}


### PR DESCRIPTION
## Problem

\`transaction-rules-service\` 的 \`learnFromExpense\` / \`suggestCategory\` catch block 無條件吞掉所有 Firebase 錯誤，**Firebase PERMISSION_DENIED / UNAUTHENTICATED 完全隱形**。使用者被移出群組或 session 過期時，client 持續發起請求但永遠沒有 re-auth prompt。

由 PR #163 的 security-reviewer 發現（HIGH）。

## Changes

### SUT（\`src/lib/services/transaction-rules-service.ts\`）
- 公開新 helper \`isAuthError(err)\` — 檢測 \`'permission-denied'\` / \`'unauthenticated'\` code
- 兩個 catch block 加早退：\`if (isAuthError(e)) throw e\` — 其他錯誤（\`unavailable\`, 網路短暫失敗）仍 best-effort 吞掉

### Callers
- \`quick-add-bar.tsx\`：兩處 \`.catch()\` 從 silent 改為 \`isAuthError\` 分流，auth error → \`logger.error\` + 紅色 toast「登入狀態失效，請重新整理或重新登入」
- \`expense-form.tsx\`：兩處同樣邏輯，用 \`logger.error\` 進 system_logs（本檔沒 toast 系統，避免引入新依賴；主 expense save path 會自己冒 auth error 給使用者看）

## Tests（+11）

\`__tests__/transaction-rules-service.test.ts\`:
- \`isAuthError\` 6 案例（true/false/null/non-object/missing code/non-string code）
- \`suggestCategory\` 兩個 re-throw case（permission-denied, unauthenticated）
- \`learnFromExpense\` 三個：getDocs re-throw、addDoc re-throw、non-auth 仍吞

總測試 **120 → 131 pass**

## Verification

- ✅ \`npm run build\` 通過
- ✅ \`npm run test\` 131/131 通過
- ✅ \`npm run lint\` 0 errors

## Test plan

- [ ] 成員正常 Firestore auth：規則學習/建議行為不變
- [ ] 成員被群組 owner 移出後仍留在頁面：下次 \`learnFromExpense\` 應在 toast 顯示「登入狀態失效」
- [ ] Firebase emulator 模擬 \`unavailable\` code：catch 吞掉無 toast（best-effort）

Closes #164
Related: PR #163（發現問題的 reviewer）