### PR TITLE
perf(settlement): batch activity log N+1 合併成 1 筆 summary (Closes #196)

### DIFF
--- a/__tests__/batch-settlement-summary.test.ts
+++ b/__tests__/batch-settlement-summary.test.ts
@@ -25,10 +25,12 @@ describe('formatBatchSettlementSummary', () => {
       ],
       fmt,
     )
-    expect(out).toBe('批次結清（共 3 筆）：爸爸→泳淳 NT$ 100、媽媽→泳淳 NT$ 200、爸爸→媽媽 NT$ 300')
+    expect(out).toBe(
+      '批次結清（共 3 筆）：爸爸 → 泳淳 NT$ 100、媽媽 → 泳淳 NT$ 200、爸爸 → 媽媽 NT$ 300',
+    )
   })
 
-  it('truncates after 3 items when count > 3', () => {
+  it('truncates after 3 items when count > 3 and names the REMAINING count', () => {
     const out = formatBatchSettlementSummary(
       [
         { fromMemberName: 'A', toMemberName: 'B', amount: 10 },
@@ -39,11 +41,25 @@ describe('formatBatchSettlementSummary', () => {
       ],
       fmt,
     )
-    expect(out).toContain('A→B NT$ 10')
-    expect(out).toContain('C→D NT$ 20')
-    expect(out).toContain('E→F NT$ 30')
-    expect(out).not.toContain('G→H')
-    expect(out).toContain('…等 5 筆')
+    expect(out).toContain('A → B NT$ 10')
+    expect(out).toContain('C → D NT$ 20')
+    expect(out).toContain('E → F NT$ 30')
+    expect(out).not.toContain('G → H')
+    // 5 total, 3 shown → "…等 2 筆" (remaining), not "…等 5 筆" (total).
+    expect(out).toContain('…等 2 筆')
+    expect(out).toContain('共 5 筆')
+  })
+
+  it('shows exactly 0 remaining when count === MAX_INLINE', () => {
+    const out = formatBatchSettlementSummary(
+      [
+        { fromMemberName: 'A', toMemberName: 'B', amount: 1 },
+        { fromMemberName: 'C', toMemberName: 'D', amount: 2 },
+        { fromMemberName: 'E', toMemberName: 'F', amount: 3 },
+      ],
+      fmt,
+    )
+    expect(out).not.toContain('…等')
   })
 
   it('uses the provided amount formatter', () => {
@@ -68,8 +84,10 @@ describe('formatBatchSettlementSummary', () => {
       amount: i,
     }))
     const out = formatBatchSettlementSummary(items, fmt)
-    expect(out).toContain('…等 50 筆')
-    expect(out).toContain('M0→N0')
-    expect(out).not.toContain('M3→N3')
+    // 50 total, 3 shown → "…等 47 筆".
+    expect(out).toContain('…等 47 筆')
+    expect(out).toContain('共 50 筆')
+    expect(out).toContain('M0 → N0')
+    expect(out).not.toContain('M3 → N3')
   })
 })

--- a/__tests__/batch-settlement-summary.test.ts
+++ b/__tests__/batch-settlement-summary.test.ts
@@ -1,0 +1,75 @@
+import { formatBatchSettlementSummary } from '@/lib/batch-settlement-summary'
+
+const fmt = (n: number) => `NT$ ${n.toLocaleString()}`
+
+describe('formatBatchSettlementSummary', () => {
+  it('degrades gracefully on empty list', () => {
+    expect(formatBatchSettlementSummary([], fmt)).toBe('批次結清（無項目）')
+  })
+
+  it('renders a single item in the same shape as a solo settlement', () => {
+    expect(
+      formatBatchSettlementSummary(
+        [{ fromMemberName: '爸爸', toMemberName: '泳淳', amount: 2000 }],
+        fmt,
+      ),
+    ).toBe('批次結清：爸爸 → 泳淳 NT$ 2,000')
+  })
+
+  it('lists all items when count ≤ 3', () => {
+    const out = formatBatchSettlementSummary(
+      [
+        { fromMemberName: '爸爸', toMemberName: '泳淳', amount: 100 },
+        { fromMemberName: '媽媽', toMemberName: '泳淳', amount: 200 },
+        { fromMemberName: '爸爸', toMemberName: '媽媽', amount: 300 },
+      ],
+      fmt,
+    )
+    expect(out).toBe('批次結清（共 3 筆）：爸爸→泳淳 NT$ 100、媽媽→泳淳 NT$ 200、爸爸→媽媽 NT$ 300')
+  })
+
+  it('truncates after 3 items when count > 3', () => {
+    const out = formatBatchSettlementSummary(
+      [
+        { fromMemberName: 'A', toMemberName: 'B', amount: 10 },
+        { fromMemberName: 'C', toMemberName: 'D', amount: 20 },
+        { fromMemberName: 'E', toMemberName: 'F', amount: 30 },
+        { fromMemberName: 'G', toMemberName: 'H', amount: 40 },
+        { fromMemberName: 'I', toMemberName: 'J', amount: 50 },
+      ],
+      fmt,
+    )
+    expect(out).toContain('A→B NT$ 10')
+    expect(out).toContain('C→D NT$ 20')
+    expect(out).toContain('E→F NT$ 30')
+    expect(out).not.toContain('G→H')
+    expect(out).toContain('…等 5 筆')
+  })
+
+  it('uses the provided amount formatter', () => {
+    const out = formatBatchSettlementSummary(
+      [{ fromMemberName: '小明', toMemberName: '小華', amount: 1500 }],
+      (n) => `$${n}`,
+    )
+    expect(out).toBe('批次結清：小明 → 小華 $1500')
+  })
+
+  it('falls back to a default formatter if none supplied', () => {
+    const out = formatBatchSettlementSummary([
+      { fromMemberName: 'A', toMemberName: 'B', amount: 1234 },
+    ])
+    expect(out).toMatch(/A → B .+1/)
+  })
+
+  it('handles very large batches deterministically', () => {
+    const items = Array.from({ length: 50 }, (_, i) => ({
+      fromMemberName: `M${i}`,
+      toMemberName: `N${i}`,
+      amount: i,
+    }))
+    const out = formatBatchSettlementSummary(items, fmt)
+    expect(out).toContain('…等 50 筆')
+    expect(out).toContain('M0→N0')
+    expect(out).not.toContain('M3→N3')
+  })
+})

--- a/src/lib/batch-settlement-summary.ts
+++ b/src/lib/batch-settlement-summary.ts
@@ -1,0 +1,46 @@
+/**
+ * Build a single human-readable summary string for a batched settlement
+ * action, so the activity log records one row per user action (not N rows
+ * for N debts closed).
+ *
+ * Format:
+ *   - 0 items  → "批次結清（無項目）"       (defensive; caller should filter)
+ *   - 1 item   → "批次結清：<from> → <to> <amount>"
+ *   - 2-3      → "批次結清（共 N 筆）：<list joined by 、>"
+ *   - > 3      → "批次結清（共 N 筆）：<first 3 joined>…等 N 筆"
+ *
+ * Pure function — injectable `formatAmount` keeps it locale-agnostic for
+ * tests. Issue #196.
+ */
+export interface SettlementSummaryItem {
+  fromMemberName: string
+  toMemberName: string
+  amount: number
+}
+
+const DEFAULT_AMOUNT_FORMAT = (n: number): string => `NT$ ${n.toLocaleString()}`
+const MAX_INLINE = 3
+
+export function formatBatchSettlementSummary(
+  settlements: ReadonlyArray<SettlementSummaryItem>,
+  formatAmount: (_n: number) => string = DEFAULT_AMOUNT_FORMAT,
+): string {
+  if (settlements.length === 0) return '批次結清（無項目）'
+
+  if (settlements.length === 1) {
+    const s = settlements[0]
+    return `批次結清：${s.fromMemberName} → ${s.toMemberName} ${formatAmount(s.amount)}`
+  }
+
+  const shown = settlements
+    .slice(0, MAX_INLINE)
+    .map((s) => `${s.fromMemberName}→${s.toMemberName} ${formatAmount(s.amount)}`)
+    .join('、')
+
+  const tail =
+    settlements.length > MAX_INLINE
+      ? `…等 ${settlements.length} 筆`
+      : ''
+
+  return `批次結清（共 ${settlements.length} 筆）：${shown}${tail}`
+}

--- a/src/lib/batch-settlement-summary.ts
+++ b/src/lib/batch-settlement-summary.ts
@@ -34,13 +34,14 @@ export function formatBatchSettlementSummary(
 
   const shown = settlements
     .slice(0, MAX_INLINE)
-    .map((s) => `${s.fromMemberName}→${s.toMemberName} ${formatAmount(s.amount)}`)
+    .map((s) => `${s.fromMemberName} → ${s.toMemberName} ${formatAmount(s.amount)}`)
     .join('、')
 
-  const tail =
-    settlements.length > MAX_INLINE
-      ? `…等 ${settlements.length} 筆`
-      : ''
+  // tail is the count of items NOT shown inline ("remaining"), not the total.
+  // "列 3 筆 + …等 5 筆" would read as if 5 more existed after the 3; we want
+  // "列 3 筆 + …等 2 筆" for 5 total. Issue #196 review feedback.
+  const remaining = settlements.length - MAX_INLINE
+  const tail = remaining > 0 ? `…等 ${remaining} 筆` : ''
 
   return `批次結清（共 ${settlements.length} 筆）：${shown}${tail}`
 }

--- a/src/lib/services/settlement-service.ts
+++ b/src/lib/services/settlement-service.ts
@@ -3,6 +3,7 @@ import { db, auth } from '@/lib/firebase'
 import { addActivityLog } from './activity-log-service'
 import { addNotification } from './notification-service'
 import { notifyByEmailFanOut } from './email-notification'
+import { formatBatchSettlementSummary } from '@/lib/batch-settlement-summary'
 import { currency } from '@/lib/utils'
 
 import { logger } from '@/lib/logger'
@@ -102,23 +103,23 @@ export async function addSettlements(
     })
   }
 
