### PR TITLE
fix(ux): submit guard 防止快速連擊重複送出 (Closes #193)

### DIFF
--- a/__tests__/submit-guard.test.ts
+++ b/__tests__/submit-guard.test.ts
@@ -1,0 +1,56 @@
+import { createSubmitGuard } from '@/lib/submit-guard'
+
+describe('createSubmitGuard', () => {
+  it('allows first acquire', () => {
+    const g = createSubmitGuard()
+    expect(g.tryAcquire()).toBe(true)
+  })
+
+  it('rejects second acquire without release', () => {
+    const g = createSubmitGuard()
+    g.tryAcquire()
+    expect(g.tryAcquire()).toBe(false)
+  })
+
+  it('rejects many rapid acquires until released', () => {
+    const g = createSubmitGuard()
+    expect(g.tryAcquire()).toBe(true)
+    for (let i = 0; i < 5; i++) {
+      expect(g.tryAcquire()).toBe(false)
+    }
+    g.release()
+    expect(g.tryAcquire()).toBe(true)
+  })
+
+  it('allows re-acquire after release', () => {
+    const g = createSubmitGuard()
+    g.tryAcquire()
+    g.release()
+    expect(g.tryAcquire()).toBe(true)
+  })
+
+  it('isInFlight reflects acquire state', () => {
+    const g = createSubmitGuard()
+    expect(g.isInFlight()).toBe(false)
+    g.tryAcquire()
+    expect(g.isInFlight()).toBe(true)
+    g.release()
+    expect(g.isInFlight()).toBe(false)
+  })
+
+  it('release is idempotent when not held', () => {
+    const g = createSubmitGuard()
+    expect(() => g.release()).not.toThrow()
+    expect(g.isInFlight()).toBe(false)
+    expect(g.tryAcquire()).toBe(true)
+  })
+
+  it('guards across instances independently', () => {
+    const a = createSubmitGuard()
+    const b = createSubmitGuard()
+    a.tryAcquire()
+    expect(b.tryAcquire()).toBe(true)
+    expect(a.isInFlight()).toBe(true)
+    expect(b.isInFlight()).toBe(true)
+  })
+})

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -19,6 +19,7 @@ import { learnFromExpense, suggestCategory, isAuthError } from '@/lib/services/t
 import { useAuth, getActor } from '@/lib/auth'
 import { toDate } from '@/lib/utils'
 import { saveButtonLabel, type UploadProgress } from '@/lib/save-button-label'
+import { useSubmitGuard } from '@/lib/hooks/use-submit-guard'
 import { ref as storageRef, getDownloadURL } from 'firebase/storage'
 import { storage } from '@/lib/firebase'
 import { logger } from '@/lib/logger'
@@ -87,7 +88,7 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
   const [percentages, setPercentages] = useState<Record<string, number>>({})
   const [customAmounts, setCustomAmounts] = useState<Record<string, number>>({})
   const [weights, setWeights] = useState<Record<string, number>>({})
-  const [saving, setSaving] = useState(false)
+  const { inFlight: saving, run: runSubmit } = useSubmitGuard()
   /** Upload progress for receipt images: both 0 when idle. */
   const [uploadProgress, setUploadProgress] = useState<UploadProgress>({ current: 0, total: 0 })
   const [error, setError] = useState<string | null>(null)
@@ -415,117 +416,117 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         return
       }
     }
-    setSaving(true)
     setError(null)
