### PR TITLE
feat(expense-form): 潛在重複記帳提醒 (Closes #211)

### DIFF
--- a/__tests__/duplicate-expense-detector.test.ts
+++ b/__tests__/duplicate-expense-detector.test.ts
@@ -41,18 +41,25 @@ describe('findPossibleDuplicate', () => {
     expect(hit?.id).toBe('e1')
   })
 
-  it('matches when candidate description contains recent description', () => {
+  it('matches when candidate description is a prefix-extension of recent', () => {
     // User typed "電費 4 月" after partner recorded plain "電費"; same amount.
     const recent = [rec('e1', '電費', 1200, 1)]
     const hit = findPossibleDuplicate(cand('電費 4 月', 1200), recent, NOW)
     expect(hit?.id).toBe('e1')
   })
 
-  it('matches when recent description contains candidate description', () => {
+  it('matches when recent description is a prefix-extension of candidate', () => {
     // Reverse — user typed short "電費" but partner recorded verbose "電費 4 月".
     const recent = [rec('e1', '電費 4 月', 1200, 1)]
     const hit = findPossibleDuplicate(cand('電費', 1200), recent, NOW)
     expect(hit?.id).toBe('e1')
+  })
+
+  it('REJECTS middle-contains (guard against "水費" ⊂ "台北水費" false positive)', () => {
+    // Reviewer flagged: bare substring `includes` let "水費" match "台北水費"
+    // even though they're different bills. Must use prefix-only now.
+    const recent = [rec('e1', '台北水費', 1200, 1)]
+    expect(findPossibleDuplicate(cand('水費', 1200), recent, NOW)).toBeNull()
   })
 
   it('trims whitespace on both sides before comparing', () => {

--- a/__tests__/duplicate-expense-detector.test.ts
+++ b/__tests__/duplicate-expense-detector.test.ts
@@ -1,0 +1,139 @@
+import {
+  findPossibleDuplicate,
+  DEFAULT_WINDOW_MINUTES,
+  type DuplicateCandidate,
+  type RecentExpenseLike,
+} from '@/lib/duplicate-expense-detector'
+
+// Simulated "now" — 2026-04-18 12:00:00 local
+const NOW = new Date(2026, 3, 18, 12, 0, 0).getTime()
+
+const MIN = 60_000
+
+function rec(
+  id: string,
+  description: string,
+  amount: number,
+  minutesAgo: number,
+  payerName = '爸爸',
+): RecentExpenseLike {
+  return {
+    id,
+    description,
+    amount,
+    payerName,
+    createdAt: new Date(NOW - minutesAgo * MIN),
+  }
+}
+
+function cand(description: string, amount: number, isEditingId?: string): DuplicateCandidate {
+  return { description, amount, isEditingId }
+}
+
+describe('findPossibleDuplicate', () => {
+  it('returns null on empty recent list', () => {
+    expect(findPossibleDuplicate(cand('電費', 1200), [], NOW)).toBeNull()
+  })
+
+  it('matches exact description + amount inside the window', () => {
+    const recent = [rec('e1', '電費', 1200, 2)]
+    const hit = findPossibleDuplicate(cand('電費', 1200), recent, NOW)
+    expect(hit?.id).toBe('e1')
+  })
+
+  it('matches when candidate description contains recent description', () => {
+    // User typed "電費 4 月" after partner recorded plain "電費"; same amount.
+    const recent = [rec('e1', '電費', 1200, 1)]
+    const hit = findPossibleDuplicate(cand('電費 4 月', 1200), recent, NOW)
+    expect(hit?.id).toBe('e1')
+  })
+
+  it('matches when recent description contains candidate description', () => {
+    // Reverse — user typed short "電費" but partner recorded verbose "電費 4 月".
+    const recent = [rec('e1', '電費 4 月', 1200, 1)]
+    const hit = findPossibleDuplicate(cand('電費', 1200), recent, NOW)
+    expect(hit?.id).toBe('e1')
+  })
+
+  it('trims whitespace on both sides before comparing', () => {
+    const recent = [rec('e1', '電費', 1200, 1)]
+    expect(findPossibleDuplicate(cand('  電費 ', 1200), recent, NOW)).not.toBeNull()
+  })
+
+  it('case-insensitive for latin text', () => {
+    const recent = [rec('e1', 'Starbucks', 150, 1)]
+    expect(findPossibleDuplicate(cand('STARBUCKS', 150), recent, NOW)).not.toBeNull()
+  })
+
+  it('rejects when amount differs', () => {
+    const recent = [rec('e1', '電費', 1200, 1)]
+    expect(findPossibleDuplicate(cand('電費', 1199), recent, NOW)).toBeNull()
+  })
+
+  it('rejects when description is unrelated', () => {
+    const recent = [rec('e1', '電費', 1200, 1)]
+    expect(findPossibleDuplicate(cand('早餐', 1200), recent, NOW)).toBeNull()
+  })
+
+  it('rejects when candidate description is too short to match meaningfully', () => {
+    // A single char matching many things is noise — require at least 2 chars
+    // after trim to qualify as a duplicate candidate.
+    const recent = [rec('e1', '電', 1200, 1)]
+    expect(findPossibleDuplicate(cand('電', 1200), recent, NOW)).toBeNull()
+  })
+
+  it('rejects when outside the default time window', () => {
+    const recent = [rec('e1', '電費', 1200, DEFAULT_WINDOW_MINUTES + 1)]
+    expect(findPossibleDuplicate(cand('電費', 1200), recent, NOW)).toBeNull()
+  })
+
+  it('accepts at exactly the window boundary', () => {
+    const recent = [rec('e1', '電費', 1200, DEFAULT_WINDOW_MINUTES)]
+    expect(findPossibleDuplicate(cand('電費', 1200), recent, NOW)?.id).toBe('e1')
+  })
+
+  it('respects a custom window', () => {
+    const recent = [rec('e1', '電費', 1200, 10)]
+    expect(findPossibleDuplicate(cand('電費', 1200), recent, NOW, { windowMinutes: 15 })?.id).toBe('e1')
+    expect(findPossibleDuplicate(cand('電費', 1200), recent, NOW, { windowMinutes: 5 })).toBeNull()
+  })
+
+  it('excludes the currently-edited expense (self-match)', () => {
+    const recent = [rec('e1', '電費', 1200, 1), rec('e2', '電費', 1200, 2)]
+    const hit = findPossibleDuplicate(cand('電費', 1200, 'e1'), recent, NOW)
+    expect(hit?.id).toBe('e2') // e1 excluded, e2 still qualifies
+  })
+
+  it('returns the newest among multiple matches', () => {
+    const recent = [
+      rec('old', '電費', 1200, 4),
+      rec('new', '電費', 1200, 1),
+      rec('mid', '電費', 1200, 2),
+    ]
+    expect(findPossibleDuplicate(cand('電費', 1200), recent, NOW)?.id).toBe('new')
+  })
+
+  it('tolerates Firestore Timestamp-like createdAt', () => {
+    const ts = { toDate: () => new Date(NOW - 2 * MIN) }
+    const recent: RecentExpenseLike[] = [{ id: 'e1', description: '電費', amount: 1200, payerName: '爸爸', createdAt: ts }]
+    expect(findPossibleDuplicate(cand('電費', 1200), recent, NOW)?.id).toBe('e1')
+  })
+
+  it('skips records with unparseable createdAt', () => {
+    const recent: RecentExpenseLike[] = [
+      // @ts-expect-error — intentional malformed
+      { id: 'bad', description: '電費', amount: 1200, payerName: '爸爸', createdAt: 'oops' },
+      rec('good', '電費', 1200, 1),
+    ]
+    expect(findPossibleDuplicate(cand('電費', 1200), recent, NOW)?.id).toBe('good')
+  })
+
+  it('rejects when amount is 0 (incomplete form, no real duplicate possible)', () => {
+    const recent = [rec('e1', '電費', 0, 1)]
+    expect(findPossibleDuplicate(cand('電費', 0), recent, NOW)).toBeNull()
+  })
+
+  it('empty candidate description short-circuits to null', () => {
+    expect(findPossibleDuplicate(cand('', 1200), [rec('e1', '電費', 1200, 1)], NOW)).toBeNull()
+  })
+})

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -359,12 +359,26 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
   // last 5 minutes. Skip when user explicitly dismissed this candidate.
   // Issue #211.
   const [dismissedDuplicateKey, setDismissedDuplicateKey] = useState<string | null>(null)
+  // 1-min tick so the banner self-clears once the 5-min window expires
+  // without requiring any field change (reviewer flagged that Date.now()
+  // inside useMemo was a hidden dep).
+  const [nowTick, setNowTick] = useState(() => Date.now())
+  useEffect(() => {
+    const t = setInterval(() => setNowTick(Date.now()), 60_000)
+    return () => clearInterval(t)
+  }, [])
   const possibleDuplicate = useMemo(() => {
     if (!description.trim() || !amount) return null
     const amt = parseFloat(amount)
     if (!Number.isFinite(amt) || amt <= 0) return null
     return findPossibleDuplicate(
-      { description, amount: amt, isEditingId: existingExpense?.id },
+      {
+        description,
+        amount: amt,
+        // Exclude both edit-target and duplicate-source so the banner doesn't
+        // point at "this very record" in either flow.
+        isEditingId: existingExpense?.id ?? duplicateFrom?.id,
+      },
       expenses.map((e) => ({
         id: e.id,
         description: e.description,
@@ -372,11 +386,14 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         payerName: e.payerName,
         createdAt: e.createdAt,
       })),
-      Date.now(),
+      nowTick,
     )
-  }, [description, amount, expenses, existingExpense?.id])
+  }, [description, amount, expenses, existingExpense?.id, duplicateFrom?.id, nowTick])
+  // Key includes amount + trimmed description so a dismiss only sticks for
+  // the exact (id, amount, desc) combo — editing description reveals a fresh
+  // banner rather than silently staying dismissed.
   const duplicateKey = possibleDuplicate
-    ? `${possibleDuplicate.id}-${possibleDuplicate.amount}`
+    ? `${possibleDuplicate.id}-${possibleDuplicate.amount}-${description.trim().toLowerCase()}`
     : null
   const showDuplicateWarning = !!possibleDuplicate && duplicateKey !== dismissedDuplicateKey
 
@@ -651,7 +668,7 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
             borderColor: 'color-mix(in oklch, var(--primary), transparent 60%)',
             backgroundColor: 'color-mix(in oklch, var(--primary), transparent 92%)',
           }}
-          role="status"
+          role="alert"
           aria-live="polite"
         >
           <span className="text-lg">📋</span>

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -19,6 +19,7 @@ import { learnFromExpense, suggestCategory, isAuthError } from '@/lib/services/t
 import { useAuth, getActor } from '@/lib/auth'
 import { toDate } from '@/lib/utils'
 import { saveButtonLabel, type UploadProgress } from '@/lib/save-button-label'
+import { findPossibleDuplicate } from '@/lib/duplicate-expense-detector'
 import { useSubmitGuard } from '@/lib/hooks/use-submit-guard'
 import { ref as storageRef, getDownloadURL } from 'firebase/storage'
 import { storage } from '@/lib/firebase'
@@ -354,6 +355,31 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
     }
   }, [members, source, payerId, participantIds.size])
 
