### PR TITLE
feat(budget): 月底預測支出（超標提前預警） (Closes #203)

### DIFF
--- a/__tests__/budget.test.ts
+++ b/__tests__/budget.test.ts
@@ -249,4 +249,36 @@ describe('classifyBudgetStatus', () => {
     expect(r.projected).toBe(30000)
     expect(r.projectedOverBudget).toBe(false)
   })
+
+  it('projection: overPace and projectedOverBudget track the same threshold', () => {
+    // Math: spent > budget*day/days  ⇔  projected > budget. The two flags are
+    // two labels for the same inequality. Reviewer caught the JSDoc had this
+    // backwards — this test pins the correct relationship.
+    const overPace = classifyBudgetStatus({ budget: 30000, spent: 20000, dayOfMonth: 15, daysInMonth: 30 })
+    expect(overPace.overPace).toBe(true)
+    expect(overPace.projectedOverBudget).toBe(true)
+
+    const onPace = classifyBudgetStatus({ budget: 30000, spent: 15000, dayOfMonth: 15, daysInMonth: 30 })
+    expect(onPace.overPace).toBe(false)
+    expect(onPace.projectedOverBudget).toBe(false)
+
+    const underPace = classifyBudgetStatus({ budget: 30000, spent: 10000, dayOfMonth: 15, daysInMonth: 30 })
+    expect(underPace.overPace).toBe(false)
+    expect(underPace.projectedOverBudget).toBe(false)
+  })
+
+  it('projection: daysInMonth=0 fallback (30) applies to projected too', () => {
+    const r = classifyBudgetStatus({ budget: 30000, spent: 10000, dayOfMonth: 15, daysInMonth: 0 })
+    expect(r.projected).toBe(20000) // 10000 / 15 * 30
+  })
+
+  it('projection: percent derives from rounded projected (display consistency)', () => {
+    // Was a reviewer-flagged inconsistency: percent computed from raw float
+    // could differ from the displayed rounded amount. Now both use the
+    // already-rounded projected value.
+    const r = classifyBudgetStatus({ budget: 30000, spent: 9999, dayOfMonth: 15, daysInMonth: 30 })
+    // 9999 / 15 * 30 = 19998 (exact integer, round no-op); percent = 67
+    expect(r.projected).toBe(19998)
+    expect(r.projectedPercent).toBe(67)
+  })
 })

--- a/__tests__/budget.test.ts
+++ b/__tests__/budget.test.ts
@@ -198,4 +198,55 @@ describe('classifyBudgetStatus', () => {
     expect(r.kind).toBe('ok')
     expect(r.percentUsed).toBe(0)
   })
+
+  // ── Projection (Issue #203) ─────────────────────────────────────────
+
+  it('projection: day 15/30, spent 10000 → projected 20000 (linear)', () => {
+    const r = classifyBudgetStatus({ budget: 30000, spent: 10000, dayOfMonth: 15, daysInMonth: 30 })
+    expect(r.projected).toBe(20000)
+    expect(r.projectedPercent).toBe(67)
+    expect(r.projectedOverBudget).toBe(false)
+  })
+
+  it('projection: overPace 15/30 20000 spent → projected 40000, overBudget', () => {
+    const r = classifyBudgetStatus({ budget: 30000, spent: 20000, dayOfMonth: 15, daysInMonth: 30 })
+    expect(r.projected).toBe(40000)
+    expect(r.projectedPercent).toBe(133)
+    expect(r.projectedOverBudget).toBe(true)
+  })
+
+  it('projection: last day of month projected equals spent', () => {
+    const r = classifyBudgetStatus({ budget: 30000, spent: 12345, dayOfMonth: 30, daysInMonth: 30 })
+    expect(r.projected).toBe(12345)
+  })
+
+  it('projection: day 1 spent 500 → projected = 500 × daysInMonth (extreme extrapolation)', () => {
+    const r = classifyBudgetStatus({ budget: 30000, spent: 500, dayOfMonth: 1, daysInMonth: 30 })
+    expect(r.projected).toBe(15000) // 500 * 30 / 1
+  })
+
+  it('projection: dayOfMonth 0 (pathological) falls back to 1 to avoid /0', () => {
+    const r = classifyBudgetStatus({ budget: 30000, spent: 1000, dayOfMonth: 0, daysInMonth: 30 })
+    // 1000 * 30 / 1 = 30000; no division-by-zero crash
+    expect(r.projected).toBe(30000)
+  })
+
+  it('projection: budget 0 returns projectedPercent 0 (no NaN)', () => {
+    const r = classifyBudgetStatus({ budget: 0, spent: 1000, dayOfMonth: 10, daysInMonth: 30 })
+    expect(r.projectedPercent).toBe(0)
+    expect(r.projectedOverBudget).toBe(false)
+  })
+
+  it('projection: spent 0 → projected 0 regardless of day', () => {
+    const r = classifyBudgetStatus({ budget: 30000, spent: 0, dayOfMonth: 15, daysInMonth: 30 })
+    expect(r.projected).toBe(0)
+    expect(r.projectedPercent).toBe(0)
+  })
+
+  it('projection: projectedOverBudget uses strict greater-than', () => {
+    // Exactly meets budget → not over
+    const r = classifyBudgetStatus({ budget: 30000, spent: 15000, dayOfMonth: 15, daysInMonth: 30 })
+    expect(r.projected).toBe(30000)
+    expect(r.projectedOverBudget).toBe(false)
+  })
 })

