### PR TITLE
fix(infra): deploy-rules.yml 加 pre-flight + post-deploy 驗證 (Closes #169)

### DIFF
--- a/.github/workflows/deploy-rules.yml
+++ b/.github/workflows/deploy-rules.yml
@@ -24,6 +24,21 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
+      # Pre-flight: fail fast with a clear message if the secret is missing or empty.
+      # Previously surfaced as a cryptic "Failed to authenticate" deep in the
+      # deploy step. Issue #169.
+      - name: Verify FIREBASE_DEPLOY_TOKEN is set
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_DEPLOY_TOKEN }}
+        run: |
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "::error::FIREBASE_DEPLOY_TOKEN secret is missing or empty."
+            echo "::error::To regenerate: run 'firebase login:ci' locally, add output"
+            echo "::error::as a repo secret at Settings → Secrets → Actions."
+            echo "::error::Manual fallback: firebase deploy --only firestore:rules,storage"
+            exit 1
+          fi
+
       - name: Deploy Firestore Rules
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_DEPLOY_TOKEN }}
@@ -33,3 +48,22 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_DEPLOY_TOKEN }}
         run: firebase deploy --only storage:rules --project family-ledger-784ed
+
+      # Post-deploy smoke: pull the live rules back and check they look sane.
+      # Catches silent partial deploys or wrong project. Issue #169.
+      - name: Verify deployed rules are non-empty
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_DEPLOY_TOKEN }}
+        run: |
+          LIVE_RULES=$(firebase firestore:rules get --project family-ledger-784ed 2>/dev/null || true)
+          if [ -z "$LIVE_RULES" ]; then
+            echo "::error::Post-deploy verification failed: could not fetch live rules."
+            echo "::error::Deploy may have succeeded but the live state is unreadable."
+            exit 1
+          fi
+          # Sanity check: live content should contain the rules_version marker
+          if ! echo "$LIVE_RULES" | grep -q "rules_version"; then
+            echo "::error::Live rules do not contain 'rules_version' — deploy likely malformed."
+            exit 1
+          fi
+          echo "✓ Post-deploy verification passed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,16 @@ Tailwind CSS v4 with CSS custom properties defined in `globals.css`. Key variabl
 - Database: Firestore (localized in Taiwan)
 - Storage: Receipt image uploads
 
+### Rules Deploy
+
+- CI workflow: `.github/workflows/deploy-rules.yml` — auto-deploys `firestore.rules` / `storage.rules` when they change on `main`. Requires `FIREBASE_DEPLOY_TOKEN` secret.
+- **Manual fallback** (if the workflow fails — see Issue #169):
+  ```bash
+  firebase deploy --only firestore:rules,storage --project family-ledger-784ed
+  ```
+- **Regenerate CI token** when expired: `firebase login:ci` locally, paste output into repo Settings → Secrets and variables → Actions → `FIREBASE_DEPLOY_TOKEN`.
+- Workflow now has a pre-flight check that fails with a clear instruction if the secret is missing, and a post-deploy smoke that verifies the live rules are non-empty.
+
 ## Testing
 
 ### Unit Tests


### PR DESCRIPTION
## Problem

\`.github/workflows/deploy-rules.yml\` 在 #156/#157 合併後兩次 silent failure（見 issue #169）：

1. \`FIREBASE_DEPLOY_TOKEN\` secret 空值
2. Firebase CLI 回錯訊息「\`Failed to authenticate, have you run firebase login?\`」深埋輸出
3. **無 post-deploy 驗證** — 即使部署 step 跳過，workflow 還是「成功」結束

結果：rules 程式碼進了 main 但沒上線，老闆手動 deploy 才生效。

## Fix（additive，不動既有邏輯）

### Pre-flight 檢查
在 deploy steps 之前插入 \`Verify FIREBASE_DEPLOY_TOKEN is set\`，空值時用 \`::error::\` 註解**清楚列出**：
- 怎麼 regenerate token（\`firebase login:ci\`）
- 去哪設 secret（Settings → Secrets → Actions）
- 手動 fallback 命令

### Post-deploy 驗證
部署完成後拉回 live rules（\`firebase firestore:rules get\`），檢查：
- 內容非空
- 含 \`rules_version\` marker

任何檢查失敗 → workflow 失敗 → GitHub 自動發 email / notification。

### 文件
CLAUDE.md 新增 **Rules Deploy** 小節，記錄 manual fallback 命令 + token 更新步驟 + 新檢查的存在。

## 仍需老闆手動處理

**本 PR 無法修的部分**：Claude 沒權限設 GitHub repo secret。要完全修好 #169：
1. 老闆本機跑 \`firebase login:ci\`
2. 複製輸出貼到 repo Settings → Secrets → Actions → \`FIREBASE_DEPLOY_TOKEN\`
3. 下次 rules PR 合併 → workflow 自動驗證新 token 有效

## Scope 控制（遵守 loop 指示）

- ❌ 沒升級 firebase-tools 版本（仍用 v15 的 \`FIREBASE_TOKEN\` 流程）
- ❌ 沒改用 Workload Identity Federation（下一階段，需 GCP 設定）
- ❌ 沒改用 service account JSON（長期 secret 風險不比現狀低）
- ✅ 純 additive：既有 step 完全沒變，只在前後加檢查

## Verification

- ✅ \`npm run test\` 120/120 通過
- ✅ \`npm run build\` 通過
- workflow 本身要到 merge + 下次 rules PR 才會實測

Closes #169
Related: issue #156/#157 的 silent failure runs