### PR TITLE
feat(settings): transactionRules 手動清理工具 (Closes #167)

### DIFF
--- a/__tests__/transaction-rules-prune.test.ts
+++ b/__tests__/transaction-rules-prune.test.ts
@@ -1,0 +1,142 @@
+// Dedicated file for pruneStaleRules (Issue #167), separate from the main
+// transaction-rules-service.test.ts to limit merge conflicts.
+
+jest.mock('@/lib/firebase', () => ({ db: {}, auth: {}, storage: {} }))
+
+const mockGetDocs = jest.fn()
+const mockDeleteDoc = jest.fn()
+jest.mock('firebase/firestore', () => ({
+  addDoc: jest.fn(),
+  collection: jest.fn(() => ({ _type: 'collection' })),
+  deleteDoc: (...args: unknown[]) => mockDeleteDoc(...args),
+  doc: jest.fn((..._args: unknown[]) => ({ _type: 'docRef' })),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  query: jest.fn(),
+  serverTimestamp: jest.fn(),
+  updateDoc: jest.fn(),
+  where: jest.fn(),
+  Timestamp: { fromDate: jest.fn() },
+}))
+
+jest.mock('@/lib/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}))
+
+import {
+  pruneStaleRules,
+  TRANSACTION_RULE_MIN_HITS,
+  STALE_RULE_DAYS,
+} from '@/lib/services/transaction-rules-service'
+
+/** Build a fake Firestore timestamp that survives toMillis(). */
+function ts(date: Date) {
+  return { toMillis: () => date.getTime() }
+}
+
+describe('pruneStaleRules (Issue #167)', () => {
+  beforeEach(() => {
+    mockGetDocs.mockReset()
+    mockDeleteDoc.mockReset()
+  })
+
+  function stubRules(rules: Array<{ id: string; hitCount: number; lastUsed: Date }>) {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: rules.map((r) => ({
+        id: r.id,
+        data: () => ({
+          pattern: 'p',
+          category: 'c',
+          hitCount: r.hitCount,
+          lastUsed: ts(r.lastUsed),
+          createdAt: ts(r.lastUsed),
+        }),
+      })),
+    })
+  }
+
+  it('returns an empty result for empty groupId without touching Firestore', async () => {
+    const r = await pruneStaleRules('')
+    expect(r).toEqual({ scanned: 0, pruned: 0, kept: 0, failed: 0 })
+    expect(mockGetDocs).not.toHaveBeenCalled()
+  })
+
+  it('prunes only rules that are BOTH below threshold AND older than cutoff', async () => {
+    const NOW = Date.now()
+    const oldIdle = new Date(NOW - (STALE_RULE_DAYS + 10) * 86400000)
+    const recentIdle = new Date(NOW - 5 * 86400000)
+
+    stubRules([
+      { id: 'r1', hitCount: 1, lastUsed: oldIdle }, // prune
+      { id: 'r2', hitCount: 2, lastUsed: oldIdle }, // prune (< threshold of 3)
+      { id: 'r3', hitCount: TRANSACTION_RULE_MIN_HITS, lastUsed: oldIdle }, // KEEP — active
+      { id: 'r4', hitCount: 1, lastUsed: recentIdle }, // KEEP — recent
+      { id: 'r5', hitCount: TRANSACTION_RULE_MIN_HITS + 10, lastUsed: oldIdle }, // KEEP — active, high count
+    ])
+    mockDeleteDoc.mockResolvedValue(undefined)
+
+    const result = await pruneStaleRules('g1')
+
+    expect(result.scanned).toBe(5)
+    expect(result.pruned).toBe(2)
+    expect(result.kept).toBe(3)
+    expect(result.failed).toBe(0)
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(2)
+  })
+
+  it('NEVER prunes rules at or above the suggestion threshold regardless of age', async () => {
+    // Rule hitCount == threshold, idle for 1000 days — still kept.
+    const veryOld = new Date(Date.now() - 1000 * 86400000)
+    stubRules([
+      { id: 'r1', hitCount: TRANSACTION_RULE_MIN_HITS, lastUsed: veryOld },
+    ])
+    const result = await pruneStaleRules('g1')
+    expect(result.pruned).toBe(0)
+    expect(result.kept).toBe(1)
+    expect(mockDeleteDoc).not.toHaveBeenCalled()
+  })
+
+  it('counts per-deletion failures without aborting', async () => {
+    const oldIdle = new Date(Date.now() - (STALE_RULE_DAYS + 10) * 86400000)
+    stubRules([
+      { id: 'r1', hitCount: 1, lastUsed: oldIdle },
+      { id: 'r2', hitCount: 1, lastUsed: oldIdle },
+    ])
+    mockDeleteDoc
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined)
+    const result = await pruneStaleRules('g1')
+    expect(result.pruned).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(result.kept).toBe(0) // 2 scanned, 1 pruned, 1 failed → 0 kept
+  })
+
+  it('re-throws Firebase auth errors from deleteDoc', async () => {
+    const oldIdle = new Date(Date.now() - (STALE_RULE_DAYS + 10) * 86400000)
+    stubRules([{ id: 'r1', hitCount: 1, lastUsed: oldIdle }])
+    const authErr = Object.assign(new Error('denied'), { code: 'permission-denied' })
+    mockDeleteDoc.mockRejectedValueOnce(authErr)
+    await expect(pruneStaleRules('g1')).rejects.toBe(authErr)
+  })
+
+  it('handles missing lastUsed (legacy data) by treating it as very old', async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [{
+        id: 'r1',
+        data: () => ({ pattern: 'p', category: 'c', hitCount: 1 }),
+      }],
+    })
+    mockDeleteDoc.mockResolvedValue(undefined)
+    const result = await pruneStaleRules('g1')
+    // Missing lastUsed → lastUsedMs = 0, which is older than any cutoff → prune.
+    expect(result.pruned).toBe(1)
+  })
+
+  it('honors a custom staleDays parameter', async () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 86400000)
+    stubRules([{ id: 'r1', hitCount: 1, lastUsed: twoDaysAgo }])
+    // With 1-day cutoff, r1 IS stale (2 > 1).
+    mockDeleteDoc.mockResolvedValue(undefined)
+    const result = await pruneStaleRules('g1', 1)
+    expect(result.pruned).toBe(1)
+  })
+})

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -15,6 +15,7 @@ import { addActivityLog } from '@/lib/services/activity-log-service'
 import { useRouter } from 'next/navigation'
 import { BudgetSection } from '@/components/budget-section'
 import { OrphanCleanupSection } from '@/components/orphan-cleanup-section'
