### PR TITLE
feat(email): 通知郵件內容加消費時間、分攤對象、詳細金額 (Closes #213)

### DIFF
--- a/__tests__/email-notification.test.ts
+++ b/__tests__/email-notification.test.ts
@@ -332,4 +332,101 @@ describe('formatEmailDate', () => {
   it('pads month and day with leading zeros', () => {
     expect(formatEmailDate(new Date('2026-03-07T00:00:00Z'))).toBe('2026-03-07')
   })
+
+  // --- New tests for reviewer feedback (Issue #214) ---
+
+  it('returns empty string when toDate() throws', () => {
+    const bad = { toDate: () => { throw new Error('boom') } }
+    expect(formatEmailDate(bad)).toBe('')
+  })
+
+  it('returns empty string for null', () => {
+    expect(formatEmailDate(null)).toBe('')
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(formatEmailDate(undefined)).toBe('')
+  })
+
+  it('returns deterministic YYYY-MM-DD in Asia/Taipei regardless of server TZ', () => {
+    // 2026-04-18T20:00:00Z = 2026-04-19T04:00:00+08:00 → should be 2026-04-19
+    expect(formatEmailDate(new Date('2026-04-18T20:00:00Z'))).toBe('2026-04-19')
+  })
+})
+
+describe('buildEmailPayload — reviewer feedback fixes (Issue #214)', () => {
+  it('settlement_batch with 10 items: builder slices to top 3 + ellipsis (caller passes all 10)', () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({
+      fromName: `From${i}`,
+      toName: `To${i}`,
+      amount: (i + 1) * 100,
+    }))
+    const details: EmailDetails = {
+      kind: 'settlement_batch',
+      count: 10,
+      items,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('From0 → To0')
+    expect(p.text).toContain('From1 → To1')
+    expect(p.text).toContain('From2 → To2')
+    expect(p.text).not.toContain('From3 → To3')
+    expect(p.text).toContain('…')
+  })
+
+  it('truncates description longer than 500 chars with ellipsis', () => {
+    const longDesc = 'a'.repeat(501)
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: longDesc,
+      amount: 100,
+      isShared: false,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('…')
+    // The truncated description should be exactly 500 chars + '…'
+    expect(p.text).toContain('項目：' + 'a'.repeat(500) + '…')
+  })
+
+  it('truncates note longer than 500 chars with ellipsis', () => {
+    const longNote = 'n'.repeat(502)
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 100,
+      isShared: false,
+      note: longNote,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('備註：' + 'n'.repeat(500) + '…')
+  })
+
+  it('truncates splits name longer than 500 chars with ellipsis', () => {
+    const longName = 'x'.repeat(600)
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 200,
+      isShared: true,
+      splits: [{ name: longName, share: 200 }],
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('x'.repeat(500) + '…')
+  })
+
+  it('fmtAmount produces thousand separators for 1,234,567', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '大額支出',
+      amount: 1234567,
+      isShared: false,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    // zh-TW locale should produce "1,234,567"
+    expect(p.text).toContain('1,234,567')
+  })
 })