-    try {
-      const expenseId = isEditing ? existingExpense!.id : genExpenseId()
-      const uploaderUid = user?.uid ?? payerId
-
-      // Upload any newly picked images first. On partial failure, uploadReceiptImages
-      // rolls back everything it uploaded in this call so we never leave orphans.
-      // Progress callback drives the "上傳中 N/M 張" indicator on the submit button.
-      let uploadedPaths: string[] = []
-      if (newFiles.length > 0) {
-        setUploadProgress({ current: 0, total: newFiles.length })
-        const result = await uploadReceiptImages(
-          group.id,
-          expenseId,
-          newFiles,
-          uploaderUid,
-          (current, total) => setUploadProgress({ current, total }),
-        )
-        uploadedPaths = result.paths
-      }
-
-      const finalPaths = [...existingReceiptPaths, ...uploadedPaths]
-
-      const input: ExpenseInput = {
-        date: new Date(`${date}T00:00:00`),
-        description: description.trim(),
-        amount: saveAmt,
-        category,
-        isShared,
-        splitMethod,
-        payerId,
-        payerName: members.find((m) => m.id === payerId)?.name ?? '',
-        splits,
-        paymentMethod,
-        receiptPaths: finalPaths,
-        note: note.trim() || undefined,
-        createdBy: uploaderUid,
-      }
+    await runSubmit(async () => {
       try {
-        if (isEditing) {
-          await updateExpense(group.id, existingExpense!.id, input, getActor(user))
-        } else {
-          await addExpense(group.id, input, getActor(user), expenseId)
+        const expenseId = isEditing ? existingExpense!.id : genExpenseId()
+        const uploaderUid = user?.uid ?? payerId
+
+        // Upload any newly picked images first. On partial failure, uploadReceiptImages
+        // rolls back everything it uploaded in this call so we never leave orphans.
+        // Progress callback drives the "上傳中 N/M 張" indicator on the submit button.
+        let uploadedPaths: string[] = []
+        if (newFiles.length > 0) {
+          setUploadProgress({ current: 0, total: newFiles.length })
+          const result = await uploadReceiptImages(
+            group.id,
+            expenseId,
+            newFiles,
+            uploaderUid,
+            (current, total) => setUploadProgress({ current, total }),
+          )
+          uploadedPaths = result.paths
         }
-      } catch (writeErr) {
-        // Firestore write failed — rollback freshly uploaded files so they don't orphan.
-        // If the rollback itself fails we must surface it: the remaining blobs
-        // incur storage cost and contain PII, and silently swallowing the error
-        // would leave no audit trail. See Issue #150 follow-up about a
-        // server-side orphan scanner.
-        if (uploadedPaths.length > 0) {
-          deleteReceiptImages(uploadedPaths).catch((rollbackErr) => {
-            logger.error('[ExpenseForm] Orphan receipts after failed Firestore write', {
+
+        const finalPaths = [...existingReceiptPaths, ...uploadedPaths]
+
+        const input: ExpenseInput = {
+          date: new Date(`${date}T00:00:00`),
+          description: description.trim(),
+          amount: saveAmt,
+          category,
+          isShared,
+          splitMethod,
+          payerId,
+          payerName: members.find((m) => m.id === payerId)?.name ?? '',
+          splits,
+          paymentMethod,
+          receiptPaths: finalPaths,
+          note: note.trim() || undefined,
+          createdBy: uploaderUid,
+        }
+        try {
+          if (isEditing) {
+            await updateExpense(group.id, existingExpense!.id, input, getActor(user))
+          } else {
+            await addExpense(group.id, input, getActor(user), expenseId)
+          }
+        } catch (writeErr) {
+          // Firestore write failed — rollback freshly uploaded files so they don't orphan.
+          // If the rollback itself fails we must surface it: the remaining blobs
+          // incur storage cost and contain PII, and silently swallowing the error
+          // would leave no audit trail. See Issue #150 follow-up about a
+          // server-side orphan scanner.
+          if (uploadedPaths.length > 0) {
+            deleteReceiptImages(uploadedPaths).catch((rollbackErr) => {
+              logger.error('[ExpenseForm] Orphan receipts after failed Firestore write', {
+                groupId: group.id,
+                expenseId,
+                paths: uploadedPaths,
+                rollbackErr,
+              })
+            })
+          }
+          throw writeErr
+        }
+
+        // Firestore write succeeded — now safe to delete receipts the user removed.
+        if (removedPaths.length > 0) {
+          deleteReceiptImages(removedPaths).catch((removeErr) => {
+            logger.error('[ExpenseForm] Failed to delete removed receipts', {
               groupId: group.id,
               expenseId,
-              paths: uploadedPaths,
-              rollbackErr,
+              paths: removedPaths,
+              removeErr,
             })
           })
         }
-        throw writeErr
-      }
-
-      // Firestore write succeeded — now safe to delete receipts the user removed.
-      if (removedPaths.length > 0) {
-        deleteReceiptImages(removedPaths).catch((removeErr) => {
-          logger.error('[ExpenseForm] Failed to delete removed receipts', {
-            groupId: group.id,
-            expenseId,
-            paths: removedPaths,
-            removeErr,
-          })
+        // Create recurring template if toggled
+        if (setAsRecurring && !isEditing) {
+          addRecurringExpense(group.id, {
+            description: input.description,
+            amount: input.amount,
+            category: input.category,
+            payerId: input.payerId,
+            payerName: input.payerName,
+            isShared: input.isShared,
+            splitMethod: input.splitMethod,
+            splits: input.splits,
+            paymentMethod: input.paymentMethod,
+            frequency: 'monthly',
+            dayOfMonth: recurringDayOfMonth,
+            startDate: input.date,
+            createdBy: input.createdBy,
+          }).catch(() => { /* silent — template creation is non-critical */ })
+        }
+        // Learn from this save to improve future auto-categorization
+        learnFromExpense(group.id, input.description, input.category).catch((e) => {
+          // Auth errors go to system_logs (Issue #164); other errors stay silent
+          // since rule learning is best-effort and must never block save UX.
+          if (isAuthError(e)) logger.error('[ExpenseForm] learnFromExpense auth error', e)
         })
+        // Clear draft after successful save
+        if (draftKey && typeof window !== 'undefined') {
+          sessionStorage.removeItem(draftKey)
+        }
+        onSaved()
+      } catch (e: unknown) {
+        if (e instanceof ReceiptUploadError) setError(`圖片上傳失敗：${e.message}`)
+        else setError(e instanceof Error ? e.message : '儲存失敗')
+      } finally {
+        setUploadProgress({ current: 0, total: 0 })
       }
-      // Create recurring template if toggled
-      if (setAsRecurring && !isEditing) {
-        addRecurringExpense(group.id, {
-          description: input.description,
-          amount: input.amount,
-          category: input.category,
-          payerId: input.payerId,
-          payerName: input.payerName,
-          isShared: input.isShared,
-          splitMethod: input.splitMethod,
-          splits: input.splits,
-          paymentMethod: input.paymentMethod,
-          frequency: 'monthly',
-          dayOfMonth: recurringDayOfMonth,
-          startDate: input.date,
-          createdBy: input.createdBy,
-        }).catch(() => { /* silent — template creation is non-critical */ })
-      }
-      // Learn from this save to improve future auto-categorization
-      learnFromExpense(group.id, input.description, input.category).catch((e) => {
-        // Auth errors go to system_logs (Issue #164); other errors stay silent
-        // since rule learning is best-effort and must never block save UX.
-        if (isAuthError(e)) logger.error('[ExpenseForm] learnFromExpense auth error', e)
-      })
-      // Clear draft after successful save
-      if (draftKey && typeof window !== 'undefined') {
-        sessionStorage.removeItem(draftKey)
-      }
-      onSaved()
-    } catch (e: unknown) {
-      if (e instanceof ReceiptUploadError) setError(`圖片上傳失敗：${e.message}`)
-      else setError(e instanceof Error ? e.message : '儲存失敗')
-    } finally {
-      setSaving(false)
-      setUploadProgress({ current: 0, total: 0 })
-    }
+    })
   }
 
   const amt = parseFloat(amount) || 0

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -417,6 +417,11 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
       }
     }
     setError(null)
+    // Guard acquired here, inside runSubmit. All earlier validation (buildSplits,
+    // parseFloat, sum check) is synchronous, so tryAcquire() runs before this
+    // async handler yields to the event loop — second clicks are blocked.
+    // If future changes insert any await between the click entry and this
+    // runSubmit call, move the guard earlier.
     await runSubmit(async () => {
       try {
         const expenseId = isEditing ? existingExpense!.id : genExpenseId()

--- a/src/components/quick-add-bar.tsx
+++ b/src/components/quick-add-bar.tsx
@@ -11,6 +11,7 @@ import { addExpense, type ExpenseInput } from '@/lib/services/expense-service'
 import { parseExpense } from '@/lib/services/local-expense-parser'
 import { learnFromExpense, suggestCategory, isAuthError } from '@/lib/services/transaction-rules-service'
 import { useToast } from '@/components/toast'
+import { useSubmitGuard } from '@/lib/hooks/use-submit-guard'
 import { logger } from '@/lib/logger'
 
 export function QuickAddBar() {
@@ -26,7 +27,7 @@ export function QuickAddBar() {
   const [amount, setAmount] = useState('')
   const [category, setCategory] = useState('')
   const [autoFilled, setAutoFilled] = useState(false)
-  const [saving, setSaving] = useState(false)
+  const { inFlight: saving, run: runSubmit } = useSubmitGuard()
 
   const activeCategories = useMemo(
     () => categories.filter((c) => c.isActive).map((c) => c.name).slice(0, 6),
@@ -119,30 +120,29 @@ export function QuickAddBar() {
       createdBy: user.uid,
     }
 
-    setSaving(true)
-    try {
-      await addExpense(group.id, input, { id: payerId, name: payerName })
-      // Learn the (description, category) pair for future auto-fill suggestions.
-      // Non-fatal by design — except for auth errors, which surface to the user
-      // so they can re-authenticate (Issue #164).
-      learnFromExpense(group.id, description.trim(), input.category).catch((e) => {
-        if (isAuthError(e)) {
-          logger.error('[QuickAdd] learnFromExpense auth error', e)
-          addToast('登入狀態失效，規則學習已停止', 'warning')
-        }
-      })
-      addToast(`已記錄 ${description.trim()} $${amt}`, 'success')
-      setDescription('')
-      setAmount('')
-      setCategory('')
-      setAutoFilled(false)
-      setExpanded(false)
-    } catch (e) {
-      logger.error('[QuickAdd] Failed:', e)
-      addToast('記帳失敗，請重試', 'error')
-    } finally {
-      setSaving(false)
-    }
+    await runSubmit(async () => {
+      try {
+        await addExpense(group.id, input, { id: payerId, name: payerName })
+        // Learn the (description, category) pair for future auto-fill suggestions.
+        // Non-fatal by design — except for auth errors, which surface to the user
+        // so they can re-authenticate (Issue #164).
+        learnFromExpense(group.id, description.trim(), input.category).catch((e) => {
+          if (isAuthError(e)) {
+            logger.error('[QuickAdd] learnFromExpense auth error', e)
+            addToast('登入狀態失效，規則學習已停止', 'warning')
+          }
+        })
+        addToast(`已記錄 ${description.trim()} $${amt}`, 'success')
+        setDescription('')
+        setAmount('')
+        setCategory('')
+        setAutoFilled(false)
+        setExpanded(false)
+      } catch (e) {
+        logger.error('[QuickAdd] Failed:', e)
+        addToast('記帳失敗，請重試', 'error')
+      }
+    })
   }
 
   if (!group) return null

--- a/src/components/quick-add-bar.tsx
+++ b/src/components/quick-add-bar.tsx
@@ -120,6 +120,11 @@ export function QuickAddBar() {
       createdBy: user.uid,
     }
 
+    // Guard acquired here, inside runSubmit. All earlier validation is sync,
+    // so the guard's tryAcquire() runs before this handler yields — second
+    // clicks arrive after the sync run() body has already flipped the flag.
+    // If future changes insert any await between the click entry and this
+    // runSubmit call, move the guard earlier.
     await runSubmit(async () => {
       try {
         await addExpense(group.id, input, { id: payerId, name: payerName })

--- a/src/lib/hooks/use-submit-guard.ts
+++ b/src/lib/hooks/use-submit-guard.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useRef, useState } from 'react'
-import { createSubmitGuard, type SubmitGuard } from '@/lib/submit-guard'
+import { createSubmitGuard } from '@/lib/submit-guard'
 
 /**
  * React hook wrapping `createSubmitGuard` for form handlers.
@@ -23,23 +23,21 @@ import { createSubmitGuard, type SubmitGuard } from '@/lib/submit-guard'
  *
  * Returns `undefined` when a second concurrent call is rejected, so callers
  * can distinguish "did not run" from "ran and returned undefined".
+ *
+ * Scope: this is a client-side, single-JS-environment guard. It does NOT
+ * protect against cross-tab, post-reload, or API-bypass duplicates. For those
+ * paths, rely on server-side idempotency (Firestore rule `allow create: if
+ * !exists(...)` on pre-generated doc IDs, or a dedicated idempotencyKey).
  */
-// eslint-disable-next-line no-unused-vars
-type RunFn = <T>(fn: () => Promise<T>) => Promise<T | undefined>
-
-export function useSubmitGuard(): {
-  inFlight: boolean
-  run: RunFn
-} {
-  const guardRef = useRef<SubmitGuard | null>(null)
-  if (guardRef.current === null) {
-    guardRef.current = createSubmitGuard()
-  }
+export function useSubmitGuard() {
+  // Direct init: createSubmitGuard() is a pure, cheap allocation, and useRef
+  // only invokes the initializer once. Avoids render-body side effects.
+  const guardRef = useRef(createSubmitGuard())
   const [inFlight, setInFlight] = useState(false)
 
-  const run = useCallback(async <T,>(fn: () => Promise<T>): Promise<T | undefined> => {
+  const run = useCallback(async function runImpl<T>(fn: () => Promise<T>): Promise<T | undefined> {
     const guard = guardRef.current
-    if (!guard || !guard.tryAcquire()) return undefined
+    if (!guard.tryAcquire()) return undefined
     setInFlight(true)
     try {
       return await fn()

--- a/src/lib/hooks/use-submit-guard.ts
+++ b/src/lib/hooks/use-submit-guard.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+import { createSubmitGuard, type SubmitGuard } from '@/lib/submit-guard'
+
+/**
+ * React hook wrapping `createSubmitGuard` for form handlers.
+ *
+ * Why this exists:
+ *   `disabled={saving}` on a submit button does NOT block a second click that
+ *   arrives before React flushes the re-render. On mobile, fast taps slip
+ *   through and call `handleSave` twice — duplicate records. The guard flips
+ *   a ref synchronously so the second call sees the in-flight state and bails.
+ *
+ * Usage:
+ *   const { inFlight, run } = useSubmitGuard()
+ *   async function onClick() {
+ *     await run(async () => {
+ *       await addExpense(...)
+ *     })
+ *   }
+ *   // disabled={inFlight} still valuable for UI — but the real guard is `run`.
+ *
+ * Returns `undefined` when a second concurrent call is rejected, so callers
+ * can distinguish "did not run" from "ran and returned undefined".
+ */
+// eslint-disable-next-line no-unused-vars
+type RunFn = <T>(fn: () => Promise<T>) => Promise<T | undefined>
+
+export function useSubmitGuard(): {
+  inFlight: boolean
+  run: RunFn
+} {
+  const guardRef = useRef<SubmitGuard | null>(null)
+  if (guardRef.current === null) {
+    guardRef.current = createSubmitGuard()
+  }
+  const [inFlight, setInFlight] = useState(false)
+
+  const run = useCallback(async <T,>(fn: () => Promise<T>): Promise<T | undefined> => {
+    const guard = guardRef.current
+    if (!guard || !guard.tryAcquire()) return undefined
+    setInFlight(true)
+    try {
+      return await fn()
+    } finally {
+      guard.release()
+      setInFlight(false)
+    }
+  }, [])
+
+  return { inFlight, run }
+}

--- a/src/lib/submit-guard.ts
+++ b/src/lib/submit-guard.ts
@@ -1,0 +1,35 @@
+/**
+ * A synchronous in-flight guard for form submissions.
+ *
+ * React state (`useState`) updates are batched — `setSaving(true)` does not
+ * block a second click that happens before the next render flush. On mobile,
+ * fast taps (touchend + click within ~50–100ms) can slip through an
+ * `disabled={saving}` button and trigger `handleSave` twice, causing duplicate
+ * writes (e.g. duplicate expense records). This guard uses a mutable flag that
+ * flips synchronously inside the click handler, closing that race window.
+ *
+ * Pair it with `useSubmitGuard` (a React hook) to also drive a UI-visible
+ * "saving" state via `useState`. See Issue #193.
+ */
+export interface SubmitGuard {
+  tryAcquire(): boolean
+  release(): void
+  isInFlight(): boolean
+}
+
+export function createSubmitGuard(): SubmitGuard {
+  let inFlight = false
+  return {
+    tryAcquire(): boolean {
+      if (inFlight) return false
+      inFlight = true
+      return true
+    },
+    release(): void {
+      inFlight = false
+    },
+    isInFlight(): boolean {
+      return inFlight
+    },
+  }
+}


### PR DESCRIPTION
## 摘要

QuickAddBar 和 ExpenseForm 在 mobile 上，快速雙擊送出按鈕可能造成 **重複記帳**。本 PR 以同步守門機制關閉這個 race window。

## 問題陳述（PM / SA 雙角度）

### PM 視角
- 家計本是金錢紀錄 app，重複記帳 = 信任危機
- Mobile 用戶最常遇到（fat-finger、touchend+click、觸控延遲）
- 使用者發現後需手動刪除 → 留下負面印象

### SA 視角
- \`disabled={saving}\` 靠 \`useState\`，屬 **async batched** 更新
- 第一次 click → \`setSaving(true)\` 入 batch queue → 但 render 未 flush
- 第二次 click（50–100ms 內）→ button 仍 enabled → handler 再次執行
- 第二次 handler 的 \`saving\` 閉包值仍是 false → 寫入 Firestore

## 解法

1. **\`src/lib/submit-guard.ts\`** — 純函式，\`createSubmitGuard()\` 返回 { tryAcquire, release, isInFlight }，mutable flag **同步**翻轉
2. **\`src/lib/hooks/use-submit-guard.ts\`** — React hook 包 \`run(asyncFn)\`：useRef 做守門（同步），useState 供 UI disabled 顯示（async 追蹤）
3. 改寫 QuickAddBar、ExpenseForm 的 handleSave 使用 \`runSubmit\`
4. 新增 7 個單元測試

## 測試

- \`__tests__/submit-guard.test.ts\` — 7/7 pass
- 全專案：**552/552 pass**
- Lint：0 error（pre-existing warnings 未新增）
- Build：OK

## 風險

- **低**。純疊加式守門，不改原流程
- Fallback：若 guard 失效，\`disabled={saving}\` 機制仍存在
- 無 breaking change

## 測試計畫（人工驗證）

- [ ] Mobile Safari：快速雙擊「儲存」，只產生 1 筆記錄
- [ ] Desktop：單擊正常、連擊被阻擋
- [ ] 儲存失敗時 guard 釋放，允許重試

Closes #193