+import { RuleCleanupSection } from '@/components/rule-cleanup-section'
 import type { FamilyMember, Category } from '@/lib/types'
 
 import { useToast } from '@/components/toast'
@@ -710,6 +711,12 @@ export default function SettingsPage() {
         {group && user?.uid === group.ownerUid && (
           <Section title="🧹 收據檔案維護">
             <OrphanCleanupSection groupId={group.id} />
+          </Section>
+        )}
+
+        {group && user?.uid === group.ownerUid && (
+          <Section title="🧼 分類規則清理">
+            <RuleCleanupSection groupId={group.id} />
           </Section>
         )}
 

--- a/src/components/rule-cleanup-section.tsx
+++ b/src/components/rule-cleanup-section.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState } from 'react'
+import { pruneStaleRules, STALE_RULE_DAYS, isAuthError } from '@/lib/services/transaction-rules-service'
+import { useToast } from '@/components/toast'
+import { logger } from '@/lib/logger'
+
+interface RuleCleanupSectionProps {
+  groupId: string
+}
+
+/**
+ * Owner-facing admin tool that prunes inactive transaction rules — rules that
+ * never reached the suggestion threshold and have not been touched in
+ * STALE_RULE_DAYS days. Mitigation for Issue #167 (transactionRules can't be
+ * size-capped at the rules layer).
+ */
+export function RuleCleanupSection({ groupId }: RuleCleanupSectionProps) {
+  const [running, setRunning] = useState(false)
+  const [lastResult, setLastResult] = useState<{
+    scanned: number
+    pruned: number
+    kept: number
+    failed: number
+  } | null>(null)
+  const { addToast } = useToast()
+
+  async function handlePrune() {
+    if (!confirm(`確定要清理 ${STALE_RULE_DAYS} 天以上未被使用、也沒累積到建議門檻的分類規則？\n此操作無法復原，但您日後記帳會重新學習。`)) {
+      return
+    }
+    setRunning(true)
+    try {
+      const result = await pruneStaleRules(groupId)
+      setLastResult(result)
+      if (result.scanned === 0) {
+        addToast('目前沒有分類規則', 'success')
+      } else if (result.pruned === 0) {
+        addToast(`掃描 ${result.scanned} 筆，沒有需要清理的規則`, 'success')
+      } else {
+        const msg = result.failed > 0
+          ? `已清理 ${result.pruned} 筆、${result.failed} 筆失敗`
+          : `已清理 ${result.pruned} 筆，保留 ${result.kept} 筆有效規則`
+        addToast(msg, result.failed > 0 ? 'warning' : 'success')
+      }
+    } catch (e) {
+      logger.error('[RuleCleanup] pruneStaleRules failed', e)
+      if (isAuthError(e)) {
+        addToast('權限不足，請確認您仍是群組成員', 'error')
+      } else {
+        addToast('清理失敗，請稍後重試', 'error')
+      }
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-[var(--muted-foreground)]">
+        智慧分類規則會在使用者重複記同樣的描述＋類別達 3 次後自動建議類別。
+        但只記一、兩次沒達門檻的組合會一直累積。本工具會清理超過 {STALE_RULE_DAYS} 天沒用、
+        且還沒達建議門檻的規則（已生效的規則不會被刪）。
+      </p>
+
+      <div className="flex gap-2">
+        <button
+          onClick={handlePrune}
+          disabled={running}
+          className="px-4 py-2 rounded-lg text-sm font-medium border border-[var(--border)] hover:bg-[var(--muted)] disabled:opacity-50 transition-colors"
+        >
+          {running ? '清理中…' : '清理過期規則'}
+        </button>
+      </div>
+
+      <div role="status" aria-live="polite" className="space-y-1">
+        {lastResult && (
+          <div className="text-xs text-[var(--muted-foreground)] space-y-0.5">
+            <div>掃描：{lastResult.scanned} 筆</div>
+            <div>已清理：{lastResult.pruned} 筆</div>
+            <div>保留：{lastResult.kept} 筆</div>
+            {lastResult.failed > 0 && (
+              <div className="text-[var(--destructive)]">失敗：{lastResult.failed} 筆（可再執行一次）</div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/services/transaction-rules-service.ts
+++ b/src/lib/services/transaction-rules-service.ts
@@ -1,6 +1,8 @@
 import {
   addDoc,
   collection,
+  deleteDoc,
+  doc,
   getDocs,
   query,
   serverTimestamp,
@@ -138,12 +140,75 @@ export async function suggestCategory(
 }
 
 /**
- * List all rules for a group (for debug / future settings UI).
- * Not used in current flow but exported for completeness.
+ * List all rules for a group (for debug / settings UI).
  */
 export async function listRules(groupId: string): Promise<TransactionRule[]> {
   const snap = await getDocs(collection(db, 'groups', groupId, 'transactionRules'))
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as TransactionRule)
+}
+
+/** Default staleness cutoff for pruneStaleRules, in days. */
+export const STALE_RULE_DAYS = 90
+
+export interface PruneResult {
+  scanned: number
+  pruned: number
+  kept: number
+  /** Rules skipped because deletion failed (e.g. transient network). */
+  failed: number
+}
+
+/**
+ * Prune rules that have never reached the suggestion threshold AND have been
+ * idle for `staleDays` days. Active learned rules (hitCount >= threshold) are
+ * preserved regardless of age — those are actual user learning.
+ *
+ * This is the after-the-fact mitigation for Issue #167 (per-group doc count
+ * flood): Firestore rules cannot cap collection size, so we give the owner a
+ * cleanup tool analogous to the orphan receipt cleanup (#157).
+ *
+ * Caller must be group owner — enforced by firestore.rules
+ * `transactionRules` delete rule (already requires isGroupMember).
+ */
+export async function pruneStaleRules(
+  groupId: string,
+  staleDays = STALE_RULE_DAYS,
+): Promise<PruneResult> {
+  if (!groupId) return { scanned: 0, pruned: 0, kept: 0, failed: 0 }
+  const cutoffMs = Date.now() - staleDays * 24 * 60 * 60 * 1000
+  const rules = await listRules(groupId)
+  let pruned = 0
+  let failed = 0
+  await Promise.all(
+    rules.map(async (r) => {
+      const hitCount = typeof r.hitCount === 'number' ? r.hitCount : 0
+      const lastUsedMs = r.lastUsed?.toMillis?.() ?? 0
+      // Conservative: only delete rules that never activated AND are old.
+      // Active rules with hitCount >= threshold are the user's real learning
+      // and must never be auto-pruned.
+      if (hitCount >= MIN_HIT_COUNT_FOR_SUGGESTION) return
+      if (lastUsedMs > cutoffMs) return
+      try {
+        await deleteDoc(doc(db, 'groups', groupId, 'transactionRules', r.id))
+        pruned++
+      } catch (e) {
+        // Permission errors should surface so the UI can prompt for re-auth
+        // (consistent with #164). Other errors are counted as failures and the
+        // prune continues — mirrors orphan-scanner's delete-best-effort pattern.
+        if (isAuthError(e)) throw e
+        failed++
+        logger.warn('[TransactionRules] pruneStaleRules: failed to delete rule', {
+          ruleId: r.id, err: e,
+        })
+      }
+    }),
+  )
+  return {
+    scanned: rules.length,
+    pruned,
+    kept: rules.length - pruned - failed,
+    failed,
+  }
 }
 
 export const TRANSACTION_RULE_MIN_HITS = MIN_HIT_COUNT_FOR_SUGGESTION


### PR DESCRIPTION
## Problem

Firestore security rules **無法表達 per-group 文件數量上限**。PR #166 已限每筆 \`transactionRules.category\` ≤ 30 字，但成員仍可呼叫 \`learnFromExpense\` 塞任意多組 (pattern, category) 組合進 collection，長期累積下來：
- 儲存成本上升
- \`suggestCategory\` iteration 變慢
- 真的不活躍的 rule 混在裡面干擾正常學習

由 PR #163 security-reviewer 發現（HIGH residual，本 PR 的 after-the-fact 緩解）。

## Solution：Owner 手動清理工具

類似 #153 孤兒收據檔清理的做法，給 group owner 在 settings 按一下清理工具，刪除：

- \`hitCount < 3\`（從未達建議門檻）
- **且** \`lastUsed\` 早於 90 天前（STALE_RULE_DAYS）

**已活化的規則（hitCount ≥ 3）無論多久沒碰都不刪** — 那是使用者真實的學習，不能毀。

## Changes

**Service** (\`transaction-rules-service.ts\`):
- \`STALE_RULE_DAYS = 90\` + \`PruneResult\` interface
- \`pruneStaleRules(groupId, staleDays?)\`：併行 deleteDoc + 失敗收集
- 永遠不刪已活化的 rule（防呆最重要）
- \`permission-denied\` / \`unauthenticated\` re-throw 讓 UI 可 prompt re-auth

**UI** (\`rule-cleanup-section.tsx\`):
- Owner-only 卡片，confirm dialog → prune → toast 顯示結果
- aria-live 區顯示 \`scanned / pruned / kept / failed\` 統計

**Settings** 頁新增 \`🧼 分類規則清理\` section（OrphanCleanupSection 下方）。

## Tests（+7）

- 空 groupId no-op
- threshold + 時間雙條件過濾
- **已達門檻永不刪**（1000 天舊也保留）
- 部分失敗不中止
- permission-denied re-throw
- 無 lastUsed 的 legacy doc → 視為超舊 → 刪
- 客製 \`staleDays\` 參數生效

**總測試 120 → 127 pass**

## Out of Scope（更強的 mitigation）

- Cloud Function 自動定期清理（需 Blaze 計費）
- Firestore counter doc + 原子 transaction（fragile + 複雜度高）
- 客戶端 throttle（易被繞過）

## Verification

- ✅ \`npm run build\` 通過
- ✅ \`npm run test\` 127/127 通過
- ✅ \`npm run lint\` 0 errors

## Test plan

- [ ] Owner 登入 settings 可看到「分類規則清理」卡片
- [ ] 非 owner 成員看不到此卡片
- [ ] 首次點執行：confirm dialog → 結果顯示 scanned/pruned/kept
- [ ] 連續點多次：第二次 scanned 一樣但 pruned=0（因為已刪過）
- [ ] 製造 hitCount=5 但 lastUsed=1 年前的 rule → 不會被刪

Closes #167
Related: PR #163（發現本問題）、PR #157（類似手動清理模式）