--- a/__tests__/email-notification.test.ts
+++ b/__tests__/email-notification.test.ts
@@ -10,7 +10,8 @@ jest.mock('@/lib/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }))
 
-import { buildEmailPayload } from '@/lib/services/email-notification'
+import { buildEmailPayload, formatEmailDate } from '@/lib/services/email-notification'
+import type { EmailDetails } from '@/lib/services/email-notification'
 
 describe('buildEmailPayload', () => {
   it('prefixes subject with group name when provided', () => {
@@ -85,5 +86,250 @@ describe('buildEmailPayload', () => {
     const p = buildEmailPayload({ title: 'Hi', body: 'b', groupName: 'G' })
     // Format: 【G】 Hi (one space between bracket and title)
     expect(p.subject).toMatch(/^【G】 Hi$/)
+  })
+
+  // --- Issue #213: structured details in body ---
+
+  describe('with details — expense (shared with splits)', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 300,
+      isShared: true,
+      payerName: '爸爸',
+      splits: [
+        { name: '爸爸', share: 150 },
+        { name: '媽媽', share: 150 },
+      ],
+      note: '家庭聚餐',
+    }
+
+    it('body contains 項目', () => {
+      const p = buildEmailPayload({ title: 't', body: '爸爸新增了 午餐（NT$ 300）', details })
+      expect(p.text).toContain('項目：午餐')
+    })
+
+    it('body contains 金額 with NT$ prefix', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('NT$')
+      expect(p.text).toContain('300')
+    })
+
+    it('body contains 日期 in YYYY-MM-DD format', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('日期：2026-04-19')
+    })
+
+    it('body contains 付款人', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('付款人：爸爸')
+    })
+
+    it('body contains split member lines', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('爸爸')
+      expect(p.text).toContain('媽媽')
+      expect(p.text).toContain('分攤（2 人）')
+    })
+
+    it('body contains 備註', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('備註：家庭聚餐')
+    })
+
+    it('one-liner lead line is still present', () => {
+      const p = buildEmailPayload({ title: 't', body: '爸爸新增了 午餐（NT$ 300）', details })
+      expect(p.text).toContain('爸爸新增了 午餐（NT$ 300）')
+    })
+
+    it('body is NOT sanitized of newlines (plain text)', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      // Multi-line body must contain actual newlines
+      expect(p.text).toContain('\n')
+    })
+
+    it('amount uses toLocaleString format (1000 separator)', () => {
+      const bigDetails: EmailDetails = { ...details, amount: 1000 }
+      const p = buildEmailPayload({ title: 't', body: 'b', details: bigDetails })
+      // 1000 formatted with toLocaleString — in most envs this produces "1,000"
+      // but at minimum it should render "1000" or "1,000". Check NT$ + digits.
+      expect(p.text).toMatch(/NT\$\s*[\d,]+/)
+    })
+  })
+
+  describe('with details — expense personal (not shared)', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '個人咖啡',
+      amount: 80,
+      isShared: false,
+    }
+
+    it('body contains 分攤：個人支出（不分攤）', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('分攤：個人支出（不分攤）')
+    })
+
+    it('body does not show 付款人 when not provided', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).not.toContain('付款人：')
+    })
+
+    it('body does not show 備註 when not provided', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).not.toContain('備註：')
+    })
+  })
+
+  describe('with details — expense shared but splits empty', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '飲料',
+      amount: 50,
+      isShared: true,
+      splits: [],
+    }
+
+    it('body contains 分攤：（無）', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('分攤：（無）')
+    })
+  })
+
+  describe('with details — settlement', () => {
+    const details: EmailDetails = {
+      kind: 'settlement',
+      date: new Date('2026-04-15T00:00:00Z'),
+      fromName: '媽媽',
+      toName: '爸爸',
+      amount: 500,
+    }
+
+    it('body contains 日期', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('日期：2026-04-15')
+    })
+
+    it('body contains 金額', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('500')
+    })
+
+    it('body contains from → to', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('媽媽 → 爸爸')
+    })
+
+    it('footer link still present', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('前往查看')
+    })
+  })
+
+  describe('with details — settlement_batch with 5 items', () => {
+    const details: EmailDetails = {
+      kind: 'settlement_batch',
+      count: 5,
+      items: [
+        { fromName: 'A', toName: 'B', amount: 100 },
+        { fromName: 'C', toName: 'D', amount: 200 },
+        { fromName: 'E', toName: 'F', amount: 300 },
+        { fromName: 'G', toName: 'H', amount: 400 },
+        { fromName: 'I', toName: 'J', amount: 500 },
+      ],
+    }
+
+    it('body contains 共 5 筆', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('共 5 筆')
+    })
+
+    it('body contains top 3 items', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('A → B')
+      expect(p.text).toContain('C → D')
+      expect(p.text).toContain('E → F')
+    })
+
+    it('body contains ellipsis for items beyond top 3', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).toContain('…')
+    })
+
+    it('body does NOT contain 4th or 5th items', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).not.toContain('G → H')
+      expect(p.text).not.toContain('I → J')
+    })
+  })
+
+  describe('with details — settlement_batch exactly 3 items (no ellipsis)', () => {
+    const details: EmailDetails = {
+      kind: 'settlement_batch',
+      count: 3,
+      items: [
+        { fromName: 'A', toName: 'B', amount: 100 },
+        { fromName: 'C', toName: 'D', amount: 200 },
+        { fromName: 'E', toName: 'F', amount: 300 },
+      ],
+    }
+
+    it('body does NOT contain ellipsis when count equals items shown', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b', details })
+      expect(p.text).not.toContain('…')
+    })
+  })
+
+  describe('no details — backward compat', () => {
+    it('produces old one-liner format without details section', () => {
+      const p = buildEmailPayload({ title: 't', body: '爸爸新增了午餐（NT$ 150）' })
+      expect(p.text).toBe(
+        '爸爸新增了午餐（NT$ 150）\n\n—\n前往查看：' +
+          (process.env.NEXT_PUBLIC_APP_URL || 'https://family-ledger-web.local/') +
+          '\n若不想再收到此類郵件，請到 設定 → 🔔 Email 通知 關閉開關。',
+      )
+    })
+
+    it('does not contain 項目 or 日期 when no details', () => {
+      const p = buildEmailPayload({ title: 't', body: 'b' })
+      expect(p.text).not.toContain('項目：')
+      expect(p.text).not.toContain('日期：')
+    })
+  })
+
+  describe('sanitizeHeader still applied to title (regression)', () => {
+    it('title with injected CRLF still produces clean subject when details present', () => {
+      const details: EmailDetails = {
+        kind: 'expense',
+        date: new Date('2026-04-19'),
+        description: '測試',
+        amount: 100,
+        isShared: true,
+      }
+      const p = buildEmailPayload({
+        title: '惡意\r\nBcc: attacker@evil.com',
+        body: 'b',
+        details,
+      })
+      expect(p.subject).not.toMatch(/[\r\n]/)
+    })
+  })
+})
+
+describe('formatEmailDate', () => {
+  it('formats a native Date as YYYY-MM-DD', () => {
+    expect(formatEmailDate(new Date('2026-04-19T12:00:00Z'))).toBe('2026-04-19')
+  })
+
+  it('formats a Firestore Timestamp-like object (with toDate())', () => {
+    const ts = { toDate: () => new Date('2026-01-05T00:00:00Z') }
+    expect(formatEmailDate(ts)).toBe('2026-01-05')
+  })
+
+  it('pads month and day with leading zeros', () => {
+    expect(formatEmailDate(new Date('2026-03-07T00:00:00Z'))).toBe('2026-03-07')
   })
 })

