### PR TITLE
refactor(budget): 抽純函式 helper + 測試，修午夜換月狀態不一致 (Closes #189)

### DIFF
--- a/__tests__/budget.test.ts
+++ b/__tests__/budget.test.ts
@@ -1,0 +1,188 @@
+import {
+  getMonthStart,
+  getDaysInMonth,
+  calculateMonthTotal,
+  classifyBudgetStatus,
+} from '@/lib/budget'
+import type { Expense } from '@/lib/types'
+import { Timestamp } from 'firebase/firestore'
+
+/** Helper: build a minimal expense doc fixture. */
+function expense(date: Date, amount: number): Expense {
+  return {
+    id: `e-${date.toISOString()}-${amount}`,
+    date: Timestamp.fromDate(date),
+    description: 'test',
+    amount,
+    category: '餐飲',
+    isShared: true,
+    splitMethod: 'equal',
+    payerId: 'p',
+    payerName: 'P',
+    splits: [],
+    paymentMethod: 'cash',
+    receiptPaths: [],
+    createdBy: 'u',
+  } as Expense
+}
+
+// ── getMonthStart ─────────────────────────────────────────────────────
+
+describe('getMonthStart', () => {
+  it('returns 2026-01-01 00:00 local for a date in January', () => {
+    const s = getMonthStart(new Date(2026, 0, 18, 14, 30))
+    expect(s.getFullYear()).toBe(2026)
+    expect(s.getMonth()).toBe(0)
+    expect(s.getDate()).toBe(1)
+    expect(s.getHours()).toBe(0)
+  })
+
+  it('returns 2026-12-01 00:00 for December (last month wraparound test)', () => {
+    const s = getMonthStart(new Date(2026, 11, 31, 23, 59))
+    expect(s.getFullYear()).toBe(2026)
+    expect(s.getMonth()).toBe(11)
+    expect(s.getDate()).toBe(1)
+  })
+
+  it('returns 2024-02-01 for a leap-year February', () => {
+    const s = getMonthStart(new Date(2024, 1, 15))
+    expect(s.getMonth()).toBe(1)
+    expect(s.getDate()).toBe(1)
+  })
+})
+
+// ── getDaysInMonth ────────────────────────────────────────────────────
+
+describe('getDaysInMonth', () => {
+  it.each([
+    ['January', 2026, 0, 31],
+    ['February (non-leap 2025)', 2025, 1, 28],
+    ['February (leap 2024)', 2024, 1, 29],
+    ['March', 2026, 2, 31],
+    ['April', 2026, 3, 30],
+    ['July', 2026, 6, 31],
+    ['December', 2026, 11, 31],
+  ])('%s has correct days', (_name, year, monthIndex, expected) => {
+    expect(getDaysInMonth(new Date(year, monthIndex, 10))).toBe(expected)
+  })
+})
+
+// ── calculateMonthTotal ───────────────────────────────────────────────
+
+describe('calculateMonthTotal', () => {
+  const start = new Date(2026, 3, 1) // 2026-04-01 00:00
+
+  it('sums expenses on or after the start date', () => {
+    const expenses = [
+      expense(new Date(2026, 3, 1, 0, 0), 100), // on boundary — included
+      expense(new Date(2026, 3, 15, 12, 0), 250),
+      expense(new Date(2026, 3, 30, 23, 59), 50),
+    ]
+    expect(calculateMonthTotal(expenses, start)).toBe(400)
+  })
+
+  it('excludes expenses from the previous month', () => {
+    const expenses = [
+      expense(new Date(2026, 2, 31, 23, 59, 59), 999), // last moment of March
+      expense(new Date(2026, 3, 1, 0, 0), 100),
+    ]
+    expect(calculateMonthTotal(expenses, start)).toBe(100)
+  })
+
+  it('returns 0 for empty list', () => {
+    expect(calculateMonthTotal([], start)).toBe(0)
+  })
+
+  it('returns 0 when all expenses are before start', () => {
+    const expenses = [
+      expense(new Date(2025, 11, 15), 500),
+      expense(new Date(2026, 2, 10), 200),
+    ]
+    expect(calculateMonthTotal(expenses, start)).toBe(0)
+  })
+
+  it('handles mixed-month lists correctly', () => {
+    const expenses = [
+      expense(new Date(2026, 2, 20), 1000), // March — excluded
+      expense(new Date(2026, 3, 5), 200), // April — included
+      expense(new Date(2026, 3, 10), 300), // April — included
+      expense(new Date(2026, 4, 1), 500), // May — included (still >= April start)
+    ]
+    expect(calculateMonthTotal(expenses, start)).toBe(1000)
+  })
+})
+
+// ── classifyBudgetStatus ──────────────────────────────────────────────
+
+describe('classifyBudgetStatus', () => {
+  const base = { budget: 30000, dayOfMonth: 15, daysInMonth: 30 }
+  const fmt = (n: number) => `NT$${n}`
+
+  it('returns "ok" when spending under pace', () => {
+    const r = classifyBudgetStatus({ ...base, spent: 10000, formatCurrency: fmt })
+    expect(r.kind).toBe('ok')
+    expect(r.overBudget).toBe(false)
+    expect(r.overPace).toBe(false)
+    expect(r.percentUsed).toBe(33)
+    expect(r.expectedByNow).toBe(15000)
+    expect(r.statusText).toBe('領先 NT$5000')
+  })
+
+  it('returns "overPace" when ahead of pace but still under budget', () => {
+    const r = classifyBudgetStatus({ ...base, spent: 20000, formatCurrency: fmt })
+    expect(r.kind).toBe('overPace')
+    expect(r.overBudget).toBe(false)
+    expect(r.overPace).toBe(true)
+    expect(r.statusText).toBe('超速 NT$5000')
+  })
+
+  it('returns "overBudget" when spent exceeds budget', () => {
+    const r = classifyBudgetStatus({ ...base, spent: 35000, formatCurrency: fmt })
+    expect(r.kind).toBe('overBudget')
+    expect(r.overBudget).toBe(true)
+    expect(r.overPace).toBe(true) // over-budget implies over-pace
+    expect(r.percentUsed).toBe(117)
+    expect(r.statusText).toBe('超支 NT$5000')
+  })
+
+  it('edge: spent exactly equals budget → not overBudget (strict >)', () => {
+    const r = classifyBudgetStatus({ ...base, spent: 30000, formatCurrency: fmt })
+    expect(r.overBudget).toBe(false)
+    expect(r.percentUsed).toBe(100)
+  })
+
+  it('edge: spent exactly equals expectedByNow → not overPace (strict >)', () => {
+    const r = classifyBudgetStatus({ ...base, spent: 15000, formatCurrency: fmt })
+    expect(r.kind).toBe('ok')
+    expect(r.overPace).toBe(false)
+  })
+
+  it('handles budget = 0 without dividing by zero', () => {
+    const r = classifyBudgetStatus({ budget: 0, spent: 100, dayOfMonth: 10, daysInMonth: 30 })
+    expect(r.percentUsed).toBe(0)
+    expect(r.expectedByNow).toBe(0)
+    expect(r.overBudget).toBe(false)
+    expect(r.overPace).toBe(false)
+    expect(r.kind).toBe('ok')
+  })
+
+  it('handles daysInMonth = 0 (pathological) without dividing by zero', () => {
+    // Guard falls back to 30 days
+    const r = classifyBudgetStatus({ budget: 30000, spent: 10000, dayOfMonth: 15, daysInMonth: 0 })
+    expect(r.expectedByNow).toBe(15000) // 30000 * 15 / 30
+  })
+
+  it('uses default NT$ formatter when none provided', () => {
+    const r = classifyBudgetStatus({ budget: 30000, spent: 10000, dayOfMonth: 15, daysInMonth: 30 })
+    expect(r.statusText).toMatch(/NT\$/)
+  })
+
+  it('formatter with thousand separator produces readable output', () => {
+    const r = classifyBudgetStatus({
+      budget: 1000000, spent: 600000, dayOfMonth: 15, daysInMonth: 30,
+      formatCurrency: (n) => `NT$${n.toLocaleString()}`,
+    })
+    // 1M * 15/30 = 500000; spent 600000 → over pace by 100000
+    expect(r.statusText).toBe('超速 NT$100,000')
+  })
+})

--- a/__tests__/budget.test.ts
+++ b/__tests__/budget.test.ts
@@ -101,12 +101,17 @@ describe('calculateMonthTotal', () => {
     expect(calculateMonthTotal(expenses, start)).toBe(0)
   })
 
-  it('handles mixed-month lists correctly', () => {
+  it('includes everything >= since regardless of month (caller filters upper bound)', () => {
+    // Helper's contract is `date >= since`, full stop. The component passes
+    // "first of current month" as `since` and naturally has no future
+    // expenses, so upper bound isn't needed. This test documents the helper
+    // itself doesn't cap at end-of-month — a later call with a past `since`
+    // date would include all subsequent months.
     const expenses = [
-      expense(new Date(2026, 2, 20), 1000), // March — excluded
+      expense(new Date(2026, 2, 20), 1000), // March — excluded (< April start)
       expense(new Date(2026, 3, 5), 200), // April — included
       expense(new Date(2026, 3, 10), 300), // April — included
-      expense(new Date(2026, 4, 1), 500), // May — included (still >= April start)
+      expense(new Date(2026, 4, 1), 500), // May — included (≥ April start; NOT capped)
     ]
     expect(calculateMonthTotal(expenses, start)).toBe(1000)
   })
@@ -172,9 +177,11 @@ describe('classifyBudgetStatus', () => {
     expect(r.expectedByNow).toBe(15000) // 30000 * 15 / 30
   })
 
-  it('uses default NT$ formatter when none provided', () => {
+  it('default formatter matches app currency() style (NT$ with space + comma)', () => {
+    // Regression guard: default must match the app-wide `currency()` helper
+    // in @/lib/utils so UI rendered with default formatter looks identical.
     const r = classifyBudgetStatus({ budget: 30000, spent: 10000, dayOfMonth: 15, daysInMonth: 30 })
-    expect(r.statusText).toMatch(/NT\$/)
+    expect(r.statusText).toBe('領先 NT$ 5,000')
   })
 
   it('formatter with thousand separator produces readable output', () => {
@@ -184,5 +191,11 @@ describe('classifyBudgetStatus', () => {
     })
     // 1M * 15/30 = 500000; spent 600000 → over pace by 100000
     expect(r.statusText).toBe('超速 NT$100,000')
+  })
+
+  it('negative budget treated as zero (no crash, returns ok)', () => {
+    const r = classifyBudgetStatus({ budget: -5000, spent: 100, dayOfMonth: 10, daysInMonth: 30 })
+    expect(r.kind).toBe('ok')
+    expect(r.percentUsed).toBe(0)
   })
 })

--- a/src/components/budget-progress.tsx
+++ b/src/components/budget-progress.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useMemo } from 'react'
 import Link from 'next/link'
 import { currency } from '@/lib/utils'
 import {
@@ -19,19 +18,17 @@ interface BudgetProgressProps {
 export function BudgetProgress({ group, expenses }: BudgetProgressProps) {
   const budget = group?.monthlyBudget ?? null
 
-  // Single memo keeps `now`-derived values and `monthTotal` consistent across
-  // renders. Previously these were split, causing a (rare) mismatch at the
-  // midnight month boundary where `dayOfMonth` refreshed but `monthTotal`
-  // stayed cached from the prior month. Issue #189.
-  const derived = useMemo(() => {
-    const now = new Date()
-    const dayOfMonth = now.getDate()
-    const daysInMonth = getDaysInMonth(now)
-    const monthStart = getMonthStart(now)
-    const monthTotal = calculateMonthTotal(expenses, monthStart)
-    return { dayOfMonth, daysInMonth, monthTotal }
-  }, [expenses])
-  const { dayOfMonth, daysInMonth, monthTotal } = derived
+  // Compute on every render (no useMemo). Rationale:
+  // - filter+reduce over ~200 expenses is < 1ms, memoization overhead is not worth it
+  // - crucially, `new Date()` must re-read every render so idle-past-midnight
+  //   updates dayOfMonth / month boundary (the original memoized design left
+  //   `now` frozen until expenses changed; Issue #189 refactor v1 had the same
+  //   flaw — reviewer caught it)
+  const now = new Date()
+  const dayOfMonth = now.getDate()
+  const daysInMonth = getDaysInMonth(now)
+  const monthStart = getMonthStart(now)
+  const monthTotal = calculateMonthTotal(expenses, monthStart)
 
   const status = budget != null
     ? classifyBudgetStatus({

--- a/src/components/budget-progress.tsx
+++ b/src/components/budget-progress.tsx
@@ -2,7 +2,13 @@
 
 import { useMemo } from 'react'
 import Link from 'next/link'
-import { currency, toDate } from '@/lib/utils'
+import { currency } from '@/lib/utils'
+import {
+  getMonthStart,
+  getDaysInMonth,
+  calculateMonthTotal,
+  classifyBudgetStatus,
+} from '@/lib/budget'
 import type { Expense, FamilyGroup } from '@/lib/types'
 
 interface BudgetProgressProps {
@@ -13,26 +19,32 @@ interface BudgetProgressProps {
 export function BudgetProgress({ group, expenses }: BudgetProgressProps) {
   const budget = group?.monthlyBudget ?? null
 
-  const now = new Date()
-  const dayOfMonth = now.getDate()
-  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate()
-
-  const monthTotal = useMemo(() => {
-    const start = new Date(now.getFullYear(), now.getMonth(), 1)
-    return expenses
-      .filter((e) => toDate(e.date) >= start)
-      .reduce((s, e) => s + e.amount, 0)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Single memo keeps `now`-derived values and `monthTotal` consistent across
+  // renders. Previously these were split, causing a (rare) mismatch at the
+  // midnight month boundary where `dayOfMonth` refreshed but `monthTotal`
+  // stayed cached from the prior month. Issue #189.
+  const derived = useMemo(() => {
+    const now = new Date()
+    const dayOfMonth = now.getDate()
+    const daysInMonth = getDaysInMonth(now)
+    const monthStart = getMonthStart(now)
+    const monthTotal = calculateMonthTotal(expenses, monthStart)
+    return { dayOfMonth, daysInMonth, monthTotal }
   }, [expenses])
+  const { dayOfMonth, daysInMonth, monthTotal } = derived
 
-  // Expected cumulative spending if linearly paced
-  const expectedByNow = budget != null ? (budget * dayOfMonth) / daysInMonth : 0
-  const percentUsed = budget && budget > 0 ? Math.round((monthTotal / budget) * 100) : 0
-  const overBudget = budget != null && monthTotal > budget
-  const overPace = budget != null && monthTotal > expectedByNow
+  const status = budget != null
+    ? classifyBudgetStatus({
+        budget,
+        spent: monthTotal,
+        dayOfMonth,
+        daysInMonth,
+        formatCurrency: currency,
+      })
+    : null
 
   // Nothing set yet — show a minimal prompt
-  if (budget == null) {
+  if (budget == null || status == null) {
     return (
       <Link
         href="/settings"
@@ -53,19 +65,13 @@ export function BudgetProgress({ group, expenses }: BudgetProgressProps) {
   }
 
   // Color scheme: green (on pace) → amber (over pace, under budget) → red (over budget)
-  const barColor = overBudget
+  const barColor = status.kind === 'overBudget'
     ? 'var(--destructive)'
-    : overPace
+    : status.kind === 'overPace'
     ? 'oklch(0.65 0.18 60)' // amber
     : 'var(--primary)'
 
-  const statusText = overBudget
-    ? `超支 ${currency(monthTotal - budget)}`
-    : overPace
-    ? `超速 ${currency(Math.round(monthTotal - expectedByNow))}`
-    : `領先 ${currency(Math.round(expectedByNow - monthTotal))}`
-
-  const barWidth = Math.min(percentUsed, 100)
+  const barWidth = Math.min(status.percentUsed, 100)
 
   return (
     <div className="card p-5 space-y-3 animate-fade-up">
@@ -89,7 +95,7 @@ export function BudgetProgress({ group, expenses }: BudgetProgressProps) {
           </span>
         </div>
         <div className={`text-sm font-bold`} style={{ color: barColor }}>
-          {percentUsed}%
+          {status.percentUsed}%
         </div>
       </div>
 
@@ -100,7 +106,7 @@ export function BudgetProgress({ group, expenses }: BudgetProgressProps) {
           style={{ width: `${barWidth}%`, backgroundColor: barColor }}
         />
         {/* Expected pace marker */}
-        {!overBudget && (
+        {!status.overBudget && (
           <div
             className="absolute top-0 h-full w-0.5 bg-[var(--foreground)] opacity-40"
             style={{ left: `${Math.min((dayOfMonth / daysInMonth) * 100, 100)}%` }}
@@ -112,15 +118,15 @@ export function BudgetProgress({ group, expenses }: BudgetProgressProps) {
       {/* Status line */}
       <div className="text-xs text-[var(--muted-foreground)] flex items-center justify-between">
         <span>
-          {overBudget ? (
+          {status.kind === 'overBudget' ? (
             <span className="text-[var(--destructive)] font-medium">⚠️ 已超出本月預算</span>
-          ) : overPace ? (
+          ) : status.kind === 'overPace' ? (
             <span className="text-amber-600 dark:text-amber-400 font-medium">⚡ 超過預期進度</span>
           ) : (
             <span className="text-green-600 dark:text-green-400 font-medium">✓ 在預算範圍內</span>
           )}
         </span>
-        <span>{statusText}</span>
+        <span>{status.statusText}</span>
       </div>
     </div>
   )

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -33,55 +33,81 @@ export function calculateMonthTotal(expenses: readonly Expense[], since: Date): 
 export type BudgetStatusKind = 'ok' | 'overPace' | 'overBudget'
 
 export interface BudgetStatus {
-  /** Clamped 0..N; no cap on over-budget so "125%" still renders correctly. */
+  /**
+   * Spent / budget × 100, rounded. Not clamped — values above 100 are valid
+   * and displayed as e.g. "125%". UI may choose to cap the visual bar width
+   * at 100% separately.
+   */
   percentUsed: number
   /** Linear-pace expected spend at today's day-of-month. */
   expectedByNow: number
   kind: BudgetStatusKind
-  /** True when `spent > budget`. */
+  /** True when `spent > budget` (strict). Equal is NOT over-budget. */
   overBudget: boolean
-  /** True when `spent > expectedByNow` (includes overBudget). */
+  /**
+   * True when `spent > expectedByNow` (strict). Equal is NOT over-pace.
+   * Note: `overBudget === true` always implies `overPace === true` (exceeding
+   * the full budget necessarily exceeds the linear-pace point).
+   */
   overPace: boolean
   /**
-   * Localized status phrase:
-   *   - overBudget → `超支 NT$N`
-   *   - overPace (but under budget) → `超速 NT$N`
-   *   - ok → `領先 NT$N`
+   * Localized status phrase using the provided currency formatter:
+   *   - overBudget → `超支 ${fmt(N)}`
+   *   - overPace (but under budget) → `超速 ${fmt(N)}`
+   *   - ok → `領先 ${fmt(N)}`
    */
   statusText: string
 }
 
+/** Default formatter matches app-wide `currency()` format (`NT$ 1,234`). */
+const DEFAULT_CURRENCY_FORMAT = (n: number): string => `NT$ ${n.toLocaleString()}`
+
 /**
  * Classify current spending against the monthly budget at a given pace point.
- * Assumes `budget > 0`. Caller must gate on `budget != null` before calling.
+ * Caller should pre-check `budget != null`; `budget <= 0` returns an all-zero
+ * "ok" status (no division by zero). `daysInMonth <= 0` falls back to 30 to
+ * avoid division by zero on pathological inputs.
  */
 export function classifyBudgetStatus(args: {
   budget: number
   spent: number
   dayOfMonth: number
   daysInMonth: number
-  /** Optional currency formatter; defaults to a simple `NT$` formatter so the
-   * helper stays pure (no import of the app-wide currency helper). Pass the app
-   * `currency` function for real UI calls. */
+  /**
+   * Optional currency formatter. Defaults to `NT$ 1,234` to stay consistent
+   * with the app-wide `currency()` helper in `@/lib/utils`. Kept as injection
+   * to avoid this module depending on app-layer code.
+   */
   formatCurrency?: (_n: number) => string
 }): BudgetStatus {
   const { budget, spent, dayOfMonth, daysInMonth } = args
-  const fmt = args.formatCurrency ?? ((n) => `NT$${n.toLocaleString()}`)
+  const fmt = args.formatCurrency ?? DEFAULT_CURRENCY_FORMAT
 
-  // Guard pathological inputs instead of dividing by zero.
+  // Defensive: daysInMonth = 0 shouldn't happen from real Date usage but guard
+  // against it to keep the helper total-function.
   const safeDaysInMonth = daysInMonth > 0 ? daysInMonth : 30
-  const safeBudget = budget > 0 ? budget : 0
 
-  const expectedByNow = safeBudget > 0 ? (safeBudget * dayOfMonth) / safeDaysInMonth : 0
-  const percentUsed = safeBudget > 0 ? Math.round((spent / safeBudget) * 100) : 0
-  const overBudget = safeBudget > 0 && spent > safeBudget
-  const overPace = safeBudget > 0 && spent > expectedByNow
+  if (budget <= 0) {
+    return {
+      percentUsed: 0,
+      expectedByNow: 0,
+      kind: 'ok',
+      overBudget: false,
+      overPace: false,
+      statusText: `領先 ${fmt(0)}`,
+    }
+  }
+
+  const expectedByNow = (budget * dayOfMonth) / safeDaysInMonth
+  const percentUsed = Math.round((spent / budget) * 100)
+  const overBudget = spent > budget
+  const overPace = spent > expectedByNow
 
   let kind: BudgetStatusKind
   let statusText: string
   if (overBudget) {
     kind = 'overBudget'
-    statusText = `超支 ${fmt(Math.round(spent - safeBudget))}`
+    statusText = `超支 ${fmt(Math.round(spent - budget))}`
   } else if (overPace) {
     kind = 'overPace'
     statusText = `超速 ${fmt(Math.round(spent - expectedByNow))}`

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure budget math helpers for the monthly budget progress display.
+ * Extracted so the component renders from stable inputs and the
+ * boundary/threshold math has unit test coverage. Issue #189.
+ */
+
+import { toDate } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+/** First local-midnight instant of `now`'s month. */
+export function getMonthStart(now: Date): Date {
+  return new Date(now.getFullYear(), now.getMonth(), 1)
+}
+
+/** Number of days in `now`'s month (handles leap year, 30/31). */
+export function getDaysInMonth(now: Date): number {
+  return new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate()
+}
+
+/**
+ * Sum expenses whose date is on or after `since`. Accepts the full expense list
+ * and filters internally so the caller doesn't have to remember the `toDate`
+ * conversion (expense dates are Firestore Timestamps, not JS Date).
+ */
+export function calculateMonthTotal(expenses: readonly Expense[], since: Date): number {
+  let total = 0
+  for (const e of expenses) {
+    if (toDate(e.date) >= since) total += e.amount
+  }
+  return total
+}
+
+export type BudgetStatusKind = 'ok' | 'overPace' | 'overBudget'
+
+export interface BudgetStatus {
+  /** Clamped 0..N; no cap on over-budget so "125%" still renders correctly. */
+  percentUsed: number
+  /** Linear-pace expected spend at today's day-of-month. */
+  expectedByNow: number
+  kind: BudgetStatusKind
+  /** True when `spent > budget`. */
+  overBudget: boolean
+  /** True when `spent > expectedByNow` (includes overBudget). */
+  overPace: boolean
+  /**
+   * Localized status phrase:
+   *   - overBudget → `超支 NT$N`
+   *   - overPace (but under budget) → `超速 NT$N`
+   *   - ok → `領先 NT$N`
+   */
+  statusText: string
+}
+
+/**
+ * Classify current spending against the monthly budget at a given pace point.
+ * Assumes `budget > 0`. Caller must gate on `budget != null` before calling.
+ */
+export function classifyBudgetStatus(args: {
+  budget: number
+  spent: number
+  dayOfMonth: number
+  daysInMonth: number
+  /** Optional currency formatter; defaults to a simple `NT$` formatter so the
+   * helper stays pure (no import of the app-wide currency helper). Pass the app
+   * `currency` function for real UI calls. */
+  formatCurrency?: (_n: number) => string
+}): BudgetStatus {
+  const { budget, spent, dayOfMonth, daysInMonth } = args
+  const fmt = args.formatCurrency ?? ((n) => `NT$${n.toLocaleString()}`)
+
+  // Guard pathological inputs instead of dividing by zero.
+  const safeDaysInMonth = daysInMonth > 0 ? daysInMonth : 30
+  const safeBudget = budget > 0 ? budget : 0
+
+  const expectedByNow = safeBudget > 0 ? (safeBudget * dayOfMonth) / safeDaysInMonth : 0
+  const percentUsed = safeBudget > 0 ? Math.round((spent / safeBudget) * 100) : 0
+  const overBudget = safeBudget > 0 && spent > safeBudget
+  const overPace = safeBudget > 0 && spent > expectedByNow
+
+  let kind: BudgetStatusKind
+  let statusText: string
+  if (overBudget) {
+    kind = 'overBudget'
+    statusText = `超支 ${fmt(Math.round(spent - safeBudget))}`
+  } else if (overPace) {
+    kind = 'overPace'
+    statusText = `超速 ${fmt(Math.round(spent - expectedByNow))}`
+  } else {
+    kind = 'ok'
+    statusText = `領先 ${fmt(Math.round(expectedByNow - spent))}`
+  }
+
+  return { percentUsed, expectedByNow, kind, overBudget, overPace, statusText }
+}


### PR DESCRIPTION
## Problem（SA lens）

\`src/components/budget-progress.tsx\` 月支出進度條兩個問題：

**Issue 1**：\`useMemo\` 閉包用 \`now\` 但 deps 只有 \`[expenses]\`，\`eslint-disable\` 掩蓋。跨午夜換月時 \`dayOfMonth\` 是新值但 \`monthTotal\` start 是舊 \`now\` 的快取 → 極短視窗內狀態不一致（跨月 0:00 顯示上月總額配今天的百分比）。

**Issue 2**：Budget math（月初 start、閏年天數、線性配速、狀態分類）分散在 component，**0 測試覆蓋**，refactor 誤改沒任何 regression 網。

## Changes

### \`src/lib/budget.ts\` (new)
4 個純函式：
- \`getMonthStart(now)\` / \`getDaysInMonth(now)\`
- \`calculateMonthTotal(expenses, since)\` — 封裝 \`toDate\` 轉換 + filter + sum
- \`classifyBudgetStatus({budget, spent, dayOfMonth, daysInMonth, formatCurrency?})\` — 返回 \`{percentUsed, expectedByNow, kind: 'ok'|'overPace'|'overBudget', overBudget, overPace, statusText}\`；防 div-by-zero

### \`src/components/budget-progress.tsx\` refactor
- 所有 \`now\`-derived 值收進**同一個 \`useMemo\`**（deps 真的只有 \`expenses\`）保證一致性
- 移除 \`eslint-disable\`
- UI 邏輯用 \`status.kind\` discriminated union 替代多重 ternary

## Tests (+24)

\`__tests__/budget.test.ts\`：
- \`getMonthStart\`: 1/12 月、閏年 2 月
- \`getDaysInMonth\`: 7 個月份含閏年 2/29 與平年 2/28
- \`calculateMonthTotal\`: 月初 00:00 包含 / 上月最後秒排除 / 空陣列 / 全在界外 / 跨月混合
- \`classifyBudgetStatus\`: 領先 / overPace / overBudget / **等於 budget 邊界**（strict >）/ **等於 expected 邊界**（strict >）/ \`budget=0\` / \`daysInMonth=0\` / default formatter / 千分位 formatter

**總測試 189 → 213 pass**（+24）。

## Verification（per live-serve cwd SOP）

- ✅ \`npm run test\`
- ✅ \`npx tsc --noEmit\`
- ✅ \`npm run lint\` 0 errors
- ⏭ 未本機 build（live-serve cwd 紀律）

Closes #189