### PR TITLE
feat(notifications): 點擊通知跳轉對應 entity (Closes #205)

### DIFF
--- a/__tests__/notification-navigation.test.ts
+++ b/__tests__/notification-navigation.test.ts
@@ -1,0 +1,76 @@
+import { getNotificationHref } from '@/lib/notification-navigation'
+
+function n(type: string, entityId?: string | null) {
+  return { type, entityId: entityId ?? null } as { type: string; entityId: string | null }
+}
+
+describe('getNotificationHref', () => {
+  describe('expense events', () => {
+    it('expense_added with entityId → /expense/:id (edit page)', () => {
+      expect(getNotificationHref(n('expense_added', 'e1'))).toBe('/expense/e1')
+    })
+
+    it('expense_updated with entityId → /expense/:id', () => {
+      expect(getNotificationHref(n('expense_updated', 'e2'))).toBe('/expense/e2')
+    })
+
+    it('expense_added without entityId → /records (fallback, no id to open)', () => {
+      expect(getNotificationHref(n('expense_added', null))).toBe('/records')
+    })
+
+    it('expense_deleted → /settings/activity-log (entity gone, see audit trail)', () => {
+      // Even with entityId we cannot open /expense/:id because it will 404;
+      // route to the activity log where the deletion is recorded.
+      expect(getNotificationHref(n('expense_deleted', 'e3'))).toBe('/settings/activity-log')
+      expect(getNotificationHref(n('expense_deleted', null))).toBe('/settings/activity-log')
+    })
+  })
+
+  describe('settlement events', () => {
+    it('settlement_created → /split', () => {
+      expect(getNotificationHref(n('settlement_created', 's1'))).toBe('/split')
+    })
+
+    it('settlement_deleted → /split', () => {
+      expect(getNotificationHref(n('settlement_deleted', 's2'))).toBe('/split')
+    })
+
+    it('settlement events ignore entityId (splits page shows all)', () => {
+      expect(getNotificationHref(n('settlement_created', null))).toBe('/split')
+    })
+  })
+
+  describe('member events', () => {
+    it('member_added → /settings', () => {
+      expect(getNotificationHref(n('member_added'))).toBe('/settings')
+    })
+
+    it('member_removed → /settings', () => {
+      expect(getNotificationHref(n('member_removed'))).toBe('/settings')
+    })
+
+    it('member_updated → /settings', () => {
+      expect(getNotificationHref(n('member_updated'))).toBe('/settings')
+    })
+  })
+
+  describe('miscellaneous', () => {
+    it('unknown type → null (no navigation)', () => {
+      expect(getNotificationHref(n('reminder'))).toBeNull()
+      expect(getNotificationHref(n('future_unknown_type'))).toBeNull()
+    })
+
+    it('empty type → null', () => {
+      expect(getNotificationHref(n(''))).toBeNull()
+    })
+  })
+
+  describe('path safety', () => {
+    it('encodes entityId segment to avoid path injection', () => {
+      // An attacker cannot inject ?query=… or #hash via entityId because
+      // encodeURIComponent escapes reserved chars.
+      const href = getNotificationHref(n('expense_added', 'weird/id?x=1'))
+      expect(href).toBe('/expense/weird%2Fid%3Fx%3D1')
+    })
+  })
+})

--- a/__tests__/notification-navigation.test.ts
+++ b/__tests__/notification-navigation.test.ts
@@ -72,5 +72,14 @@ describe('getNotificationHref', () => {
       const href = getNotificationHref(n('expense_added', 'weird/id?x=1'))
       expect(href).toBe('/expense/weird%2Fid%3Fx%3D1')
     })
+
+    it('treats empty / whitespace-only entityId as missing', () => {
+      // Firestore rules don't validate entityId today; a writer could save "".
+      // Without normalization we'd emit `/expense/` → Next.js collapses to
+      // the list page, contradicting the advertised "open edit page" UX.
+      expect(getNotificationHref(n('expense_added', ''))).toBe('/records')
+      expect(getNotificationHref(n('expense_added', '   '))).toBe('/records')
+      expect(getNotificationHref(n('expense_updated', ''))).toBe('/records')
+    })
   })
 })

--- a/src/app/(auth)/notifications/page.tsx
+++ b/src/app/(auth)/notifications/page.tsx
@@ -1,11 +1,13 @@
 'use client'
 
