### PR TITLE
feat(notifications): 支出/結算事件 email 通知 + deleteSettlement 補 in-app (Closes #187)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,35 @@ Tailwind CSS v4 with CSS custom properties defined in `globals.css`. Key variabl
 - Database: Firestore (localized in Taiwan)
 - Storage: Receipt image uploads
 
+### Email Notifications Setup（Issue #187）
+
+程式碼已 wire 好 email pipeline，但實際寄送需要以下**一次性手動設定**：
+
+1. **升級 Firebase 到 Blaze 計費方案**
+   - https://console.firebase.google.com/project/family-ledger-784ed/usage/details
+   - 綁信用卡（家庭用量實際費用 $0）
+
+2. **安裝 Trigger Email from Firestore extension**
+   - https://console.firebase.google.com/project/family-ledger-784ed/extensions
+   - 搜尋「Trigger Email from Firestore」（ext-firestore-send-email）
+   - 安裝時填入：
+     - Mail collection: `mail`
+     - Default FROM: `<your-gmail>@gmail.com`
+     - SMTP connection URI：見第 3 步
+
+3. **產生 Gmail App Password**
+   - Google Account → Security → 2-Step Verification → App Passwords
+   - 產生 "Mail" 專用密碼（16 字元）
+   - SMTP URI 格式：`smtps://<gmail>%40gmail.com:<app-password-no-spaces>@smtp.gmail.com:465`
+   - 注意 `@` 要 URL-encode 成 `%40`
+
+4. **驗證**
+   - 使用者到 設定 → 🔔 Email 通知 → 開啟
+   - 另一個 group member 建立支出 → 第一位使用者的 gmail 收到信
+
+設定完成前，pipeline 仍會寫 `mail/{id}` 文件，但不會有 extension 讀取；
+等第 2 步完成後新的 mail 文件才會被寄出（backfill 不處理舊的）。
+
 ### Rules Deploy
 
 - CI workflow: `.github/workflows/deploy-rules.yml` — auto-deploys `firestore.rules` / `storage.rules` when they change on `main`. Requires `FIREBASE_DEPLOY_TOKEN` secret.

--- a/__tests__/email-notification.test.ts
+++ b/__tests__/email-notification.test.ts
@@ -31,7 +31,42 @@ describe('buildEmailPayload', () => {
   it('body text includes app link and unsubscribe hint', () => {
     const p = buildEmailPayload({ title: 't', body: 'b' })
     expect(p.text).toContain('前往查看')
-    expect(p.text).toMatch(/取消勾選.*Email/)
+    expect(p.text).toMatch(/Email 通知/)
+  })
+
+  // --- Issue #187 HIGH fixes: SMTP header injection guards ---
+
+  it('strips CRLF from title to prevent SMTP header injection', () => {
+    // The real exploit is injecting CRLF so the SMTP server treats the rest as
+    // a new header (e.g., Bcc:). After sanitization, "Bcc:" may still appear
+    // as plain subject text but has no structural effect without the CRLF
+    // delimiter. The security property we verify is: subject contains no CRLF.
+    const p = buildEmailPayload({
+      title: '新增支出\r\nBcc: attacker@evil.com',
+      body: 'b',
+    })
+    expect(p.subject).not.toMatch(/[\r\n]/)
+  })
+
+  it('strips CRLF from groupName (also flows into header via the tag prefix)', () => {
+    const p = buildEmailPayload({
+      title: 't',
+      body: 'b',
+      groupName: '家裡\r\nX-Injected: yes',
+    })
+    expect(p.subject).not.toMatch(/[\r\n]/)
+  })
+
+  it('multiple consecutive CRLFs collapse to a single space (no hidden blanks)', () => {
+    const p = buildEmailPayload({ title: 'A\r\n\r\n\r\nB', body: 'b' })
+    expect(p.subject).not.toMatch(/[\r\n]/)
+    // A and B should be separated by exactly one space, not preserved as gap
+    expect(p.subject).toContain('A B')
+  })
+
+  it('allows CRLF in body text (body is not a header)', () => {
+    const p = buildEmailPayload({ title: 't', body: 'line1\nline2\nline3' })
+    expect(p.text).toContain('line1\nline2\nline3')
   })
 
   it('empty title still produces a valid subject', () => {

--- a/__tests__/email-notification.test.ts
+++ b/__tests__/email-notification.test.ts
@@ -1,0 +1,54 @@
+jest.mock('@/lib/firebase', () => ({ db: {}, auth: {}, storage: {} }))
+jest.mock('firebase/firestore', () => ({
+  addDoc: jest.fn(),
+  collection: jest.fn(),
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+  serverTimestamp: jest.fn(),
+}))
+jest.mock('@/lib/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}))
+
+import { buildEmailPayload } from '@/lib/services/email-notification'
+
+describe('buildEmailPayload', () => {
+  it('prefixes subject with group name when provided', () => {
+    const p = buildEmailPayload({ title: '新增共同支出', body: 'anything', groupName: '家裡' })
+    expect(p.subject).toBe('【家裡】 新增共同支出')
+  })
+
+  it('falls back to 家計本 when no group name', () => {
+    const p = buildEmailPayload({ title: '新增結算', body: 'x' })
+    expect(p.subject).toBe('【家計本】 新增結算')
+  })
+
+  it('body text contains the notification body', () => {
+    const p = buildEmailPayload({ title: 't', body: '阿爸新增了午餐 (NT$150)' })
+    expect(p.text).toContain('阿爸新增了午餐 (NT$150)')
+  })
+
+  it('body text includes app link and unsubscribe hint', () => {
+    const p = buildEmailPayload({ title: 't', body: 'b' })
+    expect(p.text).toContain('前往查看')
+    expect(p.text).toMatch(/取消勾選.*Email/)
+  })
+
+  it('empty title still produces a valid subject', () => {
+    const p = buildEmailPayload({ title: '', body: 'b' })
+    expect(p.subject).toBe('【家計本】 ')
+    expect(p.subject.length).toBeGreaterThan(0)
+  })
+
+  it('extremely long body still builds (caller should size-check before write)', () => {
+    const huge = 'x'.repeat(10000)
+    const p = buildEmailPayload({ title: 't', body: huge })
+    expect(p.text).toContain(huge)
+  })
+
+  it('subject has no leading/trailing whitespace around the tag-title separator', () => {
+    const p = buildEmailPayload({ title: 'Hi', body: 'b', groupName: 'G' })
+    // Format: 【G】 Hi (one space between bracket and title)
+    expect(p.subject).toMatch(/^【G】 Hi$/)
+  })
+})

--- a/firestore.rules
+++ b/firestore.rules
@@ -266,16 +266,21 @@ service cloud.firestore {
     //
     // 由 notifyByEmail helper 在 in-app 通知建立時同步寫入，待 extension 讀取
     // 並透過 Gmail SMTP 寄送。schema 符合 ext-firestore-send-email 預期：
-    //   { to: string, message: { subject, text, html? }, createdAt, ...meta }
+    //   { to: string, message: { subject, text, html? }, meta: { groupId, recipientUid }, createdAt }
     //
-    // Create: 任何已登入使用者可寫（通知流程需要），但 body size 有限制防濫用
-    // Read: 禁止（含收件信箱、內文，敏感）
-    // Update: 僅 extension 本身（via service account）— client 不可改
-    // Delete: 禁止（審計軌跡）
+    // 關鍵安全機制（防止 open relay）：
+    //   - `to` 必須 == 宣稱 recipientUid 已 opt-in 的 userPreferences.email
+    //   - 寫入者與 recipient 必須同 group 成員
+    // 這讓惡意使用者無法把 SMTP 當成對外發信工具：只能發給已經登記 email 的同群
+    // 成員本人。
+    //
+    // Extension 以 Cloud Function service account 執行，bypass rules，可自由
+    // update delivery 欄位 + 任意 read；因此此處 read/update/delete 全拒 client。
     // Issue #187.
     match /mail/{mailId} {
       allow read: if false;
       allow create: if isSignedIn()
+        // Shape validation
         && request.resource.data.to is string
         && request.resource.data.to.size() > 0
         && request.resource.data.to.size() <= 200
@@ -284,7 +289,22 @@ service cloud.firestore {
         && request.resource.data.message.subject.size() > 0
         && request.resource.data.message.subject.size() <= 200
         && request.resource.data.message.text is string
-        && request.resource.data.message.text.size() <= 5000;
+        && request.resource.data.message.text.size() <= 5000
+        && request.resource.data.meta is map
+        && request.resource.data.meta.groupId is string
+        && request.resource.data.meta.recipientUid is string
+        // Writer must belong to the claimed group
+        && request.auth.uid in
+          firestore.get(/databases/$(database)/documents/groups/$(request.resource.data.meta.groupId)).data.memberUids
+        // Recipient must also belong to the same group
+        && request.resource.data.meta.recipientUid in
+          firestore.get(/databases/$(database)/documents/groups/$(request.resource.data.meta.groupId)).data.memberUids
+        // The `to` address must match the recipient's registered preference email
+        // (this is the open-relay guard). Reading userPreferences is allowed
+        // for group members; if the recipient hasn't opted in the read fails
+        // because `email` field is null/missing and equality fails.
+        && request.resource.data.to ==
+          firestore.get(/databases/$(database)/documents/groups/$(request.resource.data.meta.groupId)/userPreferences/$(request.resource.data.meta.recipientUid)).data.email;
       allow update, delete: if false;
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -262,6 +262,32 @@ service cloud.firestore {
       }
     }
 
+    // ─── Email 寄送佇列（Firebase Trigger Email Extension）───
+    //
+    // 由 notifyByEmail helper 在 in-app 通知建立時同步寫入，待 extension 讀取
+    // 並透過 Gmail SMTP 寄送。schema 符合 ext-firestore-send-email 預期：
+    //   { to: string, message: { subject, text, html? }, createdAt, ...meta }
+    //
+    // Create: 任何已登入使用者可寫（通知流程需要），但 body size 有限制防濫用
+    // Read: 禁止（含收件信箱、內文，敏感）
+    // Update: 僅 extension 本身（via service account）— client 不可改
+    // Delete: 禁止（審計軌跡）
+    // Issue #187.
+    match /mail/{mailId} {
+      allow read: if false;
+      allow create: if isSignedIn()
+        && request.resource.data.to is string
+        && request.resource.data.to.size() > 0
+        && request.resource.data.to.size() <= 200
+        && request.resource.data.message is map
+        && request.resource.data.message.subject is string
+        && request.resource.data.message.subject.size() > 0
+        && request.resource.data.message.subject.size() <= 200
+        && request.resource.data.message.text is string
+        && request.resource.data.message.text.size() <= 5000;
+      allow update, delete: if false;
+    }
+
     // ─── 系統日誌（production debugging） ───
     //
     // 所有 logger.error()/warn() 在 production 會寫入此 collection。

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -16,6 +16,7 @@ import { useRouter } from 'next/navigation'
 import { BudgetSection } from '@/components/budget-section'
 import { OrphanCleanupSection } from '@/components/orphan-cleanup-section'
 import { RuleCleanupSection } from '@/components/rule-cleanup-section'
+import { EmailPreferenceSection } from '@/components/email-preference-section'
 import type { FamilyMember, Category } from '@/lib/types'
 
 import { useToast } from '@/components/toast'
@@ -717,6 +718,12 @@ export default function SettingsPage() {
         {group && user?.uid === group.ownerUid && (
           <Section title="🧼 分類規則清理">
             <RuleCleanupSection groupId={group.id} />
+          </Section>
+        )}
+
+        {group && (
+          <Section title="🔔 Email 通知">
+            <EmailPreferenceSection groupId={group.id} />
           </Section>
         )}
 

--- a/src/components/email-preference-section.tsx
+++ b/src/components/email-preference-section.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useAuth } from '@/lib/auth'
+import { useToast } from '@/components/toast'
+import { logger } from '@/lib/logger'
+import {
+  getEmailNotificationEnabled,
+  setEmailNotificationEnabled,
+} from '@/lib/services/user-preference-service'
+
+interface Props {
+  groupId: string
+}
+
+/**
+ * Per-group opt-in toggle for email notifications (Issue #187).
+ * Flips userPreferences.emailEnabled and caches the Firebase Auth email so the
+ * notify pipeline can reach the user without an admin-SDK lookup.
+ */
+export function EmailPreferenceSection({ groupId }: Props) {
+  const { user } = useAuth()
+  const { addToast } = useToast()
+  const [enabled, setEnabled] = useState<boolean | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    getEmailNotificationEnabled(groupId)
+      .then((v) => {
+        if (!cancelled) setEnabled(v)
+      })
+      .catch(() => {
+        if (!cancelled) setEnabled(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [groupId])
+
+  async function toggle(next: boolean) {
+    if (saving) return
+    setSaving(true)
+    try {
+      await setEmailNotificationEnabled(groupId, next)
+      setEnabled(next)
+      addToast(next ? '已開啟 Email 通知' : '已關閉 Email 通知', 'success')
+    } catch (e) {
+      logger.error('[EmailPreference] Failed to toggle', e)
+      addToast('設定失敗，請稍後再試', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const displayEmail = user?.email ?? '（未提供 email）'
+  const hasEmail = !!user?.email
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-[var(--muted-foreground)]">
+        開啟後，本群組其他成員新增/編輯/刪除支出或結算時，系統會寄送 email 到
+        下方信箱。您自己的動作不會寄給您自己。
+      </p>
+
+      <div className="flex items-center gap-3 p-3 rounded-lg border border-[var(--border)]">
+        <div className="flex-1 min-w-0">
+          <div className="text-xs text-[var(--muted-foreground)]">收件信箱</div>
+          <div className="text-sm font-mono truncate" title={displayEmail}>{displayEmail}</div>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled === true}
+          disabled={saving || enabled === null || !hasEmail}
+          onClick={() => toggle(!enabled)}
+          className={`relative h-7 w-12 rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+            enabled ? 'bg-[var(--primary)]' : 'bg-[var(--muted)]'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 h-6 w-6 rounded-full bg-white shadow transition-transform ${
+              enabled ? 'translate-x-[22px]' : 'translate-x-0.5'
+            }`}
+          />
+        </button>
+      </div>
+
+      {!hasEmail && (
+        <p className="text-xs text-[var(--destructive)]">
+          您的 Firebase Auth 帳號沒有 email，無法開啟此功能。
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/lib/services/email-notification.ts
+++ b/src/lib/services/email-notification.ts
@@ -37,15 +37,37 @@ export interface EmailPayload {
   text: string
 }
 
+/**
+ * Strip CR/LF from a string to prevent SMTP header injection when the value
+ * ends up in a `Subject:` or similar header. A malicious actor writing
+ * `description` or `actorName` with `\r\nBcc: evil@attacker.com` could
+ * otherwise inject additional headers. Called on every untrusted input that
+ * feeds buildEmailPayload.
+ */
+function sanitizeHeader(s: string): string {
+  return s.replace(/[\r\n]+/g, ' ').trim()
+}
+
+/**
+ * App URL used in email body for the "go to app" link. Reads from
+ * `NEXT_PUBLIC_APP_URL` env var with a generic fallback — avoids hardcoding
+ * a Tailscale/personal URL into source. Set in `.env.local`.
+ */
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://family-ledger-web.local/'
+
 export function buildEmailPayload(args: {
   title: string
   body: string
   groupName?: string
 }): EmailPayload {
-  const groupTag = args.groupName ? `【${args.groupName}】` : '【家計本】'
+  const safeTitle = sanitizeHeader(args.title)
+  const safeGroup = args.groupName ? sanitizeHeader(args.groupName) : ''
+  const groupTag = safeGroup ? `【${safeGroup}】` : '【家計本】'
+  // Body is plain text (not a header), so CRLF is allowed — just avoid the
+  // hardcoded Tailscale URL by routing via env var.
   return {
-    subject: `${groupTag} ${args.title}`,
-    text: `${args.body}\n\n—\n前往查看：https://claude-openclaw.tail7fcdd.ts.net/family-ledger-web/\n若不想再收到此類郵件，請到 設定 → 個人通知 取消勾選 Email 通知。`,
+    subject: `${groupTag} ${safeTitle}`,
+    text: `${args.body}\n\n—\n前往查看：${APP_URL}\n若不想再收到此類郵件，請到 設定 → 🔔 Email 通知 關閉開關。`,
   }
 }
 

--- a/src/lib/services/email-notification.ts
+++ b/src/lib/services/email-notification.ts
@@ -1,0 +1,133 @@
+import { addDoc, collection, doc, getDoc, serverTimestamp } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { logger } from '@/lib/logger'
+
+/**
+ * Email notification pipeline for in-app notifications (Issue #187).
+ *
+ * Flow:
+ *   1. Caller (expense/settlement service) creates in-app notification doc
+ *   2. Caller ALSO calls `notifyByEmail(groupId, recipientUid, subject, text)`
+ *   3. We look up `groups/{g}/userPreferences/{uid}` to check `emailEnabled` + `email`
+ *   4. If opted in, write a mail doc to root `mail` collection
+ *   5. Firebase "Trigger Email from Firestore" extension (ext-firestore-send-email)
+ *      picks up the mail doc and dispatches via Gmail SMTP
+ *
+ * Best-effort: email failures never surface to the caller. In-app notification
+ * is the source of truth; email is a convenience on top.
+ *
+ * Phase 2 prerequisites (user ops, not code):
+ *   - Firebase project on Blaze plan
+ *   - "Trigger Email from Firestore" extension installed and configured
+ *   - Gmail app password, SMTP URI saved in extension config
+ *   - See CLAUDE.md "Email Notifications" section for full checklist
+ */
+
+export interface UserEmailPreference {
+  emailEnabled: boolean
+  email: string
+}
+
+/**
+ * Build the subject + text body for a mail doc. Pure helper so it's unit-testable
+ * without Firebase. Keeps subject prefix consistent across all events.
+ */
+export interface EmailPayload {
+  subject: string
+  text: string
+}
+
+export function buildEmailPayload(args: {
+  title: string
+  body: string
+  groupName?: string
+}): EmailPayload {
+  const groupTag = args.groupName ? `【${args.groupName}】` : '【家計本】'
+  return {
+    subject: `${groupTag} ${args.title}`,
+    text: `${args.body}\n\n—\n前往查看：https://claude-openclaw.tail7fcdd.ts.net/family-ledger-web/\n若不想再收到此類郵件，請到 設定 → 個人通知 取消勾選 Email 通知。`,
+  }
+}
+
+/**
+ * Fetch a recipient's email preference from Firestore. Returns null on any error
+ * or if the user has not opted in.
+ */
+export async function getRecipientEmailPreference(
+  groupId: string,
+  recipientUid: string,
+): Promise<UserEmailPreference | null> {
+  try {
+    const ref = doc(db, 'groups', groupId, 'userPreferences', recipientUid)
+    const snap = await getDoc(ref)
+    if (!snap.exists()) return null
+    const data = snap.data() as Partial<UserEmailPreference>
+    if (!data.emailEnabled || !data.email) return null
+    return { emailEnabled: true, email: data.email }
+  } catch (e) {
+    logger.warn('[EmailNotification] Failed to read user preference', { groupId, recipientUid, err: e })
+    return null
+  }
+}
+
+/**
+ * Fire-and-forget: write a mail doc for the given recipient if they've opted in.
+ * Errors are logged (not thrown) — email is best-effort, must never block the
+ * calling notification flow.
+ */
+export async function notifyByEmail(args: {
+  groupId: string
+  recipientUid: string
+  title: string
+  body: string
+  groupName?: string
+}): Promise<void> {
+  try {
+    const pref = await getRecipientEmailPreference(args.groupId, args.recipientUid)
+    if (!pref) return // not opted in or lookup failed
+    const payload = buildEmailPayload({
+      title: args.title,
+      body: args.body,
+      groupName: args.groupName,
+    })
+    await addDoc(collection(db, 'mail'), {
+      to: pref.email,
+      message: {
+        subject: payload.subject,
+        text: payload.text,
+      },
+      // Metadata for audit / debugging. Extension ignores extra fields.
+      meta: {
+        groupId: args.groupId,
+        recipientUid: args.recipientUid,
+      },
+      createdAt: serverTimestamp(),
+    })
+  } catch (e) {
+    logger.error('[EmailNotification] notifyByEmail failed', e)
+  }
+}
+
+/**
+ * Fan out email notifications to multiple recipients in parallel.
+ * Convenience wrapper for the notifyMembersAboutX pattern.
+ */
+export async function notifyByEmailFanOut(args: {
+  groupId: string
+  recipientUids: readonly string[]
+  title: string
+  body: string
+  groupName?: string
+}): Promise<void> {
+  await Promise.all(
+    args.recipientUids.map((uid) =>
+      notifyByEmail({
+        groupId: args.groupId,
+        recipientUid: uid,
+        title: args.title,
+        body: args.body,
+        groupName: args.groupName,
+      }),
+    ),
+  )
+}

--- a/src/lib/services/expense-service.ts
+++ b/src/lib/services/expense-service.ts
@@ -2,6 +2,7 @@ import { collection, doc, setDoc, deleteDoc, Timestamp, getDoc, getDocs, query, 
 import { db, auth } from '@/lib/firebase'
 import { addActivityLog } from './activity-log-service'
 import { addNotification } from './notification-service'
+import { notifyByEmailFanOut } from './email-notification'
 import { deleteReceiptImages, normalizeReceiptPaths } from './image-upload'
 import { currency } from '@/lib/utils'
 import type { Expense, SplitDetail, SplitMethod, PaymentMethod } from '@/lib/types'
@@ -30,13 +31,24 @@ async function notifyMembersAboutExpense(
 ): Promise<void> {
   try {
     const groupSnap = await getDoc(doc(db, 'groups', groupId))
-    const memberUids: string[] = groupSnap.data()?.memberUids ?? []
+    const groupData = groupSnap.data()
+    const memberUids: string[] = groupData?.memberUids ?? []
+    const groupName = groupData?.name as string | undefined
     const currentUid = auth.currentUser?.uid
+    const recipients = memberUids.filter((uid) => uid !== currentUid)
+    // In-app notifications (primary, sync).
     await Promise.all(
-      memberUids
-        .filter((uid) => uid !== currentUid)
-        .map((uid) => addNotification(groupId, { ...payload, recipientId: uid })),
+      recipients.map((uid) => addNotification(groupId, { ...payload, recipientId: uid })),
     )
+    // Email notifications (best-effort, Issue #187) — gated by each recipient's
+    // per-group opt-in preference.
+    await notifyByEmailFanOut({
+      groupId,
+      recipientUids: recipients,
+      title: payload.title,
+      body: payload.body,
+      groupName,
+    })
   } catch (e) {
     logger.error('[ExpenseService] Failed to send notifications:', e)
   }

--- a/src/lib/services/settlement-service.ts
+++ b/src/lib/services/settlement-service.ts
@@ -2,6 +2,7 @@ import { addDoc, collection, deleteDoc, doc, getDoc, serverTimestamp, Timestamp,
 import { db, auth } from '@/lib/firebase'
 import { addActivityLog } from './activity-log-service'
 import { addNotification } from './notification-service'
+import { notifyByEmailFanOut } from './email-notification'
 import { currency } from '@/lib/utils'
 
 import { logger } from '@/lib/logger'
@@ -50,24 +51,22 @@ export async function addSettlement(groupId: string, data: NewSettlement, actor?
       logger.error('[SettlementService] Failed to log activity:', e)
     }
   }
-  // Notify other group members about the settlement
+  // Notify other group members about the settlement (in-app + email).
   try {
     const groupSnap = await getDoc(doc(db, 'groups', groupId))
-    const memberUids: string[] = groupSnap.data()?.memberUids ?? []
+    const groupData = groupSnap.data()
+    const memberUids: string[] = groupData?.memberUids ?? []
+    const groupName = groupData?.name as string | undefined
     const currentUid = auth.currentUser?.uid
+    const recipients = memberUids.filter((uid) => uid !== currentUid)
+    const title = '新增結算'
+    const body = `${data.fromMemberName} → ${data.toMemberName}（${currency(data.amount)}）`
     await Promise.all(
-      memberUids
-        .filter((uid) => uid !== currentUid)
-        .map((uid) =>
-          addNotification(groupId, {
-            type: 'settlement_created',
-            title: '新增結算',
-            body: `${data.fromMemberName} → ${data.toMemberName}（${currency(data.amount)}）`,
-            recipientId: uid,
-            entityId: ref.id,
-          }),
-        ),
+      recipients.map((uid) =>
+        addNotification(groupId, { type: 'settlement_created', title, body, recipientId: uid, entityId: ref.id }),
+      ),
     )
+    await notifyByEmailFanOut({ groupId, recipientUids: recipients, title, body, groupName })
   } catch (e) {
     logger.error('[SettlementService] Failed to send notifications:', e)
   }
@@ -121,22 +120,21 @@ export async function addSettlements(
     }
   }
 
-  // Notify other group members about the batch settlement
+  // Notify other group members about the batch settlement (in-app + email).
   try {
     const groupSnap = await getDoc(doc(db, 'groups', groupId))
-    const memberUids: string[] = groupSnap.data()?.memberUids ?? []
+    const groupData = groupSnap.data()
+    const memberUids: string[] = groupData?.memberUids ?? []
+    const groupName = groupData?.name as string | undefined
+    const recipients = memberUids.filter((u) => u !== uid)
+    const title = '批次結清'
+    const body = `已結清 ${settlements.length} 筆債務`
     await Promise.all(
-      memberUids
-        .filter((u) => u !== uid)
-        .map((u) =>
-          addNotification(groupId, {
-            type: 'settlement_created',
-            title: '批次結清',
-            body: `已結清 ${settlements.length} 筆債務`,
-            recipientId: u,
-          }),
-        ),
+      recipients.map((u) =>
+        addNotification(groupId, { type: 'settlement_created', title, body, recipientId: u }),
+      ),
     )
+    await notifyByEmailFanOut({ groupId, recipientUids: recipients, title, body, groupName })
   } catch (e) {
     logger.error('[SettlementService] Failed to send batch notifications:', e)
   }
@@ -144,6 +142,26 @@ export async function addSettlements(
 
 export async function deleteSettlement(groupId: string, settlementId: string, actor?: Actor): Promise<void> {
   if (!auth.currentUser?.uid) throw new Error('Not authenticated')
+
+  // Read pre-delete snapshot for notification context (who settled whom for how much).
+  // Best-effort: if the read fails we still delete but the notification body degrades.
+  // Issue #187.
+  let settlementDesc = '此筆結算紀錄'
+  try {
+    const snap = await getDoc(doc(db, 'groups', groupId, 'settlements', settlementId))
+    if (snap.exists()) {
+      const d = snap.data() as {
+        fromMemberName?: string
+        toMemberName?: string
+        amount?: number
+      }
+      if (d.fromMemberName && d.toMemberName && typeof d.amount === 'number') {
+        settlementDesc = `${d.fromMemberName} → ${d.toMemberName}（${currency(d.amount)}）`
+      }
+    }
+  } catch (e) {
+    logger.error('[SettlementService] Failed to read pre-delete snapshot:', e)
+  }
 
   await deleteDoc(doc(db, 'groups', groupId, 'settlements', settlementId))
   if (actor) {
@@ -158,5 +176,26 @@ export async function deleteSettlement(groupId: string, settlementId: string, ac
     } catch (e) {
       logger.error('[SettlementService] Failed to log activity:', e)
     }
+  }
+
+  // Notify other group members about the deletion (in-app + email).
+  // Issue #187.
+  try {
+    const groupSnap = await getDoc(doc(db, 'groups', groupId))
+    const groupData = groupSnap.data()
+    const memberUids: string[] = groupData?.memberUids ?? []
+    const groupName = groupData?.name as string | undefined
+    const currentUid = auth.currentUser?.uid
+    const recipients = memberUids.filter((uid) => uid !== currentUid)
+    const title = '刪除結算'
+    const body = `${actor?.name ?? '成員'}刪除了結算：${settlementDesc}`
+    await Promise.all(
+      recipients.map((uid) =>
+        addNotification(groupId, { type: 'settlement_deleted', title, body, recipientId: uid, entityId: settlementId }),
+      ),
+    )
+    await notifyByEmailFanOut({ groupId, recipientUids: recipients, title, body, groupName })
+  } catch (e) {
+    logger.error('[SettlementService] Failed to send delete notifications:', e)
   }
 }

--- a/src/lib/services/user-preference-service.ts
+++ b/src/lib/services/user-preference-service.ts
@@ -4,8 +4,12 @@ import { db, auth } from '@/lib/firebase'
 import { logger } from '@/lib/logger'
 
 /**
- * Per-user preference for linking a Firebase Auth user to a family member.
- * Stored at: groups/{groupId}/userPreferences/{uid}
+ * Per-user preferences stored at: groups/{groupId}/userPreferences/{uid}
+ *
+ * Fields:
+ *   - linkedMemberId: Firebase Auth user → family member binding
+ *   - emailEnabled: opt-in for email notifications (Issue #187)
+ *   - email: recipient address for email notifications (Issue #187)
  */
 
 export async function setCurrentMember(groupId: string, memberId: string): Promise<void> {
@@ -16,7 +20,7 @@ export async function setCurrentMember(groupId: string, memberId: string): Promi
   await setDoc(ref, {
     linkedMemberId: memberId,
     updatedAt: Timestamp.now(),
-  })
+  }, { merge: true })
   logger.info(`[UserPreference] User ${uid} linked to member ${memberId} in group ${groupId}`)
 }
 
@@ -28,4 +32,32 @@ export async function getCurrentMemberId(groupId: string): Promise<string | null
   const snap = await getDoc(ref)
   if (!snap.exists()) return null
   return snap.data().linkedMemberId ?? null
+}
+
+/**
+ * Enable or disable email notifications for the current user in the given group.
+ * When enabling, stores the user's Firebase Auth email alongside the flag.
+ * Issue #187.
+ */
+export async function setEmailNotificationEnabled(groupId: string, enabled: boolean): Promise<void> {
+  const user = auth.currentUser
+  if (!user) throw new Error('Not authenticated')
+  if (enabled && !user.email) {
+    throw new Error('Firebase Auth user has no email; cannot enable email notifications')
+  }
+  const ref = doc(db, 'groups', groupId, 'userPreferences', user.uid)
+  await setDoc(ref, {
+    emailEnabled: enabled,
+    email: enabled ? user.email : null,
+    updatedAt: Timestamp.now(),
+  }, { merge: true })
+  logger.info(`[UserPreference] Email ${enabled ? 'enabled' : 'disabled'} for user ${user.uid} in group ${groupId}`)
+}
+
+export async function getEmailNotificationEnabled(groupId: string): Promise<boolean> {
+  const uid = auth.currentUser?.uid
+  if (!uid) return false
+  const ref = doc(db, 'groups', groupId, 'userPreferences', uid)
+  const snap = await getDoc(ref)
+  return snap.exists() && snap.data().emailEnabled === true
 }


### PR DESCRIPTION
## Need

使用者要求：轉帳/支出新增、異動、刪除增加 email 通知。

## 盤點

| 事件 | in-app 現況 | email（本 PR 新增）|
|------|------------|----|
| addExpense | ✅ 已有 | ✅ |
| updateExpense | ✅ | ✅ |
| deleteExpense | ✅ | ✅ |
| addSettlement | ✅ | ✅ |
| addSettlements（批次結清）| ✅ | ✅ |
| **deleteSettlement** | ❌ 本 PR 補上 | ✅ |

## Changes

### 1. deleteSettlement 補 in-app 通知
讀 pre-delete snapshot（from → to 金額）讓通知有可讀上下文。

### 2. Email pipeline
- \`src/lib/services/email-notification.ts\` (新): \`buildEmailPayload\`（純）、\`getRecipientEmailPreference\`、\`notifyByEmail\`、\`notifyByEmailFanOut\`。符合 Firebase Trigger Email Extension schema
- \`firestore.rules\`: 新增 \`mail\` collection — create 驗欄位 + size cap，read/update/delete 禁止
- user-preference-service: 加 \`emailEnabled\` + \`email\` 欄位 + \`set/getEmailNotificationEnabled\`
- expense-service / settlement-service 的 fan-out 同時寫 in-app + mail

### 3. Settings UI
\`EmailPreferenceSection\`：顯示 Firebase Auth email + role=switch toggle（無 email 的使用者會被 disabled 並提示）

### 4. 文件
CLAUDE.md 新增 **Email Notifications Setup** 章節 — Blaze/extension/Gmail App Password 手動步驟。

## Tests (+7)

\`__tests__/email-notification.test.ts\` 覆蓋 \`buildEmailPayload\` 純函式。總測試 **189 → 196**。

## 需要老闆做的手動設定（Phase 2 infra）

**code 已全部就位，但實際寄送需要以下一次性操作**（詳見 CLAUDE.md）:

1. 升級 Firebase Blaze（家庭用量 $0）
2. Firebase Console 安裝 "Trigger Email from Firestore" extension
3. Gmail → Security → App Password 產生 16 字元密碼
4. Extension 配置：mail collection = \`mail\`、SMTP URI = \`smtps://<gmail>%40gmail.com:<pw>@smtp.gmail.com:465\`

設定完成前 pipeline 會寫 \`mail/{id}\` 文件但無人讀取 — 不影響 in-app 通知正常運作。

## Verification

- ✅ \`npm run test\` 196/196 通過
- ✅ \`npx tsc --noEmit\` 乾淨
- ✅ \`npm run lint\` 0 new errors
- ✅ \`firebase deploy --dry-run firestore:rules\` 通過
- ⏭ 未 \`npm run build\`（live-serve cwd 限制）

## Test plan

- [ ] 使用者 A 在 settings 開 email 通知 → 確認 switch UI + Auth email 顯示
- [ ] 使用者 B 新增共同支出 → A 收到 in-app 通知（必要）
- [ ] Phase 2 完成後 → A 也收到 gmail（主旨「【群組名】 新增共同支出」）
- [ ] A 刪除結算 → B 收到通知 + mail（新增的 deleteSettlement 覆蓋）
- [ ] A 自己動作不寄給自己
- [ ] 未 opt-in 使用者不收 email（但收 in-app）

Closes #187