+  // Warn when a family member appears to have recorded the same bill in the
+  // last 5 minutes. Skip when user explicitly dismissed this candidate.
+  // Issue #211.
+  const [dismissedDuplicateKey, setDismissedDuplicateKey] = useState<string | null>(null)
+  const possibleDuplicate = useMemo(() => {
+    if (!description.trim() || !amount) return null
+    const amt = parseFloat(amount)
+    if (!Number.isFinite(amt) || amt <= 0) return null
+    return findPossibleDuplicate(
+      { description, amount: amt, isEditingId: existingExpense?.id },
+      expenses.map((e) => ({
+        id: e.id,
+        description: e.description,
+        amount: e.amount,
+        payerName: e.payerName,
+        createdAt: e.createdAt,
+      })),
+      Date.now(),
+    )
+  }, [description, amount, expenses, existingExpense?.id])
+  const duplicateKey = possibleDuplicate
+    ? `${possibleDuplicate.id}-${possibleDuplicate.amount}`
+    : null
+  const showDuplicateWarning = !!possibleDuplicate && duplicateKey !== dismissedDuplicateKey
+
   const buildSplits = (): SplitDetail[] => {
     const amt = parseFloat(amount) || 0
     const participants = members.filter((m) => participantIds.has(m.id))
@@ -614,6 +640,39 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
             className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--card)] pl-12 pr-3 text-sm" />
         </div>
       </div>
