### PR TITLE
fix(observability): error boundaries 寫入 system_logs (Closes #177)

### DIFF
--- a/__tests__/error-boundary-context.test.ts
+++ b/__tests__/error-boundary-context.test.ts
@@ -1,0 +1,41 @@
+import { buildBoundaryLogContext } from '@/lib/error-boundary-context'
+
+describe('buildBoundaryLogContext', () => {
+  it('extracts digest, message, stack from a Next.js boundary error', () => {
+    const err = Object.assign(new Error('boom'), { digest: 'abc123' })
+    err.stack = 'Error: boom\n    at foo.ts:10'
+    const ctx = buildBoundaryLogContext(err)
+    expect(ctx).toEqual({
+      digest: 'abc123',
+      message: 'boom',
+      stack: 'Error: boom\n    at foo.ts:10',
+    })
+  })
+
+  it('handles errors without a digest (plain Error cast to boundary shape)', () => {
+    const err = new Error('no-digest') as Error & { digest?: string }
+    const ctx = buildBoundaryLogContext(err)
+    expect(ctx.digest).toBeUndefined()
+    expect(ctx.message).toBe('no-digest')
+  })
+
+  it('handles errors without a stack', () => {
+    const err = Object.assign(new Error('no-stack'), { digest: 'd1' })
+    err.stack = undefined
+    const ctx = buildBoundaryLogContext(err)
+    expect(ctx.stack).toBeUndefined()
+  })
+
+  it('does NOT include pathname — that is captured by log-service `location.href`', () => {
+    // Regression guard: log-service already writes window.location.href; adding
+    // pathname here would double-store the same data and could drift over time.
+    const err = Object.assign(new Error('x'), { digest: 'd' })
+    const ctx = buildBoundaryLogContext(err)
+    expect(ctx).not.toHaveProperty('pathname')
+  })
+
+  it('produces a plain JSON-serializable object (for Firestore write)', () => {
+    const err = Object.assign(new Error('plain'), { digest: 'd' })
+    expect(() => JSON.stringify(buildBoundaryLogContext(err))).not.toThrow()
+  })
+})

--- a/src/app/(auth)/error.tsx
+++ b/src/app/(auth)/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import { logger } from '@/lib/logger'
+import { buildBoundaryLogContext } from '@/lib/error-boundary-context'
 
 export default function AuthError({
   error,
@@ -11,15 +12,11 @@ export default function AuthError({
   reset: () => void
 }) {
   // Forward the uncaught error to system_logs so the owner can diagnose from
-  // /settings/logs. UI below intentionally shows only `digest` to avoid leaking
-  // stack details to the end user. Issue #177.
+  // /settings/logs. UI below shows only `digest` to avoid leaking stack details
+  // to the end user. Log-service's rate limiter (MAX_WRITES_PER_MINUTE) caps
+  // Firestore writes if a crash loop re-fires this effect. Issue #177.
   useEffect(() => {
-    logger.error('[ErrorBoundary:auth] Uncaught error', {
-      digest: error.digest,
-      message: error.message,
-      stack: error.stack,
-      pathname: typeof window !== 'undefined' ? window.location.pathname : '',
-    })
+    logger.error('[ErrorBoundary:auth] Uncaught error', buildBoundaryLogContext(error))
   }, [error])
 
   return (

--- a/src/app/(auth)/error.tsx
+++ b/src/app/(auth)/error.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import { useEffect } from 'react'
+import { logger } from '@/lib/logger'
+
 export default function AuthError({
   error,
   reset,
@@ -7,6 +10,18 @@ export default function AuthError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  // Forward the uncaught error to system_logs so the owner can diagnose from
+  // /settings/logs. UI below intentionally shows only `digest` to avoid leaking
+  // stack details to the end user. Issue #177.
+  useEffect(() => {
+    logger.error('[ErrorBoundary:auth] Uncaught error', {
+      digest: error.digest,
+      message: error.message,
+      stack: error.stack,
+      pathname: typeof window !== 'undefined' ? window.location.pathname : '',
+    })
+  }, [error])
+
   return (
     <div className="min-h-screen flex items-center justify-center p-8">
       <div className="max-w-sm w-full text-center space-y-4">

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import './globals.css'
+import { useEffect } from 'react'
+import { logger } from '@/lib/logger'
 
 export default function GlobalError({
   error,
@@ -9,6 +11,18 @@ export default function GlobalError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  // Forward the uncaught root-level error to system_logs. See (auth)/error.tsx
+  // for the per-route boundary; this one catches crashes that bubble past the
+  // root layout (e.g., Providers throwing). Issue #177.
+  useEffect(() => {
+    logger.error('[ErrorBoundary:root] Uncaught error', {
+      digest: error.digest,
+      message: error.message,
+      stack: error.stack,
+      pathname: typeof window !== 'undefined' ? window.location.pathname : '',
+    })
+  }, [error])
+
   return (
     <html lang="zh-TW">
       <body>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -3,6 +3,7 @@
 import './globals.css'
 import { useEffect } from 'react'
 import { logger } from '@/lib/logger'
+import { buildBoundaryLogContext } from '@/lib/error-boundary-context'
 
 export default function GlobalError({
   error,
@@ -11,16 +12,13 @@ export default function GlobalError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
-  // Forward the uncaught root-level error to system_logs. See (auth)/error.tsx
-  // for the per-route boundary; this one catches crashes that bubble past the
-  // root layout (e.g., Providers throwing). Issue #177.
+  // Forward the uncaught root-level error to system_logs. Caveat: if the crash
+  // happens before Firebase auth hydrates, firestore.rules require `isSignedIn()`
+  // for system_logs writes — the write is silently rejected (log-service catch
+  // swallows it). Accepted trade-off per Issue #177; a bespoke auth-free log
+  // endpoint would need infrastructure beyond this fix's scope.
   useEffect(() => {
-    logger.error('[ErrorBoundary:root] Uncaught error', {
-      digest: error.digest,
-      message: error.message,
-      stack: error.stack,
-      pathname: typeof window !== 'undefined' ? window.location.pathname : '',
-    })
+    logger.error('[ErrorBoundary:root] Uncaught error', buildBoundaryLogContext(error))
   }, [error])
 
   return (

--- a/src/lib/error-boundary-context.ts
+++ b/src/lib/error-boundary-context.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure helper: build the log payload for Next.js error boundaries.
+ *
+ * Extracted so the build logic is unit-testable without needing a React render
+ * harness (the project has no @testing-library/react yet). Also keeps the two
+ * boundary components (auth/error.tsx, global-error.tsx) DRY — they only differ
+ * in the log prefix string.
+ *
+ * Note: `pathname` is NOT included here — `log-service.writeSystemLog` already
+ * captures `window.location.href` (which subsumes pathname + query). Adding
+ * pathname separately would duplicate and could drift.
+ *
+ * Known limitation (Issue #177 comment): `global-error.tsx` runs before the
+ * root providers mount. If it fires before Firebase auth is ready,
+ * `isSignedIn()` in firestore.rules will be false → the system_logs write is
+ * silently rejected by rules. Accepted trade-off: error-boundary logs are
+ * best-effort; a root crash early in boot is rare and hard to observe server-
+ * side without a bespoke auth-free logging endpoint.
+ */
+export interface BoundaryErrorLogContext {
+  digest?: string
+  message: string
+  stack?: string
+}
+
+export function buildBoundaryLogContext(
+  error: Error & { digest?: string },
+): BoundaryErrorLogContext {
+  return {
+    digest: error.digest,
+    message: error.message,
+    stack: error.stack,
+  }
+}


### PR DESCRIPTION
## Problem

Next.js 的兩個 error boundary（\`(auth)/error.tsx\`、\`global-error.tsx\`）收到 uncaught error 時只顯示 digest 給使用者，**完全沒呼叫 \`logger.error\`**。結果：

| 角色 | 看到什麼 |
|------|---------|
| 使用者 | 「載入失敗」+ digest 雜湊 → 沒辦法描述、沒辦法 report |
| Group owner | \`/settings/logs\` 空白 → 零線索 |
| Dev | Firestore 無歷史 → 無法 post-mortem |

基礎設施（\`logger.error → system_logs\` in production）**早就就位**，只差 boundary 沒接上。

## Changes（最小 scope）

兩個 boundary 各加一個 \`useEffect\` 在 mount 時 \`logger.error\`：

\`\`\`tsx
useEffect(() => {
  logger.error('[ErrorBoundary:auth] Uncaught error', {
    digest: error.digest,
    message: error.message,
    stack: error.stack,
    pathname: typeof window !== 'undefined' ? window.location.pathname : '',
  })
}, [error])
\`\`\`

**UI 維持不變** — 仍然只顯示 digest 給使用者，stack 只寫進 Firestore。避免 stack traces leak 到前端。

## Security

- \`system_logs\` 的 firestore.rules 已 gate：\`allow read: if resource.data.userId == request.auth.uid\` — 使用者只能讀自己的 log
- Stack traces / error messages 不會在 UI 顯示，只寫後端
- 不新增攻擊面

## Tests

未新增 render test：專案沒有 \`@testing-library/react\` 基礎設施，依 loop scope 「不升級/新增主要依賴」。Diff 非常小（兩個 useEffect + import），self-evident。未來若建立 render test infra，可補「boundary mount 時 logger.error 被呼叫 1 次且 payload 含預期欄位」。

## Verification

- ✅ \`npm run build\` 通過
- ✅ \`npm run lint\` 0 errors
- ✅ \`npm run test\` 138/138 通過（無 regression）

## Test plan

- [ ] 人工觸發 error（例如 suspense throw）→ \`/settings/logs\` 應看到 \`[ErrorBoundary:auth] Uncaught error\` 項目
- [ ] \`digest\` 值 UI 顯示 = system_logs 紀錄值
- [ ] 使用者畫面不變（只顯示 digest，不顯示 message / stack）

Closes #177