### PR TITLE
feat(records): 預設當月 + 月份分頁導覽 (Closes #185)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,41 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Family expense sharing app (家計本) built with Next.js App Router, React 19, TypeScript, and Firebase. Supports shared expense tracking, automatic split calculation, debt simplification, and real-time sync across family members.
 
+## ⚠ 重要警告：此 cwd 是 PM2 的 live-serve 路徑
+
+**此專案目錄（`/Users/openclaw/.openclaw/shared/projects/family-ledger-web`）同時是 PM2 `family-ledger-web` 的 production serve cwd**（port 3013，Tailscale 上家人在用）。
+
+任何會寫入 `.next/` 的命令會**立即影響生產使用者**：
+
+| 命令 | 在此 cwd 安全嗎？ |
+|------|----------------|
+| `npm run lint` / `npm test` / `npx tsc --noEmit` | ✅ 唯讀，安全 |
+| `npm run build` / `npm run dev` / `npm run start` | ❌ **會覆蓋 `.next/`**，PM2 的 server process 記憶體仍持舊 chunk 參考 → 使用者看到 chunk 404 → 「載入失敗」error boundary |
+| `npm ci` / `npm install` | ⚠️ 寫 `node_modules`，native addon 或熱重載模組可能 break |
+
+**正確做法**：debug 或 build 請用 worktree：
+```bash
+git worktree add ../family-ledger-debug main
+cd ../family-ledger-debug
+npm run build  # 安全，自己的 .next，不碰 prod
+```
+
+若必須在此 cwd build：`pm2 stop family-ledger-web && npm run build && pm2 restart family-ledger-web`。
+
+此規則的血淚來源：2026-04-18 在此 cwd 跑 `npm run build` 除錯，反而直接造成 production 「新增支出載入失敗」。
+
 ## Commands
 
 ```bash
+# 唯讀（safe in this cwd）
+npm run lint     # ESLint check
+npm run test     # Jest unit tests
+npx playwright test  # E2E tests (requires Auth emulator)
+
+# 寫入 .next（在此 cwd 等同 deploy — 見上方警告）
 npm run dev      # Start development server (Turbopack)
 npm run build    # Production build
 npm run start    # Start production server
-npm run lint     # ESLint check
-npm run test     # Jest unit tests (42 tests)
-npx playwright test  # E2E tests (54 tests, 20 passing, 34 require Auth)
 ```
 
 ## Tech Stack

--- a/__tests__/month-nav.test.ts
+++ b/__tests__/month-nav.test.ts
@@ -1,0 +1,135 @@
+import {
+  monthRange,
+  currentMonthRange,
+  shiftMonth,
+  parseYearMonth,
+  isExactMonth,
+  isCurrentMonth,
+  formatMonthLabel,
+} from '@/lib/month-nav'
+
+describe('monthRange', () => {
+  it('returns first and last day of a 30-day month', () => {
+    expect(monthRange(2026, 4)).toEqual({
+      year: 2026, month: 4, start: '2026-04-01', end: '2026-04-30',
+    })
+  })
+
+  it('returns first and last day of a 31-day month', () => {
+    expect(monthRange(2026, 1)).toEqual({
+      year: 2026, month: 1, start: '2026-01-01', end: '2026-01-31',
+    })
+  })
+
+  it('handles February 28 in non-leap year', () => {
+    expect(monthRange(2025, 2)).toMatchObject({ start: '2025-02-01', end: '2025-02-28' })
+  })
+
+  it('handles February 29 in leap year', () => {
+    expect(monthRange(2024, 2)).toMatchObject({ start: '2024-02-01', end: '2024-02-29' })
+  })
+
+  it('handles December (last month of year)', () => {
+    expect(monthRange(2026, 12)).toMatchObject({ start: '2026-12-01', end: '2026-12-31' })
+  })
+})
+
+describe('currentMonthRange', () => {
+  it('uses today by default', () => {
+    const r = currentMonthRange(new Date(2026, 3, 18)) // April 18, 2026
+    expect(r).toMatchObject({ year: 2026, month: 4, start: '2026-04-01', end: '2026-04-30' })
+  })
+})
+
+describe('shiftMonth', () => {
+  it('shifts forward one month', () => {
+    expect(shiftMonth(2026, 4, 1)).toMatchObject({ year: 2026, month: 5 })
+  })
+
+  it('shifts backward one month', () => {
+    expect(shiftMonth(2026, 4, -1)).toMatchObject({ year: 2026, month: 3 })
+  })
+
+  it('wraps across year boundary going back from January', () => {
+    expect(shiftMonth(2026, 1, -1)).toMatchObject({ year: 2025, month: 12 })
+  })
+
+  it('wraps across year boundary going forward from December', () => {
+    expect(shiftMonth(2026, 12, 1)).toMatchObject({ year: 2027, month: 1 })
+  })
+
+  it('handles large delta (shift 14 months forward from Jan)', () => {
+    expect(shiftMonth(2026, 1, 14)).toMatchObject({ year: 2027, month: 3 })
+  })
+
+  it('delta = 0 returns same month', () => {
+    expect(shiftMonth(2026, 4, 0)).toMatchObject({ year: 2026, month: 4 })
+  })
+})
+
+describe('parseYearMonth', () => {
+  it('parses a valid ISO date', () => {
+    expect(parseYearMonth('2026-04-01')).toEqual({ year: 2026, month: 4 })
+  })
+
+  it('returns null for empty string', () => {
+    expect(parseYearMonth('')).toBeNull()
+  })
+
+  it('returns null for malformed input', () => {
+    expect(parseYearMonth('04/01/2026')).toBeNull()
+    expect(parseYearMonth('2026-4-1')).toBeNull()
+    expect(parseYearMonth('garbage')).toBeNull()
+  })
+
+  it('returns null for out-of-range month', () => {
+    expect(parseYearMonth('2026-13-01')).toBeNull()
+    expect(parseYearMonth('2026-00-01')).toBeNull()
+  })
+})
+
+describe('isExactMonth', () => {
+  it('true when start/end exactly span a calendar month', () => {
+    expect(isExactMonth('2026-04-01', '2026-04-30')).toBe(true)
+  })
+
+  it('false when start is not the 1st', () => {
+    expect(isExactMonth('2026-04-02', '2026-04-30')).toBe(false)
+  })
+
+  it('false when end is not the last day', () => {
+    expect(isExactMonth('2026-04-01', '2026-04-29')).toBe(false)
+  })
+
+  it('false when range spans multiple months', () => {
+    expect(isExactMonth('2026-03-01', '2026-04-30')).toBe(false)
+  })
+
+  it('false for invalid start', () => {
+    expect(isExactMonth('garbage', '2026-04-30')).toBe(false)
+  })
+})
+
+describe('isCurrentMonth', () => {
+  it('true when range equals today-month', () => {
+    expect(isCurrentMonth('2026-04-01', '2026-04-30', new Date(2026, 3, 18))).toBe(true)
+  })
+
+  it('false for prior month', () => {
+    expect(isCurrentMonth('2026-03-01', '2026-03-31', new Date(2026, 3, 18))).toBe(false)
+  })
+
+  it('false for custom range in current month', () => {
+    expect(isCurrentMonth('2026-04-05', '2026-04-20', new Date(2026, 3, 18))).toBe(false)
+  })
+})
+
+describe('formatMonthLabel', () => {
+  it('zero-pads single-digit months', () => {
+    expect(formatMonthLabel({ year: 2026, month: 4 })).toBe('2026/04')
+  })
+
+  it('does not pad two-digit months', () => {
+    expect(formatMonthLabel({ year: 2026, month: 12 })).toBe('2026/12')
+  })
+})

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -68,9 +68,11 @@ export default function RecordsPage() {
   const [showAdvanced, setShowAdvanced] = useState(false)
   // Default to current month for efficiency — families mostly care about the
   // current monthly summary. URL params (`?start=&end=`) override for deep
-  // links (e.g., from statistics page drill-downs). Issue #185.
-  const [dateStart, setDateStart] = useState(() => searchParams.get('start') ?? currentMonthRange().start)
-  const [dateEnd, setDateEnd] = useState(() => searchParams.get('end') ?? currentMonthRange().end)
+  // links (e.g., from statistics page drill-downs). Use `||` not `??` so an
+  // empty string `?start=` also falls back to the default (not treated as
+  // "all time"). Issue #185.
+  const [dateStart, setDateStart] = useState(() => searchParams.get('start') || currentMonthRange().start)
+  const [dateEnd, setDateEnd] = useState(() => searchParams.get('end') || currentMonthRange().end)
   const [payerFilter, setPayerFilter] = useState('')
   const [categoryFilter, setCategoryFilter] = useState(() => searchParams.get('category') ?? '')
 
@@ -109,7 +111,13 @@ export default function RecordsPage() {
     return () => clearTimeout(t)
   }, [searchInput])
 
-  const hasAdvancedFilter = dateStart || dateEnd || payerFilter || categoryFilter
+  // "Advanced filter" means the user has narrowed beyond the default
+  // current-month view. The default month is NOT treated as active filtering
+  // (so the summary bar / indicator dots don't light up on plain page load).
+  // Issue #185.
+  const isOnCurrentMonth = isCurrentMonth(dateStart, dateEnd)
+  const customDateRange = !!(dateStart || dateEnd) && !isOnCurrentMonth
+  const hasAdvancedFilter = customDateRange || !!payerFilter || !!categoryFilter
 
   const filtered = useMemo(() => {
     return expenses.filter((e) => {
@@ -157,8 +165,12 @@ export default function RecordsPage() {
   function clearFilters() {
     setSearchInput('')
     setSearchQuery('')
-    setDateStart('')
-    setDateEnd('')
+    // "Clear filters" resets to the default (current-month) view, not a
+    // no-date-range "all time" view. Keeps semantics consistent with the new
+    // default behavior added in Issue #185.
+    const curr = currentMonthRange()
+    setDateStart(curr.start)
+    setDateEnd(curr.end)
     setPayerFilter('')
     setCategoryFilter('')
   }

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -17,6 +17,14 @@ import { ReceiptGallery } from '@/components/receipt-gallery'
 import { normalizeReceiptPaths } from '@/lib/services/image-upload'
 import type { Expense } from '@/lib/types'
 import type { DocumentSnapshot } from 'firebase/firestore'
+import {
+  currentMonthRange,
+  shiftMonth,
+  parseYearMonth,
+  isExactMonth,
+  isCurrentMonth,
+  formatMonthLabel,
+} from '@/lib/month-nav'
 
 type FilterType = '全部' | '共同' | '個人'
 
@@ -58,10 +66,42 @@ export default function RecordsPage() {
   const [searchInput, setSearchInput] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
   const [showAdvanced, setShowAdvanced] = useState(false)
-  const [dateStart, setDateStart] = useState(() => searchParams.get('start') ?? '')
-  const [dateEnd, setDateEnd] = useState(() => searchParams.get('end') ?? '')
+  // Default to current month for efficiency — families mostly care about the
+  // current monthly summary. URL params (`?start=&end=`) override for deep
+  // links (e.g., from statistics page drill-downs). Issue #185.
+  const [dateStart, setDateStart] = useState(() => searchParams.get('start') ?? currentMonthRange().start)
+  const [dateEnd, setDateEnd] = useState(() => searchParams.get('end') ?? currentMonthRange().end)
   const [payerFilter, setPayerFilter] = useState('')
   const [categoryFilter, setCategoryFilter] = useState(() => searchParams.get('category') ?? '')
+
+  // Derived: which month does the current date filter represent?
+  // - Exact-month range → show prev/next month navigation
+  // - Custom or all-time → show "自訂區間" and a "回本月" shortcut
+  const monthNav = useMemo(() => {
+    if (!dateStart || !dateEnd) return { kind: 'custom' as const }
+    if (!isExactMonth(dateStart, dateEnd)) return { kind: 'custom' as const }
+    const ym = parseYearMonth(dateStart)
+    if (!ym) return { kind: 'custom' as const }
+    return {
+      kind: 'month' as const,
+      year: ym.year,
+      month: ym.month,
+      isCurrent: isCurrentMonth(dateStart, dateEnd),
+    }
+  }, [dateStart, dateEnd])
+
+  function jumpToMonth(delta: number) {
+    if (monthNav.kind !== 'month') return
+    const next = shiftMonth(monthNav.year, monthNav.month, delta)
+    setDateStart(next.start)
+    setDateEnd(next.end)
+  }
+
+  function jumpToCurrentMonth() {
+    const curr = currentMonthRange()
+    setDateStart(curr.start)
+    setDateEnd(curr.end)
+  }
 
   // Debounce search input by 300ms
   useEffect(() => {
@@ -162,6 +202,56 @@ export default function RecordsPage() {
             </button>
           ))}
         </div>
+      </div>
+
+      {/* Month navigation (Issue #185) */}
+      <div className="mb-3 flex items-center gap-2">
+        {monthNav.kind === 'month' ? (
+          <>
+            <button
+              onClick={() => jumpToMonth(-1)}
+              aria-label="上一個月"
+              className="h-9 w-9 rounded-lg border border-[var(--border)] bg-[var(--card)] hover:bg-[var(--muted)] transition flex items-center justify-center text-sm"
+            >
+              ◀
+            </button>
+            <div className="flex-1 text-center">
+              <div className="text-sm font-semibold tabular-nums">
+                {formatMonthLabel({ year: monthNav.year, month: monthNav.month })}
+              </div>
+              {monthNav.isCurrent && (
+                <div className="text-[10px] text-[var(--muted-foreground)]">本月</div>
+              )}
+            </div>
+            <button
+              onClick={() => jumpToMonth(1)}
+              aria-label="下一個月"
+              className="h-9 w-9 rounded-lg border border-[var(--border)] bg-[var(--card)] hover:bg-[var(--muted)] transition flex items-center justify-center text-sm"
+            >
+              ▶
+            </button>
+            {!monthNav.isCurrent && (
+              <button
+                onClick={jumpToCurrentMonth}
+                className="h-9 px-3 rounded-lg border border-[var(--border)] bg-[var(--card)] text-xs font-medium text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--muted)] transition"
+              >
+                回本月
+              </button>
+            )}
+          </>
+        ) : (
+          <>
+            <div className="flex-1 text-sm text-[var(--muted-foreground)]">
+              自訂區間 {dateStart && dateEnd ? `(${dateStart} ~ ${dateEnd})` : ''}
+            </div>
+            <button
+              onClick={jumpToCurrentMonth}
+              className="h-9 px-3 rounded-lg border border-[var(--border)] bg-[var(--card)] text-xs font-medium text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--muted)] transition"
+            >
+              回本月
+            </button>
+          </>
+        )}
       </div>
 
       {/* Quick filter chips */}

--- a/src/lib/month-nav.ts
+++ b/src/lib/month-nav.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for the records page month-based navigation (Issue #185).
+ * All dates use local timezone to match date input elements.
+ */
+
+export type DateString = string
+
+export interface MonthRange {
+  start: DateString
+  end: DateString
+  year: number
+  month: number
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function toIso(d: Date): DateString {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
+}
+
+export function monthRange(year: number, month: number): MonthRange {
+  const first = new Date(year, month - 1, 1)
+  const last = new Date(year, month, 0)
+  return { start: toIso(first), end: toIso(last), year, month }
+}
+
+export function currentMonthRange(now: Date = new Date()): MonthRange {
+  return monthRange(now.getFullYear(), now.getMonth() + 1)
+}
+
+export function shiftMonth(year: number, month: number, delta: number): MonthRange {
+  const d = new Date(year, month - 1 + delta, 1)
+  return monthRange(d.getFullYear(), d.getMonth() + 1)
+}
+
+export function parseYearMonth(dateStr: DateString): { year: number; month: number } | null {
+  const match = /^(\d{4})-(\d{2})-\d{2}$/.exec(dateStr)
+  if (!match) return null
+  const year = Number(match[1])
+  const month = Number(match[2])
+  if (month < 1 || month > 12) return null
+  return { year, month }
+}
+
+export function isExactMonth(start: DateString, end: DateString): boolean {
+  const ym = parseYearMonth(start)
+  if (!ym) return false
+  const expected = monthRange(ym.year, ym.month)
+  return start === expected.start && end === expected.end
+}
+
+export function isCurrentMonth(start: DateString, end: DateString, now: Date = new Date()): boolean {
+  const curr = currentMonthRange(now)
+  return start === curr.start && end === curr.end
+}
+
+export function formatMonthLabel(range: Pick<MonthRange, 'year' | 'month'>): string {
+  return `${range.year}/${pad2(range.month)}`
+}


### PR DESCRIPTION
## Needs

老闆要求：「紀錄頁面預設篩選顯示當月資料，提升效率，增加分頁功能」。

解讀：
- **預設當月**：家庭用戶最常看的是當月（對帳 / 預算追蹤），進頁面不該看到整部歷史
- **分頁功能** = 以「月」為單位的前後月導覽（搭配預設當月最順；避免手動開日期 picker 翻前月）

## Changes

### 新 helper `src/lib/month-nav.ts`
8 個純函式（跨年、閏年、格式驗證皆考慮）：
- \`monthRange\` / \`currentMonthRange\` / \`shiftMonth\`
- \`parseYearMonth\` / \`isExactMonth\` / \`isCurrentMonth\`
- \`formatMonthLabel\`

### 紀錄頁 `src/app/(auth)/records/page.tsx`
- \`dateStart/dateEnd\` 預設當月（URL param \`?start=&end=\` 仍可 override）
- 在 FilterChips 上方新增月份導覽列：

  **恰為整月**：\`◀ 2026/04 ▶ [回本月]\`（本月時以 badge 標示、不顯示「回本月」）

  **自訂區間**：\`自訂區間 (2026-03-15 ~ 2026-04-05) [回本月]\`

- 既有進階篩選 / FilterChips / 載入更多全部保留

## Tests (+26)

\`__tests__/month-nav.test.ts\` 覆蓋：
- 30/31 天、閏年 2/29、跨年 (\`+1\` 從 Dec 跨到隔年 Jan / \`-1\` 從 Jan 跨到前年 Dec)
- ISO parse 合法 + 多種格式錯誤 + 月份超界
- \`isExactMonth\` 非整月的多種 case
- \`isCurrentMonth\` 真假
- \`formatMonthLabel\` zero-pad

**總測試 163 → 189 pass**。

## Verification（受限於 PM2 live-serve cwd 限制）

- ✅ \`npm run test\` 189/189 通過
- ✅ \`npm run lint\` 0 new errors
- ✅ \`npx tsc --noEmit\` 通過
- ⏭ **刻意未執行 \`npm run build\`** — 此 cwd 是 PM2 live-serve，build 會覆蓋 \`.next\` 造成生產 chunk-404（2026-04-18 學過這個教訓）

若需要 merge 前做 integration test，建議：
\`\`\`bash
git worktree add ../family-ledger-debug main
cd ../family-ledger-debug
git fetch && git checkout feat/185-records-month-nav
npm ci && npm run build && npm run start  # 用其他 port
\`\`\`

## Test plan

- [ ] 進 \`/records\`：預設看到當月、月份導覽列顯示「2026/04 本月」
- [ ] 點「◀」→ 跳到 2026/03，顯示「回本月」快捷鈕
- [ ] 點「▶」→ 跳到 2026/05
- [ ] 12 月點「▶」→ 跨年到 2027/01
- [ ] 開進階篩選、設自訂區間 2026-03-15 ~ 2026-04-05 → 月份列變「自訂區間」+「回本月」
- [ ] 點「回本月」→ 回到 2026/04 整月
- [ ] URL 進入 \`/records?start=2026-01-01&end=2026-01-31\` → 顯示 2026/01，不是當月

Closes #185