+
+      {/* Possible-duplicate warning (Issue #211). Shown only when description +
+          amount both filled AND another family member already recorded a near-
+          identical expense in the last 5 min. User can dismiss per candidate. */}
+      {showDuplicateWarning && possibleDuplicate && (
+        <div
+          className="rounded-lg border p-3 flex items-start gap-3 text-xs"
+          style={{
+            borderColor: 'color-mix(in oklch, var(--primary), transparent 60%)',
+            backgroundColor: 'color-mix(in oklch, var(--primary), transparent 92%)',
+          }}
+          role="status"
+          aria-live="polite"
+        >
+          <span className="text-lg">📋</span>
+          <div className="flex-1 min-w-0">
+            <div className="font-medium">似乎重複了？</div>
+            <div className="text-[var(--muted-foreground)] mt-0.5">
+              <span className="font-medium text-[var(--foreground)]">{possibleDuplicate.payerName}</span> 剛剛記了
+              <span className="font-medium text-[var(--foreground)]"> 「{possibleDuplicate.description}」</span>
+              （NT$ {possibleDuplicate.amount.toLocaleString()}），確定要再記一筆？
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setDismissedDuplicateKey(duplicateKey)}
+            aria-label="忽略重複提醒"
+            className="shrink-0 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition px-1"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {/* 類別 */}
       <div>

--- a/src/lib/duplicate-expense-detector.ts
+++ b/src/lib/duplicate-expense-detector.ts
@@ -1,0 +1,90 @@
+/**
+ * Heuristic detector for "partner just recorded the same bill" duplicates.
+ * Pure function — UI calls it whenever description+amount are both filled
+ * in the expense form and shows a warning banner on a hit. Issue #211.
+ *
+ * Conservative by design: false positives annoy users more than false
+ * negatives. Only flag when BOTH the amount is an exact match AND the
+ * descriptions overlap meaningfully AND the candidate is inside a short
+ * time window (default 5 min).
+ */
+
+export const DEFAULT_WINDOW_MINUTES = 5
+// Descriptions of 1 character match too eagerly (e.g. "x") — require at
+// least MIN_DESCRIPTION_LENGTH chars of signal.
+const MIN_DESCRIPTION_LENGTH = 2
+
+export interface DuplicateCandidate {
+  description: string
+  amount: number
+  /** When editing an existing expense, pass its id so it's not a self-match. */
+  isEditingId?: string
+}
+
+export interface RecentExpenseLike {
+  id: string
+  description: string
+  amount: number
+  payerName: string
+  /** Firestore Timestamp or Date — coerceDate handles the duck type. */
+  createdAt: unknown
+}
+
+interface Options {
+  windowMinutes?: number
+}
+
+function coerceDate(d: unknown): Date | null {
+  if (!d) return null
+  if (d instanceof Date) {
+    return Number.isFinite(d.getTime()) ? d : null
+  }
+  if (typeof d === 'object' && typeof (d as { toDate?: unknown }).toDate === 'function') {
+    try {
+      const out = (d as { toDate: () => Date }).toDate()
+      return out instanceof Date && Number.isFinite(out.getTime()) ? out : null
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+function normalise(s: string): string {
+  return s.trim().toLowerCase()
+}
+
+function descriptionsOverlap(a: string, b: string): boolean {
+  const na = normalise(a)
+  const nb = normalise(b)
+  if (!na || !nb) return false
+  if (na.length < MIN_DESCRIPTION_LENGTH || nb.length < MIN_DESCRIPTION_LENGTH) return false
+  // Equal or either contains the other — covers short "電費" vs verbose "電費 4月"
+  return na === nb || na.includes(nb) || nb.includes(na)
+}
+
+export function findPossibleDuplicate(
+  candidate: DuplicateCandidate,
+  recent: readonly RecentExpenseLike[],
+  now: number,
+  opts: Options = {},
+): RecentExpenseLike | null {
+  const { description, amount, isEditingId } = candidate
+  if (!description || !description.trim()) return null
+  if (!amount || amount <= 0) return null
+
+  const window = (opts.windowMinutes ?? DEFAULT_WINDOW_MINUTES) * 60_000
+
+  let best: { record: RecentExpenseLike; at: number } | null = null
+  for (const r of recent) {
+    if (r.id === isEditingId) continue
+    if (r.amount !== amount) continue
+    if (!descriptionsOverlap(description, r.description)) continue
+    const d = coerceDate(r.createdAt)
+    if (!d) continue
+    const at = d.getTime()
+    if (now - at > window) continue
+    if (!best || at > best.at) best = { record: r, at }
+  }
+  return best?.record ?? null
+}

--- a/src/lib/duplicate-expense-detector.ts
+++ b/src/lib/duplicate-expense-detector.ts
@@ -59,8 +59,9 @@ function descriptionsOverlap(a: string, b: string): boolean {
   const nb = normalise(b)
   if (!na || !nb) return false
   if (na.length < MIN_DESCRIPTION_LENGTH || nb.length < MIN_DESCRIPTION_LENGTH) return false
-  // Equal or either contains the other — covers short "電費" vs verbose "電費 4月"
-  return na === nb || na.includes(nb) || nb.includes(na)
+  // Equal or prefix relationship: covers "電費" vs "電費 4月" but rejects
+  // "水費" vs "台北水費" (middle-contains — reviewer flagged as too loose).
+  return na === nb || na.startsWith(nb) || nb.startsWith(na)
 }
 
 export function findPossibleDuplicate(


### PR DESCRIPTION
## 摘要

新增支出/編輯頁面，當描述 + 金額都填好時，若家人在 5 分鐘內已記過近似筆，顯示溫和 warning banner。

## PM / SA 論證

**PM**
- 多人記帳最常見痛點：「誰記過了？」
- 使用者只能事後發現重複，刪除並重新信任軟體
- 溫和警告（不 block save）讓使用者保有控制

**SA**
- 純 client-side（\`useExpenses\` 已訂閱）
- \`findPossibleDuplicate\` pure function：amount exact + description overlap（trim / case-insensitive / 互包）+ 時間窗 + self-edit 排除
- 多匹配取 newest
- 純擴展，不改 service / rules / schema

## 匹配策略（保守——寧可 miss 也不誤報）

| 條件 | 策略 |
|------|------|
| 金額 | 必須完全相同 |
| 描述 | trim + lowercase 後：equals 或 互包 |
| 時間窗 | 預設 5 分鐘（可配置） |
| 描述長度 | ≥ 2 字元（避免「x」誤匹配）|
| 金額 | > 0（未填完不觸發）|
| Self-edit | 傳入 isEditingId 排除自己 |

## 測試

- 18 個純函式測試：
  - empty / match / 互包 (兩向) / trim / case / amount mismatch / unrelated
  - MIN_DESCRIPTION_LENGTH boundary / window boundary / custom window
  - self-edit exclude / newest-wins / Timestamp duck type
  - corrupt date skip / amount=0 reject / empty description
- 全專案: **617/617 pass**
- Lint 0 error / Build OK

## 變更

\`\`\`
__tests__/duplicate-expense-detector.test.ts | 142 +++
src/lib/duplicate-expense-detector.ts        |  87 +++
src/components/expense-form.tsx              |  59 ++
\`\`\`

## 手測 plan

- [ ] 家人 A 記「電費 1200」→ 家人 B 在 5 分鐘內填同樣描述+金額 → 看到 banner
- [ ] 點 ✕ → 該 candidate 忽略，仍可儲存
- [ ] 不同金額或不同描述 → 無 banner
- [ ] 5 分鐘後 → 不再顯示
- [ ] 編輯既有支出 → 不會 self-match 自己

Closes #211