--- a/src/components/budget-progress.tsx
+++ b/src/components/budget-progress.tsx
@@ -125,6 +125,32 @@ export function BudgetProgress({ group, expenses }: BudgetProgressProps) {
         </span>
         <span>{status.statusText}</span>
       </div>
+
+      {/* Month-end projection (Issue #203). Hidden if nothing has been spent
+          yet — an "estimate" of 0 is noise. Early in the month the projection
+          is volatile, so we badge it "估算中" when dayOfMonth ≤ 2. */}
+      {monthTotal > 0 && (
+        <div className="text-xs flex items-center justify-between pt-2 border-t border-[var(--border)]">
+          <span className="text-[var(--muted-foreground)]">
+            按目前速度，月底預計花費
+            {dayOfMonth <= 2 && (
+              <span className="ml-1 opacity-60">（估算中）</span>
+            )}
+          </span>
+          <span
+            className={`font-semibold ${
+              status.projectedOverBudget
+                ? 'text-[var(--destructive)]'
+                : 'text-[var(--foreground)]'
+            }`}
+          >
+            {currency(Math.round(status.projected))}
+            <span className="ml-1 text-[var(--muted-foreground)] font-normal">
+              ({status.projectedPercent}%)
+            </span>
+          </span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/budget-progress.tsx
+++ b/src/components/budget-progress.tsx
@@ -128,23 +128,25 @@ export function BudgetProgress({ group, expenses }: BudgetProgressProps) {
 
       {/* Month-end projection (Issue #203). Hidden if nothing has been spent
           yet — an "estimate" of 0 is noise. Early in the month the projection
-          is volatile, so we badge it "估算中" when dayOfMonth ≤ 2. */}
+          is volatile (day 1 splurge would extrapolate to 30×), so we badge
+          "估算中" through day 5. The underlying math is identical to the
+          overPace label, but presentation is the forward-looking framing. */}
       {monthTotal > 0 && (
         <div className="text-xs flex items-center justify-between pt-2 border-t border-[var(--border)]">
           <span className="text-[var(--muted-foreground)]">
             按目前速度，月底預計花費
-            {dayOfMonth <= 2 && (
+            {dayOfMonth <= 5 && (
               <span className="ml-1 opacity-60">（估算中）</span>
             )}
           </span>
           <span
             className={`font-semibold ${
               status.projectedOverBudget
-                ? 'text-[var(--destructive)]'
+                ? 'text-red-600 dark:text-red-400'
                 : 'text-[var(--foreground)]'
             }`}
           >
-            {currency(Math.round(status.projected))}
+            {currency(status.projected)}
             <span className="ml-1 text-[var(--muted-foreground)] font-normal">
               ({status.projectedPercent}%)
             </span>

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -70,9 +70,16 @@ export interface BudgetStatus {
    */
   projectedPercent: number
   /**
-   * True when `projected > budget` (strict). Over-pace does NOT imply
-   * over-projection: a single splurge early in the month can lift projection
-   * even while cumulative spend remains below today's pace line.
+   * True when `projected > budget` (strict).
+   * Note on implication relationships (mathematically equivalent when
+   * `dayOfMonth > 0` and `daysInMonth > 0`):
+   *   spent > budget×day/daysInMonth
+   *     ⇔ (spent/day)×daysInMonth > budget
+   *     ⇔ projected > budget
+   * So `overPace` and `projectedOverBudget` coincide at the same threshold
+   * — they are TWO LABELS for the same inequality. Kept as two fields because
+   * the UI renders them differently (badge vs. projection line).
+   * `overBudget` is the stricter case `spent > budget` and implies both.
    */
   projectedOverBudget: boolean
 }
@@ -108,7 +115,9 @@ export function classifyBudgetStatus(args: {
   // dayOfMonth = 0 is pathological (Date.getDate() is 1-31), but fall back to
   // 1 to keep the helper total-function rather than NaN-propagating.
   const safeDayOfMonth = dayOfMonth > 0 ? dayOfMonth : 1
-  const projected = (spent / safeDayOfMonth) * safeDaysInMonth
+  // Round once here so `projectedPercent` derives from the same integer that
+  // the UI will display (prevents display-vs-percent off-by-one drift).
+  const projected = Math.round((spent / safeDayOfMonth) * safeDaysInMonth)
 
   if (budget <= 0) {
     return {

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -57,6 +57,24 @@ export interface BudgetStatus {
    *   - ok → `領先 ${fmt(N)}`
    */
   statusText: string
+  /**
+   * Linear extrapolation of month-end total: `spent / dayOfMonth × daysInMonth`.
+   * Early in the month the estimate is volatile (one big expense on day 1
+   * implies a 30× month) — callers should show a "stabilising" hint for small
+   * dayOfMonth. Issue #203.
+   */
+  projected: number
+  /**
+   * `projected / budget × 100`, rounded. Returns 0 when budget ≤ 0 so the UI
+   * can unconditionally read the field without a NaN guard.
+   */
+  projectedPercent: number
+  /**
+   * True when `projected > budget` (strict). Over-pace does NOT imply
+   * over-projection: a single splurge early in the month can lift projection
+   * even while cumulative spend remains below today's pace line.
+   */
+  projectedOverBudget: boolean
 }
 
 /** Default formatter matches app-wide `currency()` format (`NT$ 1,234`). */
@@ -87,6 +105,11 @@ export function classifyBudgetStatus(args: {
   // against it to keep the helper total-function.
   const safeDaysInMonth = daysInMonth > 0 ? daysInMonth : 30
 
+  // dayOfMonth = 0 is pathological (Date.getDate() is 1-31), but fall back to
+  // 1 to keep the helper total-function rather than NaN-propagating.
+  const safeDayOfMonth = dayOfMonth > 0 ? dayOfMonth : 1
+  const projected = (spent / safeDayOfMonth) * safeDaysInMonth
+
   if (budget <= 0) {
     return {
       percentUsed: 0,
@@ -95,6 +118,9 @@ export function classifyBudgetStatus(args: {
       overBudget: false,
       overPace: false,
       statusText: `領先 ${fmt(0)}`,
+      projected,
+      projectedPercent: 0,
+      projectedOverBudget: false,
     }
   }
 
@@ -102,6 +128,8 @@ export function classifyBudgetStatus(args: {
   const percentUsed = Math.round((spent / budget) * 100)
   const overBudget = spent > budget
   const overPace = spent > expectedByNow
+  const projectedPercent = Math.round((projected / budget) * 100)
+  const projectedOverBudget = projected > budget
 
   let kind: BudgetStatusKind
   let statusText: string
@@ -116,5 +144,15 @@ export function classifyBudgetStatus(args: {
     statusText = `領先 ${fmt(Math.round(expectedByNow - spent))}`
   }
 
-  return { percentUsed, expectedByNow, kind, overBudget, overPace, statusText }
+  return {
+    percentUsed,
+    expectedByNow,
+    kind,
+    overBudget,
+    overPace,
+    statusText,
+    projected,
+    projectedPercent,
+    projectedOverBudget,
+  }
 }


### PR DESCRIPTION
## 摘要

\`BudgetProgress\` widget 加「月底預計花費」行，用線性外推（spent / day × daysInMonth）讓使用者**提前**知道是否會超標，而非等超了才知道。

## PM / SA 論證

**PM**
- 家計本核心動機是「控管預算」，但目前只顯示事後 X%
- 月中第 10 天花了 40%，實際按比例月底會 120%——這種「趨勢已失控」目前沒告訴使用者
- 新一行即刻可見：「月底預計花費 NT\$36,000 (120%)」

**SA**
- 純擴展 \`classifyBudgetStatus\`，加 3 欄位（projected / projectedPercent / projectedOverBudget）
- 所有 pathological 輸入（dayOfMonth=0、budget≤0、spent=0）都有 fallback
- 無新 collection / rules / deps / CI 變動

## 設計細節

- \`monthTotal === 0\` 時整行隱藏（估算 0 是 noise）
- \`dayOfMonth ≤ 2\` 時附「估算中」badge（早期單日支出會放大 30×）
- 顏色僅在 \`projectedOverBudget\` 時轉警示色

## 測試

- 8 個 projection 單元測試（含：邊界 day=1/day=daysInMonth、strict overBudget、dayOfMonth=0 pathological、budget≤0、spent=0）
- 全專案：**607/607 pass**
- Lint: 0 error / Build: OK

## 變更

\`\`\`
__tests__/budget.test.ts           | 51 ++++
src/components/budget-progress.tsx | 26 ++
src/lib/budget.ts                  | 40 +-
\`\`\`

## 風險

- 低。擴展既有 type 不改現有欄位，無 breaking
- 純前端、無 rules / schema 變動

Closes #203