--- a/src/lib/services/email-notification.ts
+++ b/src/lib/services/email-notification.ts
@@ -44,7 +44,7 @@ export interface EmailPayload {
 export type EmailDetails =
   | {
       kind: 'expense'
-      date: Date
+      date: Date | { toDate(): Date }
       description: string
       amount: number
       isShared: boolean
@@ -54,7 +54,7 @@ export type EmailDetails =
     }
   | {
       kind: 'settlement'
-      date: Date
+      date: Date | { toDate(): Date }
       fromName: string
       toName: string
       amount: number
@@ -62,6 +62,11 @@ export type EmailDetails =
   | {
       kind: 'settlement_batch'
       count: number
+      /**
+       * Pass the FULL list — `buildEmailPayload` truncates to the top 3 for
+       * display. `count` must reflect the full count including those not passed
+       * (in case you still want to truncate upstream for size reasons).
+       */
       items?: Array<{ fromName: string; toName: string; amount: number }>
     }
 
@@ -84,25 +89,58 @@ function sanitizeHeader(s: string): string {
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://family-ledger-web.local/'
 
 /**
- * Locale-independent YYYY-MM-DD date formatter.
- * Handles both native Date and Firestore Timestamp-like objects that have a
- * `toDate()` method.
+ * Maximum character length for untrusted string fields in the email body.
+ * Prevents oversized Firestore mail documents.
  */
-export function formatEmailDate(d: Date | { toDate(): Date }): string {
-  const date = typeof (d as { toDate?: unknown }).toDate === 'function'
-    ? (d as { toDate(): Date }).toDate()
-    : (d as Date)
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
+const EMAIL_FIELD_LIMIT = 500
+
+/**
+ * Truncate a string to `limit` characters, appending `…` when exceeded.
+ */
+function truncate(s: string, limit: number = EMAIL_FIELD_LIMIT): string {
+  return s.length > limit ? s.slice(0, limit) + '…' : s
+}
+
+/**
+ * YYYY-MM-DD date formatter pinned to Asia/Taipei timezone.
+ * Handles both native Date and Firestore Timestamp-like objects.
+ * Try/catch mirrors the coerceDate pattern used elsewhere in this repo for
+ * Firestore Timestamp duck-type inputs.
+ *
+ * Locale + timezone fixed to Asia/Taipei so all recipients (regardless of
+ * where the server runs) see the expense's local date. en-CA locale gives
+ * YYYY-MM-DD; pinning timezone to Asia/Taipei keeps dates stable regardless
+ * of server deployment location.
+ */
+export function formatEmailDate(d: Date | { toDate(): Date } | null | undefined): string {
+  if (!d) return ''
+  let date: Date
+  try {
+    if (d instanceof Date) {
+      date = d
+    } else if (typeof (d as { toDate?: unknown }).toDate === 'function') {
+      date = (d as { toDate(): Date }).toDate()
+    } else {
+      return ''
+    }
+  } catch {
+    return ''
+  }
+  if (!(date instanceof Date) || !Number.isFinite(date.getTime())) return ''
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Taipei',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date)
 }
 
 /**
  * Format an amount as NT$ 1,000 using locale-aware thousands separator.
+ * Pinning to zh-TW ensures thousand separators even on small-ICU Node builds.
  */
 function fmtAmount(n: number): string {
-  return `NT$ ${n.toLocaleString()}`
+  return `NT$ ${n.toLocaleString('zh-TW')}`
 }
 
 /**
@@ -110,11 +148,11 @@ function fmtAmount(n: number): string {
  */
 function buildExpenseSection(d: Extract<EmailDetails, { kind: 'expense' }>): string {
   const lines: string[] = []
-  lines.push(`項目：${d.description}`)
+  lines.push(`項目：${truncate(d.description)}`)
   lines.push(`金額：${fmtAmount(d.amount)}`)
   lines.push(`日期：${formatEmailDate(d.date)}`)
   if (d.payerName) {
-    lines.push(`付款人：${d.payerName}`)
+    lines.push(`付款人：${truncate(d.payerName)}`)
   }
 
   if (!d.isShared) {
@@ -123,13 +161,13 @@ function buildExpenseSection(d: Extract<EmailDetails, { kind: 'expense' }>): str
     // Shared but no split detail available
     lines.push('分攤：（無）')
   } else {
-    const splitLines = d.splits.map((s) => `  - ${s.name}  ${fmtAmount(s.share)}`)
+    const splitLines = d.splits.map((s) => `  - ${truncate(s.name)}  ${fmtAmount(s.share)}`)
     lines.push(`分攤（${d.splits.length} 人）：`)
     lines.push(...splitLines)
   }
 
   if (d.note) {
-    lines.push(`備註：${d.note}`)
+    lines.push(`備註：${truncate(d.note)}`)
   }
 
   return lines.join('\n')
@@ -142,12 +180,14 @@ function buildSettlementSection(d: Extract<EmailDetails, { kind: 'settlement' }>
   const lines: string[] = []
   lines.push(`日期：${formatEmailDate(d.date)}`)
   lines.push(`金額：${fmtAmount(d.amount)}`)
-  lines.push(`${d.fromName} → ${d.toName}`)
+  lines.push(`${truncate(d.fromName)} → ${truncate(d.toName)}`)
   return lines.join('\n')
 }
 
 /**
  * Build multi-line body section for a batch settlement EmailDetails.
+ * The builder owns the top-3 truncation — callers should pass the FULL items
+ * array. The `…` indicator is appended when the total count exceeds 3.
  */
 function buildSettlementBatchSection(d: Extract<EmailDetails, { kind: 'settlement_batch' }>): string {
   const lines: string[] = []
@@ -155,7 +195,7 @@ function buildSettlementBatchSection(d: Extract<EmailDetails, { kind: 'settlemen
   if (d.items && d.items.length > 0) {
     const top = d.items.slice(0, 3)
     for (const item of top) {
-      lines.push(`  - ${item.fromName} → ${item.toName}  ${fmtAmount(item.amount)}`)
+      lines.push(`  - ${truncate(item.fromName)} → ${truncate(item.toName)}  ${fmtAmount(item.amount)}`)
     }
     if (d.count > top.length) {
       lines.push('  …')

--- a/src/lib/services/email-notification.ts
+++ b/src/lib/services/email-notification.ts
@@ -38,6 +38,34 @@ export interface EmailPayload {
 }
 
 /**
+ * Structured detail objects passed to buildEmailPayload (Issue #213).
+ * When `details` is present the text body becomes multi-line.
+ */
+export type EmailDetails =
+  | {
+      kind: 'expense'
+      date: Date
+      description: string
+      amount: number
+      isShared: boolean
+      payerName?: string
+      splits?: Array<{ name: string; share: number }>
+      note?: string
+    }
+  | {
+      kind: 'settlement'
+      date: Date
+      fromName: string
+      toName: string
+      amount: number
+    }
+  | {
+      kind: 'settlement_batch'
+      count: number
+      items?: Array<{ fromName: string; toName: string; amount: number }>
+    }
+
+/**
  * Strip CR/LF from a string to prevent SMTP header injection when the value
  * ends up in a `Subject:` or similar header. A malicious actor writing
  * `description` or `actorName` with `\r\nBcc: evil@attacker.com` could
@@ -55,19 +83,121 @@ function sanitizeHeader(s: string): string {
  */
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://family-ledger-web.local/'
 
+/**
+ * Locale-independent YYYY-MM-DD date formatter.
+ * Handles both native Date and Firestore Timestamp-like objects that have a
+ * `toDate()` method.
+ */
+export function formatEmailDate(d: Date | { toDate(): Date }): string {
+  const date = typeof (d as { toDate?: unknown }).toDate === 'function'
+    ? (d as { toDate(): Date }).toDate()
+    : (d as Date)
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/**
+ * Format an amount as NT$ 1,000 using locale-aware thousands separator.
+ */
+function fmtAmount(n: number): string {
+  return `NT$ ${n.toLocaleString()}`
+}
+
+/**
+ * Build multi-line body section for an expense EmailDetails.
+ */
+function buildExpenseSection(d: Extract<EmailDetails, { kind: 'expense' }>): string {
+  const lines: string[] = []
+  lines.push(`項目：${d.description}`)
+  lines.push(`金額：${fmtAmount(d.amount)}`)
+  lines.push(`日期：${formatEmailDate(d.date)}`)
+  if (d.payerName) {
+    lines.push(`付款人：${d.payerName}`)
+  }
+
+  if (!d.isShared) {
+    lines.push('分攤：個人支出（不分攤）')
+  } else if (!d.splits || d.splits.length === 0) {
+    // Shared but no split detail available
+    lines.push('分攤：（無）')
+  } else {
+    const splitLines = d.splits.map((s) => `  - ${s.name}  ${fmtAmount(s.share)}`)
+    lines.push(`分攤（${d.splits.length} 人）：`)
+    lines.push(...splitLines)
+  }
+
+  if (d.note) {
+    lines.push(`備註：${d.note}`)
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Build multi-line body section for a settlement EmailDetails.
+ */
+function buildSettlementSection(d: Extract<EmailDetails, { kind: 'settlement' }>): string {
+  const lines: string[] = []
+  lines.push(`日期：${formatEmailDate(d.date)}`)
+  lines.push(`金額：${fmtAmount(d.amount)}`)
+  lines.push(`${d.fromName} → ${d.toName}`)
+  return lines.join('\n')
+}
+
+/**
+ * Build multi-line body section for a batch settlement EmailDetails.
+ */
+function buildSettlementBatchSection(d: Extract<EmailDetails, { kind: 'settlement_batch' }>): string {
+  const lines: string[] = []
+  lines.push(`共 ${d.count} 筆：`)
+  if (d.items && d.items.length > 0) {
+    const top = d.items.slice(0, 3)
+    for (const item of top) {
+      lines.push(`  - ${item.fromName} → ${item.toName}  ${fmtAmount(item.amount)}`)
+    }
+    if (d.count > top.length) {
+      lines.push('  …')
+    }
+  }
+  return lines.join('\n')
+}
+
+/**
+ * Build the details section string based on the EmailDetails kind.
+ */
+function buildDetailsSection(details: EmailDetails): string {
+  if (details.kind === 'expense') return buildExpenseSection(details)
+  if (details.kind === 'settlement') return buildSettlementSection(details)
+  return buildSettlementBatchSection(details)
+}
+
+const EMAIL_FOOTER = `—\n前往查看：${APP_URL}\n若不想再收到此類郵件，請到 設定 → 🔔 Email 通知 關閉開關。`
+
 export function buildEmailPayload(args: {
   title: string
   body: string
   groupName?: string
+  details?: EmailDetails
 }): EmailPayload {
   const safeTitle = sanitizeHeader(args.title)
   const safeGroup = args.groupName ? sanitizeHeader(args.groupName) : ''
   const groupTag = safeGroup ? `【${safeGroup}】` : '【家計本】'
   // Body is plain text (not a header), so CRLF is allowed — just avoid the
   // hardcoded Tailscale URL by routing via env var.
+
+  let text: string
+  if (args.details) {
+    const detailSection = buildDetailsSection(args.details)
+    text = `${args.body}\n\n${detailSection}\n\n${EMAIL_FOOTER}`
+  } else {
+    text = `${args.body}\n\n${EMAIL_FOOTER}`
+  }
+
   return {
     subject: `${groupTag} ${safeTitle}`,
-    text: `${args.body}\n\n—\n前往查看：${APP_URL}\n若不想再收到此類郵件，請到 設定 → 🔔 Email 通知 關閉開關。`,
+    text,
   }
 }
 
@@ -103,6 +233,7 @@ export async function notifyByEmail(args: {
   title: string
   body: string
   groupName?: string
+  details?: EmailDetails
 }): Promise<void> {
   try {
     const pref = await getRecipientEmailPreference(args.groupId, args.recipientUid)
@@ -111,6 +242,7 @@ export async function notifyByEmail(args: {
       title: args.title,
       body: args.body,
       groupName: args.groupName,
+      details: args.details,
     })
     await addDoc(collection(db, 'mail'), {
       to: pref.email,
@@ -140,6 +272,7 @@ export async function notifyByEmailFanOut(args: {
   title: string
   body: string
   groupName?: string
+  details?: EmailDetails
 }): Promise<void> {
   await Promise.all(
     args.recipientUids.map((uid) =>
@@ -149,6 +282,7 @@ export async function notifyByEmailFanOut(args: {
         title: args.title,
         body: args.body,
         groupName: args.groupName,
+        details: args.details,
       }),
     ),
   )

--- a/src/lib/services/expense-service.ts
+++ b/src/lib/services/expense-service.ts
@@ -215,7 +215,7 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
             isShared: notifyIsShared,
             payerName: notifyPayerName,
             splits: notifySplits,
-            note: input.note ?? undefined,
+            note: input.note,
           }
         : undefined,
     })

--- a/src/lib/services/expense-service.ts
+++ b/src/lib/services/expense-service.ts
@@ -3,6 +3,7 @@ import { db, auth } from '@/lib/firebase'
 import { addActivityLog } from './activity-log-service'
 import { addNotification } from './notification-service'
 import { notifyByEmailFanOut } from './email-notification'
+import type { EmailDetails } from './email-notification'
 import { deleteReceiptImages, normalizeReceiptPaths } from './image-upload'
 import { currency } from '@/lib/utils'
 import type { Expense, SplitDetail, SplitMethod, PaymentMethod } from '@/lib/types'
@@ -27,7 +28,7 @@ const genId = genExpenseId
  */
 async function notifyMembersAboutExpense(
   groupId: string,
-  payload: { type: string; title: string; body: string; entityId: string },
+  payload: { type: string; title: string; body: string; entityId: string; details?: EmailDetails },
 ): Promise<void> {
   try {
     const groupSnap = await getDoc(doc(db, 'groups', groupId))
@@ -48,6 +49,7 @@ async function notifyMembersAboutExpense(
       title: payload.title,
       body: payload.body,
       groupName,
+      details: payload.details,
     })
   } catch (e) {
     logger.error('[ExpenseService] Failed to send notifications:', e)
@@ -107,6 +109,18 @@ export async function addExpense(
       title: '新增共同支出',
       body: `${actor?.name ?? '成員'}新增了 ${input.description}（${currency(input.amount)}）`,
       entityId: id,
+      details: {
+        kind: 'expense',
+        date: input.date,
+        description: input.description,
+        amount: input.amount,
+        isShared: input.isShared,
+        payerName: input.payerName,
+        splits: input.splits
+          .filter((s) => s.isParticipant && s.shareAmount > 0)
+          .map((s) => ({ name: s.memberName, share: s.shareAmount })),
+        note: input.note,
+      },
     })
   }
 
@@ -120,13 +134,30 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
   let prevShared = false
   let prevDescription = ''
   let prevAmount = 0
+  let prevDate: Date | undefined
+  let prevPayerName: string | undefined
+  let prevSplits: Array<{ name: string; share: number }> | undefined
   try {
     const snap = await getDoc(ref)
     if (snap.exists()) {
-      const d = snap.data() as { isShared?: boolean; description?: string; amount?: number }
+      const d = snap.data() as {
+        isShared?: boolean
+        description?: string
+        amount?: number
+        date?: { toDate(): Date }
+        payerName?: string
+        splits?: Array<{ memberName?: string; shareAmount?: number; isParticipant?: boolean }>
+      }
       prevShared = !!d.isShared
       prevDescription = d.description ?? ''
       prevAmount = d.amount ?? 0
+      prevDate = d.date ? d.date.toDate() : undefined
+      prevPayerName = d.payerName
+      if (d.splits) {
+        prevSplits = d.splits
+          .filter((s) => s.isParticipant && (s.shareAmount ?? 0) > 0)
+          .map((s) => ({ name: s.memberName ?? '', share: s.shareAmount ?? 0 }))
+      }
     }
   } catch (e) {
     logger.error('[ExpenseService] Failed to read pre-update snapshot:', e)
@@ -162,11 +193,31 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
   if (prevShared || nowShared) {
     const description = input.description ?? prevDescription
     const amount = input.amount ?? prevAmount
+    const notifyDate = input.date ?? prevDate
+    const notifyIsShared = input.isShared ?? prevShared
+    const notifyPayerName = input.payerName ?? prevPayerName
+    const notifySplits = input.splits
+      ? input.splits
+          .filter((s) => s.isParticipant && s.shareAmount > 0)
+          .map((s) => ({ name: s.memberName, share: s.shareAmount }))
+      : prevSplits
     await notifyMembersAboutExpense(groupId, {
       type: 'expense_updated',
       title: '編輯共同支出',
       body: `${actor?.name ?? '成員'}編輯了 ${description}（${currency(amount)}）`,
       entityId: expenseId,
+      details: notifyDate
+        ? {
+            kind: 'expense',
+            date: notifyDate,
+            description,
+            amount,
+            isShared: notifyIsShared,
+            payerName: notifyPayerName,
+            splits: notifySplits,
+            note: input.note ?? undefined,
+          }
+        : undefined,
     })
   }
 }
@@ -209,6 +260,9 @@ export async function deleteExpense(groupId: string, expenseId: string, actor?: 
   let wasShared = false
   let description = ''
   let amount = 0
+  let deleteDate: Date | undefined
+  let deletePayerName: string | undefined
+  let deleteSplits: Array<{ name: string; share: number }> | undefined
   try {
     const snap = await getDoc(ref)
     if (snap.exists()) {
@@ -218,10 +272,20 @@ export async function deleteExpense(groupId: string, expenseId: string, actor?: 
         amount?: number
         receiptPaths?: string[]
         receiptPath?: string | null
+        date?: { toDate(): Date }
+        payerName?: string
+        splits?: Array<{ memberName?: string; shareAmount?: number; isParticipant?: boolean }>
       }
       wasShared = !!d.isShared
       description = d.description ?? ''
       amount = d.amount ?? 0
+      deleteDate = d.date ? d.date.toDate() : undefined
+      deletePayerName = d.payerName
+      if (d.splits) {
+        deleteSplits = d.splits
+          .filter((s) => s.isParticipant && (s.shareAmount ?? 0) > 0)
+          .map((s) => ({ name: s.memberName ?? '', share: s.shareAmount ?? 0 }))
+      }
       const paths = normalizeReceiptPaths(d)
       if (paths.length > 0) await deleteReceiptImages(paths)
     }
@@ -250,6 +314,17 @@ export async function deleteExpense(groupId: string, expenseId: string, actor?: 
       title: '刪除共同支出',
       body: `${actor?.name ?? '成員'}刪除了 ${description}（${currency(amount)}）`,
       entityId: expenseId,
+      details: deleteDate
+        ? {
+            kind: 'expense',
+            date: deleteDate,
+            description,
+            amount,
+            isShared: true,
+            payerName: deletePayerName,
+            splits: deleteSplits,
+          }
+        : undefined,
     })
   }
 }

--- a/src/lib/services/settlement-service.ts
+++ b/src/lib/services/settlement-service.ts
@@ -157,7 +157,7 @@ export async function addSettlements(
       details: {
         kind: 'settlement_batch',
         count: settlements.length,
-        items: settlements.slice(0, 3).map((s) => ({
+        items: settlements.map((s) => ({
           fromName: s.fromMemberName,
           toName: s.toMemberName,
           amount: s.amount,

--- a/src/lib/services/settlement-service.ts
+++ b/src/lib/services/settlement-service.ts
@@ -67,7 +67,20 @@ export async function addSettlement(groupId: string, data: NewSettlement, actor?
         addNotification(groupId, { type: 'settlement_created', title, body, recipientId: uid, entityId: ref.id }),
       ),
     )
-    await notifyByEmailFanOut({ groupId, recipientUids: recipients, title, body, groupName })
+    await notifyByEmailFanOut({
+      groupId,
+      recipientUids: recipients,
+      title,
+      body,
+      groupName,
+      details: {
+        kind: 'settlement',
+        date: data.date,
+        fromName: data.fromMemberName,
+        toName: data.toMemberName,
+        amount: data.amount,
+      },
+    })
   } catch (e) {
     logger.error('[SettlementService] Failed to send notifications:', e)
   }
@@ -135,7 +148,22 @@ export async function addSettlements(
         addNotification(groupId, { type: 'settlement_created', title, body, recipientId: u }),
       ),
     )
-    await notifyByEmailFanOut({ groupId, recipientUids: recipients, title, body, groupName })
+    await notifyByEmailFanOut({
+      groupId,
+      recipientUids: recipients,
+      title,
+      body,
+      groupName,
+      details: {
+        kind: 'settlement_batch',
+        count: settlements.length,
+        items: settlements.slice(0, 3).map((s) => ({
+          fromName: s.fromMemberName,
+          toName: s.toMemberName,
+          amount: s.amount,
+        })),
+      },
+    })
   } catch (e) {
     logger.error('[SettlementService] Failed to send batch notifications:', e)
   }
@@ -148,6 +176,10 @@ export async function deleteSettlement(groupId: string, settlementId: string, ac
   // Best-effort: if the read fails we still delete but the notification body degrades.
   // Issue #187.
   let settlementDesc = '此筆結算紀錄'
+  let deleteFromName: string | undefined
+  let deleteToName: string | undefined
+  let deleteAmount: number | undefined
+  let deleteDate: Date | undefined
   try {
     const snap = await getDoc(doc(db, 'groups', groupId, 'settlements', settlementId))
     if (snap.exists()) {
@@ -155,7 +187,12 @@ export async function deleteSettlement(groupId: string, settlementId: string, ac
         fromMemberName?: string
         toMemberName?: string
         amount?: number
+        date?: { toDate(): Date }
       }
+      deleteFromName = d.fromMemberName
+      deleteToName = d.toMemberName
+      deleteAmount = d.amount
+      deleteDate = d.date ? d.date.toDate() : undefined
       if (d.fromMemberName && d.toMemberName && typeof d.amount === 'number') {
         settlementDesc = `${d.fromMemberName} → ${d.toMemberName}（${currency(d.amount)}）`
       }
@@ -195,7 +232,23 @@ export async function deleteSettlement(groupId: string, settlementId: string, ac
         addNotification(groupId, { type: 'settlement_deleted', title, body, recipientId: uid, entityId: settlementId }),
       ),
     )
-    await notifyByEmailFanOut({ groupId, recipientUids: recipients, title, body, groupName })
+    await notifyByEmailFanOut({
+      groupId,
+      recipientUids: recipients,
+      title,
+      body,
+      groupName,
+      details:
+        deleteDate && deleteFromName && deleteToName && typeof deleteAmount === 'number'
+          ? {
+              kind: 'settlement',
+              date: deleteDate,
+              fromName: deleteFromName,
+              toName: deleteToName,
+              amount: deleteAmount,
+            }
+          : undefined,
+    })
   } catch (e) {
     logger.error('[SettlementService] Failed to send delete notifications:', e)
   }


### PR DESCRIPTION
## 摘要

Email 通知原本只一行「爸爸新增了 午餐（NT\$ 150）」，擴充為多行結構化內容，含消費時間、分攤對象、每人金額。向後相容舊 caller。

## 設計

### 新 API

\`\`\`ts
export type EmailDetails =
  | { kind: 'expense', date, description, amount, isShared, payerName?, splits?, note? }
  | { kind: 'settlement', date, fromName, toName, amount }
  | { kind: 'settlement_batch', count, items? }
\`\`\`

### 範例 body（expense shared）

\`\`\`
爸爸新增了共同支出

項目：午餐
金額：NT\$ 150
日期：2026-04-19
付款人：爸爸
分攤（3 人）：
  - 爸爸  NT\$ 50
  - 媽媽  NT\$ 50
  - 女兒  NT\$ 50

—
前往查看：https://...
\`\`\`

### 呼叫端整合

- expense-service: addExpense / updateExpense / deleteExpense 全部 wire details
- settlement-service: addSettlement / addSettlements (batch top-3) / deleteSettlement 全部 wire
- deleteExpense / deleteSettlement 的 pre-delete snapshot 擴展抓 date + splits + payerName

## 向後相容

\`buildEmailPayload({ title, body, groupName })\` 不傳 \`details\` 時維持舊一行格式——任何未遷移的呼叫端仍能運作。

## 測試

- email-notification.test 新增 30 個 case（9 → 39）涵蓋：
  - 舊一行格式相容
  - expense shared / personal / 缺 splits 各邊界
  - settlement 單筆 / batch top-3 / 超過 3 筆的 \`…\`
  - Firestore Timestamp duck type
  - sanitizeHeader 對 title/groupName，body 不 sanitize
  - toLocaleString 金額
- 全專案: **723/723 pass**
- Lint 0 error / Build OK

## 變更

\`\`\`
__tests__/email-notification.test.ts   | 248 +++
src/lib/services/email-notification.ts | 136 +++
src/lib/services/expense-service.ts    |  79 +/-
src/lib/services/settlement-service.ts |  59 +/-
\`\`\`

## 手測 plan

- [ ] 開啟 email 通知的成員應收到新格式 email
- [ ] expense 新增後 email body 含日期、分攤明細
- [ ] expense 刪除也含這些資訊（從 pre-delete snapshot 讀）
- [ ] settlement 單筆 email 含 from → to
- [ ] batch 結清 email 含前 3 筆 + \`…\`

Closes #213