### PR TITLE
fix(home): 全部確認按鈕加 loading + 並行 + 錯誤回饋 (Closes #179)

### DIFF
--- a/__tests__/pending-confirmation.test.ts
+++ b/__tests__/pending-confirmation.test.ts
@@ -1,0 +1,82 @@
+import {
+  filterConfirmable,
+  summarizeConfirmResults,
+  confirmToastFromSummary,
+} from '@/lib/pending-confirmation'
+
+describe('filterConfirmable', () => {
+  it('keeps positive-amount entries', () => {
+    expect(filterConfirmable([
+      { id: 'a', amount: 100 },
+      { id: 'b', amount: 0.01 },
+    ])).toHaveLength(2)
+  })
+
+  it('drops zero-amount entries', () => {
+    const out = filterConfirmable([
+      { id: 'a', amount: 100 },
+      { id: 'b', amount: 0 },
+      { id: 'c', amount: 50 },
+    ])
+    expect(out.map((e) => e.id)).toEqual(['a', 'c'])
+  })
+
+  it('drops negative-amount entries (defensive)', () => {
+    expect(filterConfirmable([
+      { id: 'a', amount: -50 },
+      { id: 'b', amount: 100 },
+    ])).toEqual([{ id: 'b', amount: 100 }])
+  })
+
+  it('returns empty for empty input', () => {
+    expect(filterConfirmable([])).toEqual([])
+  })
+})
+
+describe('summarizeConfirmResults', () => {
+  function ok(): PromiseSettledResult<unknown> { return { status: 'fulfilled', value: undefined } }
+  function fail(): PromiseSettledResult<unknown> { return { status: 'rejected', reason: new Error('x') } }
+
+  it('counts all-success', () => {
+    expect(summarizeConfirmResults([ok(), ok(), ok()])).toEqual({ total: 3, ok: 3, fail: 0 })
+  })
+
+  it('counts all-failure', () => {
+    expect(summarizeConfirmResults([fail(), fail()])).toEqual({ total: 2, ok: 0, fail: 2 })
+  })
+
+  it('counts mixed', () => {
+    expect(summarizeConfirmResults([ok(), fail(), ok()])).toEqual({ total: 3, ok: 2, fail: 1 })
+  })
+
+  it('handles empty (degenerate)', () => {
+    expect(summarizeConfirmResults([])).toEqual({ total: 0, ok: 0, fail: 0 })
+  })
+})
+
+describe('confirmToastFromSummary', () => {
+  it('returns null when nothing was attempted', () => {
+    expect(confirmToastFromSummary({ total: 0, ok: 0, fail: 0 })).toBeNull()
+  })
+
+  it('returns success message when all OK', () => {
+    expect(confirmToastFromSummary({ total: 3, ok: 3, fail: 0 })).toEqual({
+      message: '已確認 3 筆定期支出',
+      level: 'success',
+    })
+  })
+
+  it('returns warning message when some failed', () => {
+    expect(confirmToastFromSummary({ total: 5, ok: 3, fail: 2 })).toEqual({
+      message: '已確認 3 筆，2 筆失敗（請稍後重試）',
+      level: 'warning',
+    })
+  })
+
+  it('returns warning when ALL failed (still actionable: user knows nothing succeeded)', () => {
+    expect(confirmToastFromSummary({ total: 2, ok: 0, fail: 2 })).toEqual({
+      message: '已確認 0 筆，2 筆失敗（請稍後重試）',
+      level: 'warning',
+    })
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -15,6 +15,12 @@ import { WeeklyDigest } from '@/components/weekly-digest'
 import { BudgetProgress } from '@/components/budget-progress'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { logger } from '@/lib/logger'
+import { useToast } from '@/components/toast'
+import {
+  filterConfirmable,
+  summarizeConfirmResults,
+  confirmToastFromSummary,
+} from '@/lib/pending-confirmation'
 
 function NoGroupView() {
   const [code, setCode] = useState('')
@@ -70,6 +76,8 @@ export default function HomePage() {
   const { expenses, loading: expLoading } = useExpenses()
   const { settlements } = useSettlements()
   const { members, loading: membersLoading } = useMembers()
+  const { addToast } = useToast()
+  const [confirmingPending, setConfirmingPending] = useState(false)
 
   const monthly = useMonthlyExpenses(expenses)
   const recent = useRecentExpenses(expenses, 5)
@@ -79,13 +87,41 @@ export default function HomePage() {
   // Pending confirmation: auto-generated recurring expenses
   const pendingExpenses = useMemo(() => expenses.filter((e) => e.pendingConfirm), [expenses])
 
+  /**
+   * Confirm all pending auto-generated expenses in parallel. Issue #179.
+   * Replaces a serial for-loop that had no loading state, no error feedback,
+   * and silently swallowed mid-loop failures.
+   */
+  async function handleConfirmAllPending() {
+    if (!group?.id || confirmingPending) return
+    const confirmable = filterConfirmable(pendingExpenses)
+    if (confirmable.length === 0) return
+    setConfirmingPending(true)
+    try {
+      const results = await Promise.allSettled(
+        confirmable.map((e) => confirmPendingExpense(group.id, e.id)),
+      )
+      const summary = summarizeConfirmResults(results)
+      const toast = confirmToastFromSummary(summary)
+      if (toast) addToast(toast.message, toast.level)
+      // logger.error captures rejection details for /settings/logs
+      for (const r of results) {
+        if (r.status === 'rejected') {
+          logger.error('[Home] confirmPendingExpense failed', r.reason)
+        }
+      }
+    } finally {
+      setConfirmingPending(false)
+    }
+  }
+
   // Trigger recurring expense generation on page load
   useEffect(() => {
     if (!group?.id) return
     generatePendingRecurring(group.id).catch((err) =>
       logger.error('[Home] recurring generation failed:', err),
     )
-  }, [group?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [group?.id])
 
   const now = new Date()
   const monthLabel = `${now.getFullYear()}年 ${now.getMonth() + 1}月`
@@ -122,16 +158,12 @@ export default function HomePage() {
             <p className="text-xs text-[var(--muted-foreground)]">點擊確認或前往記錄頁檢視</p>
           </div>
           <button
-            onClick={async () => {
-              for (const e of pendingExpenses) {
-                if (e.amount > 0) {
-                  await confirmPendingExpense(group!.id, e.id)
-                }
-              }
-            }}
-            className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium text-white"
+            onClick={handleConfirmAllPending}
+            disabled={confirmingPending}
+            aria-busy={confirmingPending}
+            className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium text-white disabled:opacity-50"
             style={{ backgroundColor: 'var(--primary)' }}>
-            全部確認
+            {confirmingPending ? '確認中…' : '全部確認'}
           </button>
           <button
             onClick={() => router.push('/records')}

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -104,11 +104,15 @@ export default function HomePage() {
       const summary = summarizeConfirmResults(results)
       const toast = confirmToastFromSummary(summary)
       if (toast) addToast(toast.message, toast.level)
-      // logger.error captures rejection details for /settings/logs
-      for (const r of results) {
-        if (r.status === 'rejected') {
-          logger.error('[Home] confirmPendingExpense failed', r.reason)
-        }
+      // Aggregate rejections into a single logger.error so the log-service
+      // rate limiter (MAX_WRITES_PER_MINUTE) doesn't silently drop entries
+      // 31..N if a catastrophic outage causes many simultaneous failures.
+      if (summary.fail > 0) {
+        logger.error('[Home] confirmPendingExpense batch failures', {
+          failed: summary.fail,
+          total: summary.total,
+          reasons: results.flatMap((r) => (r.status === 'rejected' ? [String(r.reason)] : [])),
+        })
       }
     } finally {
       setConfirmingPending(false)

--- a/src/lib/pending-confirmation.ts
+++ b/src/lib/pending-confirmation.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure helpers for the home-page "全部確認" pending recurring expense flow.
+ * Extracted from app/(auth)/page.tsx so the filter + result-summary logic is
+ * testable without React render infrastructure (Issue #179).
+ */
+
+export interface PendingExpense {
+  id: string
+  amount: number
+}
+
+/**
+ * Filter the pending list to those that are actually confirmable. Today this
+ * just drops zero-amount entries (those should be cleaned up via /records, not
+ * silently confirmed). Centralized so future rules (e.g. negative amounts,
+ * future-dated entries) are added in one place.
+ */
+export function filterConfirmable<T extends PendingExpense>(pending: readonly T[]): T[] {
+  return pending.filter((e) => e.amount > 0)
+}
+
+export interface ConfirmSummary {
+  total: number
+  ok: number
+  fail: number
+}
+
+/**
+ * Summarize Promise.allSettled results from parallel confirmPendingExpense calls.
+ */
+export function summarizeConfirmResults(
+  results: readonly PromiseSettledResult<unknown>[],
+): ConfirmSummary {
+  const ok = results.filter((r) => r.status === 'fulfilled').length
+  return { total: results.length, ok, fail: results.length - ok }
+}
+
+/**
+ * Map a confirm summary to the user-facing toast args. Returns null when
+ * nothing was attempted (so the caller can skip showing a toast).
+ */
+export function confirmToastFromSummary(
+  summary: ConfirmSummary,
+): { message: string; level: 'success' | 'warning' } | null {
+  if (summary.total === 0) return null
+  if (summary.fail === 0) {
+    return { message: `已確認 ${summary.ok} 筆定期支出`, level: 'success' }
+  }
+  return {
+    message: `已確認 ${summary.ok} 筆，${summary.fail} 筆失敗（請稍後重試）`,
+    level: 'warning',
+  }
+}


### PR DESCRIPTION
## Problem

首頁定期支出待確認區的「全部確認」按鈕（\`(auth)/page.tsx:124-135\`）有四項 UX 問題：

1. **串行 await**：5 筆 pending = 5 × Firestore latency（~2.5 秒）乾等
2. **無 loading state**：button 文字不變、不 disable，可重複點擊觸發多次
3. **無錯誤處理**：\`for\` 迴圈中任一筆 throw 會中斷，前面成功的不 rollback，使用者完全沒看到 toast / error
4. **無成功 toast**：確認後只能靠紅點消失推測

每天可能會碰的首頁流程，daily-friction 等級。

## Changes

### `src/app/(auth)/page.tsx`
- 抽 \`handleConfirmAllPending\` 函式，使用 \`Promise.allSettled\` 並行
- \`confirmingPending\` state → button disabled + \`aria-busy\` + 「確認中…」label
- 完成後 \`addToast\` 顯示「已確認 N 筆」/「已確認 X 筆，N 筆失敗」
- 失敗 \`logger.error\` 進 system_logs 留 audit trail
- 順手刪除 lint 抱怨的 unused \`eslint-disable\` directive

### `src/lib/pending-confirmation.ts` (new)
抽 3 個純 helper 讓單元測試可寫（無 React render infra）：
- \`filterConfirmable\`：positive-amount 過濾
- \`summarizeConfirmResults\`：Promise.allSettled 結果歸納
- \`confirmToastFromSummary\`：summary → toast args / null

### Tests (+12)
\`__tests__/pending-confirmation.test.ts\`：filter（正/零/負/空）/ summarize（全成/全敗/混合/空）/ toast（空/全成/部分失敗/全失敗）

**總測試 138 → 150 pass**

## Verification

- ✅ \`npm run build\` 通過
- ✅ \`npm run test\` 150/150 通過
- ✅ \`npm run lint\` 0 errors（含順手清掉的 unused directive）

## Test plan

- [ ] 製造 3 筆 pendingConfirm expense → 點「全部確認」→ 看到「確認中…」短暫顯示 → toast「已確認 3 筆」
- [ ] 模擬中途失敗（offline + 點擊）→ toast「已確認 X 筆，N 筆失敗」
- [ ] 螢幕閱讀器：button \`aria-busy=true\` 在點擊期間
- [ ] 多次快速點擊：only first 觸發實際呼叫

Closes #179