### PR TITLE
feat(split): debt 行顯示「上次結算 N 天前」 (Closes #209)

### DIFF
--- a/__tests__/settlement-history.test.ts
+++ b/__tests__/settlement-history.test.ts
@@ -1,6 +1,8 @@
 import {
   findLastSettlementBetween,
   formatSettlementAge,
+  DAY_MS,
+  STALE_DAYS,
   type SettlementRecord,
 } from '@/lib/settlement-history'
 
@@ -86,6 +88,16 @@ describe('findLastSettlementBetween', () => {
   it('self-pair (A==B) returns null (not meaningful)', () => {
     expect(findLastSettlementBetween([s('A', 'A', new Date())], 'A', 'A')).toBeNull()
   })
+
+  it('picks newest by DATE even when older record has larger amount', () => {
+    // Regression guard: defends against a future refactor that accidentally
+    // sorts by amount. The contract is "most recent settlement".
+    const older = s('A', 'B', new Date(2026, 3, 1), 9999)
+    const newer = s('A', 'B', new Date(2026, 3, 15), 50)
+    const out = findLastSettlementBetween([older, newer], 'A', 'B')
+    expect(out?.date).toEqual(new Date(2026, 3, 15))
+    expect(out?.amount).toBe(50)
+  })
 })
 
 describe('formatSettlementAge', () => {
@@ -112,12 +124,17 @@ describe('formatSettlementAge', () => {
     expect(formatSettlementAge(new Date(2026, 3, 8), now).text).toBe('10 天前結算')
   })
 
-  it('30 days → isStale=true', () => {
-    expect(formatSettlementAge(new Date(2026, 2, 19), now).isStale).toBe(true)
+  it('exact STALE_DAYS threshold → isStale=true (derived from const, not literal)', () => {
+    // Test uses the exported STALE_DAYS so a future tuning (e.g. to 45 days)
+    // doesn't make this test silently skew.
+    const atThreshold = new Date(now - STALE_DAYS * DAY_MS)
+    expect(formatSettlementAge(atThreshold, now).isStale).toBe(true)
+    expect(formatSettlementAge(atThreshold, now).daysAgo).toBe(STALE_DAYS)
   })
 
-  it('< 30 days → isStale=false', () => {
-    expect(formatSettlementAge(new Date(2026, 3, 1), now).isStale).toBe(false)
+  it('STALE_DAYS - 1 → isStale=false', () => {
+    const justBefore = new Date(now - (STALE_DAYS - 1) * DAY_MS)
+    expect(formatSettlementAge(justBefore, now).isStale).toBe(false)
   })
 
   it('future settlement defensively clamps to 今天', () => {

--- a/__tests__/settlement-history.test.ts
+++ b/__tests__/settlement-history.test.ts
@@ -1,0 +1,131 @@
+import {
+  findLastSettlementBetween,
+  formatSettlementAge,
+  type SettlementRecord,
+} from '@/lib/settlement-history'
+
+function s(
+  fromId: string,
+  toId: string,
+  date: Date,
+  amount = 100,
+): SettlementRecord {
+  return {
+    fromMemberId: fromId,
+    toMemberId: toId,
+    date,
+    amount,
+  }
+}
+
+describe('findLastSettlementBetween', () => {
+  it('returns null when list is empty', () => {
+    expect(findLastSettlementBetween([], 'A', 'B')).toBeNull()
+  })
+
+  it('finds a single direct match (A→B)', () => {
+    const d = new Date(2026, 3, 10)
+    const out = findLastSettlementBetween([s('A', 'B', d)], 'A', 'B')
+    expect(out?.date).toEqual(d)
+    expect(out?.amount).toBe(100)
+  })
+
+  it('finds reverse direction (B→A also counts as "this pair settled")', () => {
+    // The UI shows debt "A→B"; a prior "B→A" settlement still establishes
+    // that they've transacted recently, so reverse direction is fair game.
+    const d = new Date(2026, 3, 10)
+    const out = findLastSettlementBetween([s('B', 'A', d)], 'A', 'B')
+    expect(out?.date).toEqual(d)
+  })
+
+  it('returns the newest when multiple matches exist', () => {
+    const older = new Date(2026, 3, 1)
+    const newer = new Date(2026, 3, 15)
+    const out = findLastSettlementBetween(
+      [s('A', 'B', older, 10), s('B', 'A', newer, 20), s('A', 'B', new Date(2026, 2, 28), 5)],
+      'A', 'B',
+    )
+    expect(out?.date).toEqual(newer)
+    expect(out?.amount).toBe(20)
+  })
+
+  it('ignores settlements involving a different pair', () => {
+    const d = new Date(2026, 3, 10)
+    const out = findLastSettlementBetween(
+      [s('A', 'C', d), s('C', 'B', d), s('D', 'E', d)],
+      'A', 'B',
+    )
+    expect(out).toBeNull()
+  })
+
+  it('accepts Firestore Timestamp-like (has toDate())', () => {
+    const real = new Date(2026, 3, 10)
+    const ts = { toDate: () => real }
+    const out = findLastSettlementBetween(
+      // @ts-expect-error — simulate Firestore Timestamp duck type
+      [s('A', 'B', ts)],
+      'A', 'B',
+    )
+    expect(out?.date).toEqual(real)
+  })
+
+  it('skips records with unparseable dates', () => {
+    // Defensive: corrupted doc shouldn't throw
+    const good = new Date(2026, 3, 10)
+    const out = findLastSettlementBetween(
+      [
+        // @ts-expect-error — intentional malformed
+        s('A', 'B', 'not-a-date'),
+        s('A', 'B', good),
+      ],
+      'A', 'B',
+    )
+    expect(out?.date).toEqual(good)
+  })
+
+  it('self-pair (A==B) returns null (not meaningful)', () => {
+    expect(findLastSettlementBetween([s('A', 'A', new Date())], 'A', 'A')).toBeNull()
+  })
+})
+
+describe('formatSettlementAge', () => {
+  // Use an injectable `now` so tests don't depend on wall-clock time.
+  const now = new Date(2026, 3, 18).getTime() // 2026-04-18 00:00 local
+
+  it('returns fallback label when no settlement ever', () => {
+    expect(formatSettlementAge(null, now)).toEqual({
+      text: '尚未結算',
+      daysAgo: null,
+      isStale: false,
+    })
+  })
+
+  it('0 days → 今天結算', () => {
+    expect(formatSettlementAge(new Date(2026, 3, 18), now).text).toBe('今天結算')
+  })
+
+  it('1 day → 昨天', () => {
+    expect(formatSettlementAge(new Date(2026, 3, 17), now).text).toBe('昨天結算')
+  })
+
+  it('N days (< 30) → N 天前', () => {
+    expect(formatSettlementAge(new Date(2026, 3, 8), now).text).toBe('10 天前結算')
+  })
+
+  it('30 days → isStale=true', () => {
+    expect(formatSettlementAge(new Date(2026, 2, 19), now).isStale).toBe(true)
+  })
+
+  it('< 30 days → isStale=false', () => {
+    expect(formatSettlementAge(new Date(2026, 3, 1), now).isStale).toBe(false)
+  })
+
+  it('future settlement defensively clamps to 今天', () => {
+    // Clock skew or test fixture mismatch shouldn't render "-3 天前".
+    expect(formatSettlementAge(new Date(2026, 3, 20), now).text).toBe('今天結算')
+  })
+
+  it('reports exact daysAgo regardless of stale flag', () => {
+    expect(formatSettlementAge(new Date(2026, 2, 1), now).daysAgo).toBe(48)
+  })
+})

--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useExpenses } from '@/lib/hooks/use-expenses'
@@ -188,6 +188,19 @@ export default function SplitPage() {
 
   const netBalances = calculateNetBalances(expenses, settlements)
   const debts = simplifyDebts(expenses, settlements, nameMap)
+
+  // Batch-compute "last settled N days ago" for every debt pair. Snapshots
+  // `now` once per render so all rows share the same reference point (and
+  // unrelated state changes don't tick individual rows). Issue #209.
+  const debtAges = useMemo(() => {
+    const now = Date.now()
+    const map = new Map<string, ReturnType<typeof formatSettlementAge>>()
+    for (const d of debts) {
+      const last = findLastSettlementBetween(settlements, d.from, d.to)
+      map.set(`${d.from}-${d.to}`, formatSettlementAge(last?.date ?? null, now))
+    }
+    return map
+  }, [debts, settlements])
 
   // 所有出現過的成員 ID（union of members and expense splits）
   const expenseMemberIds = Array.from(new Set(expenses.flatMap((e) => e.splits.map((s) => s.memberId))))
@@ -383,15 +396,11 @@ export default function SplitPage() {
           ) : (
             <div className="space-y-2">
               {debts.map((d) => {
-                // Time-since-last-settlement for this pair. Computed per row
-                // (N is tiny — usually ≤ 5 debts in a family). Settlements
-                // are Firestore Timestamps; helper accepts the duck type.
-                const last = findLastSettlementBetween(
-                  settlements as unknown as Parameters<typeof findLastSettlementBetween>[0],
-                  d.from,
-                  d.to,
-                )
-                const age = formatSettlementAge(last?.date ?? null, Date.now())
+                const age = debtAges.get(`${d.from}-${d.to}`) ?? {
+                  text: '尚未結算',
+                  daysAgo: null,
+                  isStale: false,
+                }
                 return (
                 <div
                   key={`${d.from}-${d.to}`}

--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -8,6 +8,7 @@ import { useSettlements } from '@/lib/hooks/use-settlements'
 import { useMembers } from '@/lib/hooks/use-members'
 import { calculateNetBalances, simplifyDebts } from '@/lib/services/split-calculator'
 import { addSettlement, addSettlements, deleteSettlement } from '@/lib/services/settlement-service'
+import { findLastSettlementBetween, formatSettlementAge } from '@/lib/settlement-history'
 import { useToast } from '@/components/toast'
 import { currency, signedCurrency, toDate, fmtDateFull } from '@/lib/utils'
 import { useAuth, getActor } from '@/lib/auth'
@@ -381,7 +382,17 @@ export default function SplitPage() {
             </div>
           ) : (
             <div className="space-y-2">
-              {debts.map((d) => (
+              {debts.map((d) => {
+                // Time-since-last-settlement for this pair. Computed per row
+                // (N is tiny — usually ≤ 5 debts in a family). Settlements
+                // are Firestore Timestamps; helper accepts the duck type.
+                const last = findLastSettlementBetween(
+                  settlements as unknown as Parameters<typeof findLastSettlementBetween>[0],
+                  d.from,
+                  d.to,
+                )
+                const age = formatSettlementAge(last?.date ?? null, Date.now())
+                return (
                 <div
                   key={`${d.from}-${d.to}`}
                   className="flex items-center gap-3 p-3 rounded-xl"
@@ -398,7 +409,16 @@ export default function SplitPage() {
                         {d.toName}
                       </span>
                     </div>
-                    <div className="text-xs text-[var(--muted-foreground)] mt-0.5 ml-0.5">轉帳</div>
+                    <div
+                      className={`text-xs mt-0.5 ml-0.5 ${
+                        age.isStale
+                          ? 'text-amber-600 dark:text-amber-400 font-medium'
+                          : 'text-[var(--muted-foreground)]'
+                      }`}
+                    >
+                      {age.isStale ? '⚠ ' : '🕒 '}
+                      {age.text}
+                    </div>
                   </div>
                   <div className="font-bold">{currency(d.amount)}</div>
                   <button
@@ -410,7 +430,8 @@ export default function SplitPage() {
                     記錄
                   </button>
                 </div>
-              ))}
+                )
+              })}
             </div>
           )}
         </div>

--- a/src/lib/settlement-history.ts
+++ b/src/lib/settlement-history.ts
@@ -4,16 +4,16 @@
  * Issue #209.
  */
 
-type DateLike = Date | { toDate: () => Date }
-
 export interface SettlementRecord {
   fromMemberId: string
   toMemberId: string
-  date: DateLike
+  // Accept unknown so callers can pass raw Firestore documents (whose `date`
+  // is a Timestamp) without casting. coerceDate handles the duck type.
+  date: unknown
   amount: number
 }
 
-function coerceDate(d: DateLike | unknown): Date | null {
+function coerceDate(d: unknown): Date | null {
   if (!d) return null
   if (d instanceof Date) {
     return Number.isFinite(d.getTime()) ? d : null
@@ -61,8 +61,10 @@ export function findLastSettlementBetween(
   return best
 }
 
-const DAY_MS = 24 * 60 * 60 * 1000
-const STALE_DAYS = 30
+// Exported so tests can reuse them when asserting boundary behaviour, and
+// future tuning changes one number in one place.
+export const DAY_MS = 24 * 60 * 60 * 1000
+export const STALE_DAYS = 30
 
 export interface SettlementAge {
   /** Localized phrase, e.g. "3 天前結算" / "尚未結算". */

--- a/src/lib/settlement-history.ts
+++ b/src/lib/settlement-history.ts
@@ -1,0 +1,93 @@
+/**
+ * Helpers for showing settlement-age context on each debt row in the split
+ * page. Pure functions so the component renders from stable, testable inputs.
+ * Issue #209.
+ */
+
+type DateLike = Date | { toDate: () => Date }
+
+export interface SettlementRecord {
+  fromMemberId: string
+  toMemberId: string
+  date: DateLike
+  amount: number
+}
+
+function coerceDate(d: DateLike | unknown): Date | null {
+  if (!d) return null
+  if (d instanceof Date) {
+    return Number.isFinite(d.getTime()) ? d : null
+  }
+  if (typeof d === 'object' && typeof (d as { toDate?: unknown }).toDate === 'function') {
+    try {
+      const out = (d as { toDate: () => Date }).toDate()
+      return out instanceof Date && Number.isFinite(out.getTime()) ? out : null
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+/**
+ * Find the most recent settlement that involves the given pair of members, in
+ * either direction. Returns null when the pair has never settled or when all
+ * candidate records have unparseable dates.
+ *
+ * Why bidirectional: the UI shows debt `A → B` (A owes B). A prior `B → A`
+ * settlement (B paid A) still means these two people have reconciled recently,
+ * so it counts as "they're settling regularly". A strict same-direction match
+ * would hide the signal from the common case where families alternate who
+ * pays whom.
+ */
+export function findLastSettlementBetween(
+  settlements: readonly SettlementRecord[],
+  memberA: string,
+  memberB: string,
+): { date: Date; amount: number } | null {
+  if (memberA === memberB) return null
+  let best: { date: Date; amount: number } | null = null
+  for (const s of settlements) {
+    const involves =
+      (s.fromMemberId === memberA && s.toMemberId === memberB) ||
+      (s.fromMemberId === memberB && s.toMemberId === memberA)
+    if (!involves) continue
+    const d = coerceDate(s.date)
+    if (!d) continue
+    if (!best || d.getTime() > best.date.getTime()) {
+      best = { date: d, amount: s.amount }
+    }
+  }
+  return best
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const STALE_DAYS = 30
+
+export interface SettlementAge {
+  /** Localized phrase, e.g. "3 天前結算" / "尚未結算". */
+  text: string
+  /** Raw days since last settlement; null when there is none. */
+  daysAgo: number | null
+  /** True when daysAgo >= STALE_DAYS — UI may colour this as a nudge. */
+  isStale: boolean
+}
+
+/**
+ * Turn a raw last-settlement Date (or null) into a user-facing phrase plus a
+ * `isStale` flag for visual emphasis. `now` is injectable so tests stay
+ * deterministic without mocking the global clock.
+ */
+export function formatSettlementAge(date: Date | null, now: number): SettlementAge {
+  if (!date) return { text: '尚未結算', daysAgo: null, isStale: false }
+  // Clamp negative diffs (future dates) to 0 so clock skew / test fixtures
+  // don't render "-3 天前".
+  const diff = Math.max(0, now - date.getTime())
+  const daysAgo = Math.floor(diff / DAY_MS)
+  const isStale = daysAgo >= STALE_DAYS
+  let text: string
+  if (daysAgo === 0) text = '今天結算'
+  else if (daysAgo === 1) text = '昨天結算'
+  else text = `${daysAgo} 天前結算`
+  return { text, daysAgo, isStale }
+}


### PR DESCRIPTION
## 摘要

Split 頁每筆 debt 加「🕒 X 天前結算」或「⚠ N 天前結算」或「尚未結算」，家庭成員秒懂這筆錢拖多久。

## PM / SA 論證

**PM**
- Debt 顯示金額但沒有時間——錢長期欠著都不會動
- 新增「距上次結算 N 天」讓時間感視覺化
- > 30 天自動亮 amber + ⚠ 圖示，溫和催促

**SA**
- 純前端計算；資料（settlements）已訂閱
- 抽 \`findLastSettlementBetween\` + \`formatSettlementAge\` 兩個純函式便於測試
- 雙向查找（A→B 或 B→A 都算該組「有在結算」）

## 測試

- 16 個純函式測試：
  - findLastSettlementBetween: 8 個（empty/direct/reverse/multi-match/other pairs/Timestamp duck type/corrupt date/self-pair）
  - formatSettlementAge: 8 個（null/today/yesterday/N-days/stale boundary/future clamp/daysAgo 正確性）
- 全專案：**615/615 pass**
- Lint 0 error / Build OK

## 變更

\`\`\`
__tests__/settlement-history.test.ts | 137 +++
src/lib/settlement-history.ts        |  96 +++
src/app/(auth)/split/page.tsx        |  23 +/-
\`\`\`

## Scope

- 純前端、無 Firestore / rules / deps 變動
- 不衝突 pending PR #202 / #204 / #206 / #208
- 中型以下

## 手測 plan

- [ ] 打開 /split 看每筆 debt 下有新字「🕒 X 天前結算」
- [ ] 新結算後 debt 時間顯示「今天結算」
- [ ] 從未結算過的家人 debt 顯示「尚未結算」
- [ ] > 30 天未結算的 pair 顯示 amber + ⚠

Closes #209