-  await batch.commit()
-
+  // Consolidate the batch into a single activity log row. Previously we wrote
+  // N log rows in a serial for/await, producing N round-trips and N nearly
+  // identical entries. Issue #196.
   if (actor) {
-    try {
-      for (const s of settlements) {
-        await addActivityLog(groupId, {
-          action: 'settlement_created',
-          actorId: actor.id,
-          actorName: actor.name,
-          description: `批次結清：${s.fromMemberName} → ${s.toMemberName} ${currency(s.amount)}`,
-          entityId: '',
-        })
-      }
-    } catch (e) {
-      logger.error('[SettlementService] Failed to log batch activity:', e)
-    }
+    const logRef = doc(collection(db, 'groups', groupId, 'activityLogs'))
+    batch.set(logRef, {
+      groupId,
+      action: 'settlement_created',
+      actorName: actor.name,
+      actorId: actor.id,
+      description: formatBatchSettlementSummary(settlements, currency),
+      entityId: null,
+      createdAt: serverTimestamp(),
+    })
   }
+
+  await batch.commit()
 
   // Notify other group members about the batch settlement (in-app + email).
   try {


### PR DESCRIPTION
## 摘要

\`addSettlements\` 批次結清時，原本用 for + await 逐筆寫 N 筆 activity log（序列 round-trip + 視覺噪音）。本 PR 合併成 1 筆摘要，併入 writeBatch，N 次寫入 → 1 次 commit。

## 問題陳述

**SA**：Firestore 寫入 N+1，家庭結清 10 筆時 10 次序列 round-trip，成本 × 10
**PM**：活動日誌列表顯示 10 筆幾乎一樣的「批次結清：A→B xxx」，看不出這是「一次」動作

## 解法

1. \`src/lib/batch-settlement-summary.ts\` — 純函式 \`formatBatchSettlementSummary\`
   - 0/1/≤3/>3 四種格式；formatter 可注入
2. \`settlement-service.ts\` — 把 activity log 併入原本的 writeBatch，1 次 commit
3. 移除舊 for/await loop

## 測試

- 7 個新單元測試（0/1/3/5/50 筆 + formatter 注入 + default formatter）
- 全專案：**552/552 pass**
- Lint：0 error（pre-existing warnings 未新增）
- Build：OK

## 變更幅度

\`\`\`
__tests__/batch-settlement-summary.test.ts | 75 +++
src/lib/batch-settlement-summary.ts        | 46 +++
src/lib/services/settlement-service.ts     | 31 +/-
\`\`\`

## 風險

- 低。activity log 的 entityId 從 \`''\` 改 \`null\`，與 activity-log-service 內部 \`?? null\` 一致
- 無 breaking change
- Notification fan-out 不變

Closes #196