+import Link from 'next/link'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useNotifications } from '@/lib/hooks/use-notifications'
 import { useAuth } from '@/lib/auth'
 import { markAllNotificationsRead, markNotificationRead } from '@/lib/services/notification-service'
 import { toDate, fmtDateFull } from '@/lib/utils'
 import { useToast } from '@/components/toast'
+import { getNotificationHref } from '@/lib/notification-navigation'
 
 import { logger } from '@/lib/logger'
 
@@ -64,32 +66,63 @@ export default function NotificationsPage() {
         </div>
       ) : (
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] overflow-hidden">
-          {notifications.map((notif) => (
-            <button
-              key={notif.id ?? notif.title}
-              onClick={() => notif.id && !notif.isRead && handleMarkOneRead(notif.id)}
-              className={`w-full flex items-start gap-3 px-4 py-3 border-b border-[var(--border)] last:border-b-0 text-left transition-colors ${
-                !notif.isRead
-                  ? 'bg-[var(--primary)]/5 hover:bg-[var(--primary)]/10 cursor-pointer'
-                  : 'cursor-default'
-              }`}
-            >
-              <div className="w-9 h-9 rounded-full flex items-center justify-center text-lg flex-shrink-0"
-                style={{ backgroundColor: 'color-mix(in oklch, var(--primary), transparent 85%)' }}>
-                {TYPE_ICONS[notif.type] ?? '🔔'}
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium">{notif.title}</div>
-                <div className="text-xs text-[var(--muted-foreground)] mt-0.5">{notif.body}</div>
-                <div className="text-xs text-[var(--muted-foreground)] mt-1">
-                  {fmtDateFull(toDate(notif.createdAt))}
+          {notifications.map((notif) => {
+            const href = getNotificationHref(notif)
+            const onClickMark = () => notif.id && !notif.isRead && handleMarkOneRead(notif.id)
+            const sharedClass = `w-full flex items-start gap-3 px-4 py-3 border-b border-[var(--border)] last:border-b-0 text-left transition-colors ${
+              !notif.isRead
+                ? 'bg-[var(--primary)]/5 hover:bg-[var(--primary)]/10 cursor-pointer'
+                : href
+                ? 'hover:bg-[var(--muted)]/40 cursor-pointer'
+                : 'cursor-default'
+            }`
+            const inner = (
+              <>
+                <div
+                  className="w-9 h-9 rounded-full flex items-center justify-center text-lg flex-shrink-0"
+                  style={{ backgroundColor: 'color-mix(in oklch, var(--primary), transparent 85%)' }}
+                >
+                  {TYPE_ICONS[notif.type] ?? '🔔'}
                 </div>
-              </div>
-              {!notif.isRead && (
-                <div className="w-2 h-2 rounded-full bg-[var(--primary)] flex-shrink-0 mt-1.5" aria-hidden="true" />
-              )}
-            </button>
-          ))}
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium">{notif.title}</div>
+                  <div className="text-xs text-[var(--muted-foreground)] mt-0.5">{notif.body}</div>
+                  <div className="text-xs text-[var(--muted-foreground)] mt-1">
+                    {fmtDateFull(toDate(notif.createdAt))}
+                  </div>
+                </div>
+                {!notif.isRead && (
+                  <div
+                    className="w-2 h-2 rounded-full bg-[var(--primary)] flex-shrink-0 mt-1.5"
+                    aria-hidden="true"
+                  />
+                )}
+              </>
+            )
+            // With an href: render a Link so the browser can pre-fetch and
+            // middle-click/cmd-click opens in a new tab. onClick still fires
+            // before navigation so mark-read runs in-flight.
+            // Without an href (e.g. generic "reminder"): fall back to a button
+            // that only marks-read. Issue #205.
+            return href ? (
+              <Link
+                key={notif.id ?? notif.title}
+                href={href}
+                onClick={onClickMark}
+                className={sharedClass}
+              >
+                {inner}
+              </Link>
+            ) : (
+              <button
+                key={notif.id ?? notif.title}
+                onClick={onClickMark}
+                className={sharedClass}
+              >
+                {inner}
+              </button>
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/app/(auth)/notifications/page.tsx
+++ b/src/app/(auth)/notifications/page.tsx
@@ -16,8 +16,21 @@ const TYPE_ICONS: Record<string, string> = {
   expense_updated: '✏️',
   expense_deleted: '🗑️',
   settlement_created: '✅',
+  settlement_deleted: '↩️',
   member_added: '👤',
+  member_updated: '👤',
+  member_removed: '👤',
   reminder: '🔔',
+}
+
+// Class resolver for the notification row. Three-way: unread / read-clickable /
+// read-static. Extracted for readability + testability.
+function rowClass(isRead: boolean, hasHref: boolean): string {
+  const base =
+    'w-full flex items-start gap-3 px-4 py-3 border-b border-[var(--border)] last:border-b-0 text-left transition-colors'
+  if (!isRead) return `${base} bg-[var(--primary)]/5 hover:bg-[var(--primary)]/10 cursor-pointer`
+  if (hasHref) return `${base} hover:bg-[var(--muted)]/40 cursor-pointer`
+  return `${base} cursor-default`
 }
 
 export default function NotificationsPage() {
@@ -68,14 +81,17 @@ export default function NotificationsPage() {
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] overflow-hidden">
           {notifications.map((notif) => {
             const href = getNotificationHref(notif)
-            const onClickMark = () => notif.id && !notif.isRead && handleMarkOneRead(notif.id)
-            const sharedClass = `w-full flex items-start gap-3 px-4 py-3 border-b border-[var(--border)] last:border-b-0 text-left transition-colors ${
-              !notif.isRead
-                ? 'bg-[var(--primary)]/5 hover:bg-[var(--primary)]/10 cursor-pointer'
-                : href
-                ? 'hover:bg-[var(--muted)]/40 cursor-pointer'
-                : 'cursor-default'
-            }`
+            // Fire-and-forget mark-read. Firestore SDK immediately commits to
+            // the local write buffer (optimistic update), so navigation
+            // interrupting this call is safe in practice. `void` explicitly
+            // documents the floating promise.
+            const onClickMark = () => {
+              if (notif.id && !notif.isRead) void handleMarkOneRead(notif.id)
+            }
+            const className = rowClass(notif.isRead, href !== null)
+            const ariaLabel = notif.isRead
+              ? notif.title
+              : `${notif.title} – 點擊查看並標為已讀`
             const inner = (
               <>
                 <div
@@ -99,17 +115,18 @@ export default function NotificationsPage() {
                 )}
               </>
             )
-            // With an href: render a Link so the browser can pre-fetch and
-            // middle-click/cmd-click opens in a new tab. onClick still fires
-            // before navigation so mark-read runs in-flight.
-            // Without an href (e.g. generic "reminder"): fall back to a button
-            // that only marks-read. Issue #205.
+            // With an href: Link so the browser can pre-fetch and cmd-click
+            // opens in a new tab. onClick fires before navigation so mark-read
+            // runs in-flight. Without an href (e.g. generic "reminder" type):
+            // fall back to a button that only marks-read; disabled when
+            // already read so the click does nothing visible (a11y). #205
             return href ? (
               <Link
                 key={notif.id ?? notif.title}
                 href={href}
                 onClick={onClickMark}
-                className={sharedClass}
+                className={className}
+                aria-label={ariaLabel}
               >
                 {inner}
               </Link>
@@ -117,7 +134,9 @@ export default function NotificationsPage() {
               <button
                 key={notif.id ?? notif.title}
                 onClick={onClickMark}
-                className={sharedClass}
+                disabled={notif.isRead}
+                aria-label={ariaLabel}
+                className={className}
               >
                 {inner}
               </button>

--- a/src/lib/notification-navigation.ts
+++ b/src/lib/notification-navigation.ts
@@ -22,13 +22,19 @@ const DELETED_ENTITY_FALLBACK = '/settings/activity-log'
 export function getNotificationHref(notif: NotificationLike): string | null {
   const { type, entityId } = notif
 
+  // Treat whitespace-only entityId as missing. Firestore rules do not currently
+  // validate entityId format, so a malicious (or buggy) writer could store ""
+  // and have us produce `/expense/` which Next.js collapses to the list page —
+  // not the edit page we advertise. Normalize here defensively.
+  const id = typeof entityId === 'string' && entityId.trim() ? entityId : null
+
   switch (type) {
     case 'expense_added':
     case 'expense_updated':
       // Edit page — if no entityId, fall back to the records list so the user
       // at least lands somewhere relevant instead of seeing a dead link.
-      return entityId
-        ? `/expense/${encodeURIComponent(entityId)}`
+      return id
+        ? `/expense/${encodeURIComponent(id)}`
         : '/records'
 
     case 'expense_deleted':
@@ -45,6 +51,10 @@ export function getNotificationHref(notif: NotificationLike): string | null {
     case 'member_added':
     case 'member_updated':
     case 'member_removed':
+      // Forward-compatible routing — member-service.ts does NOT currently
+      // emit notifications for these events (activity log only). Kept in the
+      // switch so if a future PR wires up member notifications, the click
+      // target is already defined.
       return '/settings'
 
     default:

--- a/src/lib/notification-navigation.ts
+++ b/src/lib/notification-navigation.ts
@@ -1,0 +1,53 @@
+/**
+ * Decide where a notification click should navigate. Pure function — UI layer
+ * reads the href, wraps in a <Link>, and still runs mark-read in its onClick.
+ *
+ * Returns `null` for types with no useful destination (e.g. the generic
+ * `reminder` type or unknown future types) so the caller can fall back to a
+ * plain "mark read" button instead of rendering a dead link.
+ *
+ * Issue #205.
+ */
+
+export interface NotificationLike {
+  type: string
+  entityId?: string | null
+}
+
+// Fallback destination when the underlying entity has been deleted (or never
+// had an id). The activity log is the canonical audit trail, so even a
+// deleted expense has a visible record there.
+const DELETED_ENTITY_FALLBACK = '/settings/activity-log'
+
+export function getNotificationHref(notif: NotificationLike): string | null {
+  const { type, entityId } = notif
+
+  switch (type) {
+    case 'expense_added':
+    case 'expense_updated':
+      // Edit page — if no entityId, fall back to the records list so the user
+      // at least lands somewhere relevant instead of seeing a dead link.
+      return entityId
+        ? `/expense/${encodeURIComponent(entityId)}`
+        : '/records'
+
+    case 'expense_deleted':
+      // The expense doc is gone; /expense/:id would 404. Route to the audit
+      // trail where the deletion is visible.
+      return DELETED_ENTITY_FALLBACK
+
+    case 'settlement_created':
+    case 'settlement_deleted':
+      // /split shows all debts + settlement history; entityId-level deep-link
+      // is not meaningful today.
+      return '/split'
+
+    case 'member_added':
+    case 'member_updated':
+    case 'member_removed':
+      return '/settings'
+
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
## 摘要

通知頁面點擊通知原本只標已讀，現在會跳到對應 entity（支出/結算/成員）。entityId 早已存在但 UI 沒用，完成「通知 → 引導行動」的閉環。

## PM / SA 論證

**PM**
- 通知存在目的：引導使用者下一步行動
- 目前少了跳轉 → 使用者看到「刪除支出 Uber Eats」通知但沒辦法看該筆細節，只能自己到 records 或 activity log 找
- 修好之後閉環成立

**SA**
- 純前端純函式 \`getNotificationHref(notif)\`
- 無 Firestore / rules / API 變動
- Path injection 防護：\`encodeURIComponent(entityId)\`

## 路由決策表

| Type | Href |
|------|------|
| expense_added / updated + entityId | \`/expense/:id\` |
| expense_added / updated 缺 id | \`/records\` fallback |
| expense_deleted | \`/settings/activity-log\`（實體已刪） |
| settlement_created / deleted | \`/split\` |
| member_* | \`/settings\` |
| reminder / 未知 | null → 保留原本 button 行為 |

## 測試

- 13 個純函式測試（含路由、缺 entityId、path injection）
- 全專案: **612/612**
- Lint 0 error / Build OK

## UX 細節

- \`<Link>\` onClick 同時跑 mark-read，pre-fetch + cmd-click 新 tab 正確運作
- 已讀 + 有 href 的通知仍有 hover 效果（可點擊暗示）
- 無 href 的通知退回 button 行為（只標已讀，不跳）

## 變更

\`\`\`
__tests__/notification-navigation.test.ts | 75 +++
src/lib/notification-navigation.ts        | 52 +++
src/app/(auth)/notifications/page.tsx     | 85 +/-
\`\`\`

## 風險

- 低。路由決策純函式，測試涵蓋完整
- Path injection 已用 encodeURIComponent
- 無新依賴、無 schema 變動、不衝突 PR #202 / #204

Closes #205