### PR TITLE
fix(ux): split 頁面單筆轉帳/刪除結算補上 toast 回饋 (Closes #183)

### DIFF
--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -174,8 +174,12 @@ export default function SplitPage() {
     setDeletingId(id)
     try {
       await deleteSettlement(group.id, id, currentMember ? { id: currentMember.id, name: currentMember.name } : undefined)
+      // Success feedback — destructive, money-adjacent operation, user needs
+      // explicit confirmation. Issue #183.
+      addToast('已刪除結算紀錄', 'success')
     } catch (e) {
       logger.error('[SplitPage] Failed to delete settlement:', e)
+      addToast('刪除失敗，請稍後再試', 'error')
     } finally {
       setDeletingId(null)
     }
@@ -192,6 +196,10 @@ export default function SplitPage() {
 
   async function handleSettle(data: { fromId: string; toId: string; amount: number; note: string; date: Date }) {
     if (!group) return
+    // Success path only — the SettleDialog's own try/catch surfaces errors
+    // inline; we close the dialog + toast on success so the user sees
+    // confirmation without having to watch the Firestore subscription update.
+    // Issue #183.
     await addSettlement(group.id, {
       fromMemberId: data.fromId,
       fromMemberName: nameMap[data.fromId] ?? data.fromId,
@@ -202,6 +210,7 @@ export default function SplitPage() {
       date: data.date,
     }, getActor(user))
     setSettling(null)
+    addToast('已記錄轉帳', 'success')
   }
 
   function buildShareText() {


### PR DESCRIPTION
## Problem

Split 頁（\`src/app/(auth)/split/page.tsx\`）是家庭帳本**金錢紀錄核心路徑**，但兩個 handler 操作成功時完全沒有回饋：

| Handler | 成功路徑 | 失敗路徑 |
|---------|---------|---------|
| \`handleSettle\`（單筆轉帳） | Dialog 關閉、無 toast | SettleDialog 內部 try/catch 處理 ✓ |
| \`handleDeleteSettlement\` | **無 toast** | 只 logger.error、**無 toast** |

使用者對「這筆錢有沒有記下來/刪掉」產生不安 — 典型 daily-friction，且此流程涉及金錢計算，使用者特別敏感。

## Changes（最小 scope）

| Handler | 加了什麼 |
|---------|---------|
| \`handleSettle\` | ✅ \`addToast('已記錄轉帳', 'success')\` on success |
| \`handleDeleteSettlement\` | ✅ \`addToast('已刪除結算紀錄', 'success')\` on success <br> ✅ \`addToast('刪除失敗，請稍後再試', 'error')\` on catch |

**沒動**的部分：
- \`handleSettleAll\` — 已有 toast + logger
- SettleDialog 內部 error 處理 — 已完整，避免 double-toast
- settlement-service 單元測試 — 另案（settlement-service 0 tests，值得另開）

## Verification

- ✅ \`npm run build\` 通過
- ✅ \`npm run test\` 138/138 通過（無 regression）
- ✅ \`npm run lint\` 0 errors

## Test plan

- [ ] 點「記錄轉帳」按鈕 → 填資料 → 確認 → 看到「已記錄轉帳」toast
- [ ] 記錄失敗（手動觸發 permission error） → dialog 內部紅字錯誤仍在，不會雙 toast
- [ ] 刪除結算紀錄 → confirm → 看到「已刪除結算紀錄」toast
- [ ] 刪除失敗 → 看到「刪除失敗，請稍後再試」紅色 toast + system_logs 有 audit

Closes #183