### PR TITLE
feat(email): 通知郵件加類別 + 深度連結 (Closes #215)

### DIFF
--- a/__tests__/email-notification.test.ts
+++ b/__tests__/email-notification.test.ts
@@ -10,7 +10,7 @@ jest.mock('@/lib/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }))
 
-import { buildEmailPayload, formatEmailDate, buildDeepLinkUrl } from '@/lib/services/email-notification'
+import { buildEmailPayload, formatEmailDate, buildDeepLinkUrl, isValidEntityId } from '@/lib/services/email-notification'
 import type { EmailDetails } from '@/lib/services/email-notification'
 
 describe('buildEmailPayload', () => {
@@ -225,8 +225,8 @@ describe('buildEmailPayload', () => {
 
     it('footer link still present', () => {
       const p = buildEmailPayload({ title: 't', body: 'b', details })
-      // Settlement deep link → /split; both 查看此筆 and 前往首頁 lines appear.
-      expect(p.text).toMatch(/查看此筆|前往查看|前往首頁/)
+      // Settlement deep link → /split; footer now uses "前往結算" label.
+      expect(p.text).toMatch(/前往結算|前往查看|前往首頁/)
     })
   })
 
@@ -550,7 +550,10 @@ describe('buildDeepLinkUrl (Issue #215)', () => {
     expect(url?.replace('https://', '')).not.toContain('//')
   })
 
-  it('applies encodeURIComponent to entityId with special chars', () => {
+  it('rejects entityId with special chars (spaces/&/=) — falls back to /records (isValidEntityId guard)', () => {
+    // isValidEntityId allows only [A-Za-z0-9_-]{1,64}. An id with spaces and
+    // special chars is rejected to prevent oversized or malformed URLs. The
+    // caller would need Firestore write access to inject such an id anyway.
     const details: EmailDetails = {
       kind: 'expense',
       date: new Date(),
@@ -560,10 +563,135 @@ describe('buildDeepLinkUrl (Issue #215)', () => {
       entityId: 'id with spaces & special=chars',
     }
     const url = buildDeepLinkUrl(details, 'https://app.example.com')
-    expect(url).toBe('https://app.example.com/expense/id%20with%20spaces%20%26%20special%3Dchars')
+    expect(url).toBe('https://app.example.com/records')
   })
 
   it('returns null when details is undefined', () => {
     expect(buildDeepLinkUrl(undefined, 'https://app.example.com')).toBeNull()
+  })
+})
+
+// --- Issue #217: reviewer feedback ---
+
+describe('buildDeepLinkUrl — reviewer feedback (Issue #217)', () => {
+  const base = 'https://app.example.com'
+
+  it('empty string entityId falls back to /records (not null)', () => {
+    // Aligns with getNotificationHref: expense_added/updated without entityId → /records
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date(),
+      description: 'x',
+      amount: 1,
+      isShared: false,
+      entityId: '',
+    }
+    expect(buildDeepLinkUrl(details, base)).toBe(`${base}/records`)
+  })
+
+  it('whitespace-only entityId falls back to /records', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date(),
+      description: 'x',
+      amount: 1,
+      isShared: false,
+      entityId: '   ',
+    }
+    expect(buildDeepLinkUrl(details, base)).toBe(`${base}/records`)
+  })
+
+  it('oversized entityId (70 chars) is rejected → falls back to /records', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date(),
+      description: 'x',
+      amount: 1,
+      isShared: false,
+      entityId: 'a'.repeat(70),
+    }
+    // isValidEntityId rejects ids longer than 64 chars
+    expect(buildDeepLinkUrl(details, base)).toBe(`${base}/records`)
+  })
+
+  it('entityId with slash (a/b) is rejected → falls back to /records', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date(),
+      description: 'x',
+      amount: 1,
+      isShared: false,
+      entityId: 'a/b',
+    }
+    expect(buildDeepLinkUrl(details, base)).toBe(`${base}/records`)
+  })
+})
+
+describe('buildEmailPayload footer labels — reviewer feedback (Issue #217)', () => {
+  it('settlement footer contains "前往結算" (not "查看此筆")', () => {
+    const details: EmailDetails = {
+      kind: 'settlement',
+      date: new Date('2026-04-15T00:00:00Z'),
+      fromName: '媽媽',
+      toName: '爸爸',
+      amount: 500,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('前往結算：')
+    expect(p.text).not.toContain('查看此筆：')
+  })
+
+  it('expense with deleted:true footer contains "查看紀錄" (not "查看此筆")', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 150,
+      isShared: true,
+      entityId: 'abc123',
+      deleted: true,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('查看紀錄：')
+    expect(p.text).not.toContain('查看此筆：')
+  })
+
+  it('expense without entityId footer deep link is /records (align with getNotificationHref)', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 150,
+      isShared: true,
+      // no entityId
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('/records')
+  })
+})
+
+describe('isValidEntityId (Issue #217)', () => {
+  it('accepts a normal Firestore auto-id (alphanumeric + hyphens)', () => {
+    expect(isValidEntityId('abc123-XYZ_456')).toBe(true)
+  })
+
+  it('rejects an empty string', () => {
+    expect(isValidEntityId('')).toBe(false)
+  })
+
+  it('rejects an id longer than 64 chars', () => {
+    expect(isValidEntityId('a'.repeat(65))).toBe(false)
+  })
+
+  it('accepts an id of exactly 64 chars', () => {
+    expect(isValidEntityId('a'.repeat(64))).toBe(true)
+  })
+
+  it('rejects an id containing a slash', () => {
+    expect(isValidEntityId('a/b')).toBe(false)
+  })
+
+  it('rejects an id containing a space', () => {
+    expect(isValidEntityId('a b')).toBe(false)
   })
 })

--- a/__tests__/email-notification.test.ts
+++ b/__tests__/email-notification.test.ts
@@ -10,7 +10,7 @@ jest.mock('@/lib/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }))
 
-import { buildEmailPayload, formatEmailDate } from '@/lib/services/email-notification'
+import { buildEmailPayload, formatEmailDate, buildDeepLinkUrl } from '@/lib/services/email-notification'
 import type { EmailDetails } from '@/lib/services/email-notification'
 
 describe('buildEmailPayload', () => {
@@ -225,7 +225,8 @@ describe('buildEmailPayload', () => {
 
     it('footer link still present', () => {
       const p = buildEmailPayload({ title: 't', body: 'b', details })
-      expect(p.text).toContain('前往查看')
+      // Settlement deep link → /split; both 查看此筆 and 前往首頁 lines appear.
+      expect(p.text).toMatch(/查看此筆|前往查看|前往首頁/)
     })
   })
 
@@ -428,5 +429,141 @@ describe('buildEmailPayload — reviewer feedback fixes (Issue #214)', () => {
     const p = buildEmailPayload({ title: 't', body: 'b', details })
     // zh-TW locale should produce "1,234,567"
     expect(p.text).toContain('1,234,567')
+  })
+})
+
+// --- Issue #215: category + deep link ---
+
+describe('buildEmailPayload — category (Issue #215)', () => {
+  it('body contains 類別：餐飲 when category is provided', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 150,
+      isShared: true,
+      category: '餐飲',
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('類別：餐飲')
+  })
+
+  it('body does NOT contain 類別： when category is absent', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 150,
+      isShared: true,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).not.toContain('類別：')
+  })
+
+  it('category longer than 500 chars is truncated with ellipsis', () => {
+    const longCategory = 'c'.repeat(501)
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 150,
+      isShared: false,
+      category: longCategory,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('類別：' + 'c'.repeat(500) + '…')
+  })
+})
+
+describe('buildEmailPayload — deep link footer (Issue #215)', () => {
+  it('footer contains /expense/:id deep link when entityId is provided', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 150,
+      isShared: true,
+      entityId: 'abc123',
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('/expense/abc123')
+    expect(p.text).toContain('查看此筆')
+  })
+
+  it('footer routes to /settings/activity-log when deleted: true', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 150,
+      isShared: true,
+      entityId: 'abc123',
+      deleted: true,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('/settings/activity-log')
+    expect(p.text).not.toContain('/expense/abc123')
+  })
+
+  it('settlement footer shows /split link', () => {
+    const details: EmailDetails = {
+      kind: 'settlement',
+      date: new Date('2026-04-15T00:00:00Z'),
+      fromName: '媽媽',
+      toName: '爸爸',
+      amount: 500,
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('/split')
+  })
+
+  it('settlement_batch footer shows /split link', () => {
+    const details: EmailDetails = {
+      kind: 'settlement_batch',
+      count: 3,
+      items: [{ fromName: 'A', toName: 'B', amount: 100 }],
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('/split')
+  })
+
+  it('no details → no deep link, only generic 前往查看 line (backward compat)', () => {
+    const p = buildEmailPayload({ title: 't', body: 'b' })
+    expect(p.text).toContain('前往查看：')
+    expect(p.text).not.toContain('查看此筆：')
+  })
+})
+
+describe('buildDeepLinkUrl (Issue #215)', () => {
+  it('strips trailing slash from base URL to avoid double-slash', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date(),
+      description: 'x',
+      amount: 1,
+      isShared: false,
+      entityId: 'e1',
+    }
+    const url = buildDeepLinkUrl(details, 'https://app.example.com/')
+    expect(url).toBe('https://app.example.com/expense/e1')
+    // Path segment should not contain a double-slash after the protocol //
+    expect(url?.replace('https://', '')).not.toContain('//')
+  })
+
+  it('applies encodeURIComponent to entityId with special chars', () => {
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date(),
+      description: 'x',
+      amount: 1,
+      isShared: false,
+      entityId: 'id with spaces & special=chars',
+    }
+    const url = buildDeepLinkUrl(details, 'https://app.example.com')
+    expect(url).toBe('https://app.example.com/expense/id%20with%20spaces%20%26%20special%3Dchars')
+  })
+
+  it('returns null when details is undefined', () => {
+    expect(buildDeepLinkUrl(undefined, 'https://app.example.com')).toBeNull()
   })
 })

--- a/src/lib/services/email-notification.ts
+++ b/src/lib/services/email-notification.ts
@@ -56,9 +56,13 @@ export type EmailDetails =
       /** Firestore document id — used to build a deep link to the edit page. (Issue #215) */
       entityId?: string
       /**
-       * Set to true when the expense has been deleted.
-       * Deep link routes to /settings/activity-log instead of /expense/:id
-       * because the entity no longer exists. (Issue #215)
+       * Set when this notification is being sent for a DELETE event (the expense
+       * has just been deleted). Controls footer routing — deep link goes to
+       * /settings/activity-log (expense) so the user can still find the audit
+       * trail after the entity is gone.
+       *
+       * This is NOT a soft-delete state flag; it describes the notification event
+       * kind, not the current entity state. (Issue #215)
        */
       deleted?: boolean
     }
@@ -71,8 +75,12 @@ export type EmailDetails =
       /** Firestore document id — used to confirm the entity exists. (Issue #215) */
       entityId?: string
       /**
-       * Set to true when the settlement has been deleted.
-       * Deep link still routes to /split (the settlement history page). (Issue #215)
+       * Set when this notification is being sent for a DELETE event (the
+       * settlement has just been deleted). Deep link still routes to /split
+       * (the settlement history page).
+       *
+       * This is NOT a soft-delete state flag; it describes the notification event
+       * kind, not the current entity state. (Issue #215)
        */
       deleted?: boolean
     }
@@ -236,15 +244,33 @@ function buildDetailsSection(details: EmailDetails): string {
 const UNSUBSCRIBE_HINT = '若不想再收到此類郵件，請到 設定 → 🔔 Email 通知 關閉開關。'
 
 /**
+ * Validate that an entity id looks like a Firestore auto-id before embedding
+ * it in an email URL. Firestore auto-ids are [A-Za-z0-9_-]{1,64} in practice.
+ * Reject anything longer or with unusual chars to prevent oversized URLs in
+ * email bodies. A malicious writer would need Firestore write access anyway, so
+ * this is belt-and-suspenders only — defence in depth, not a primary control.
+ *
+ * Exported for direct test assertions.
+ */
+export function isValidEntityId(id: string): boolean {
+  return /^[A-Za-z0-9_-]{1,64}$/.test(id)
+}
+
+/**
  * Build the entity-specific deep link URL, or null when no meaningful link can
  * be derived. Exported for unit-testability. (Issue #215)
  *
- * Rules:
- * - expense (not deleted) + entityId → /expense/:entityId (edit page)
- * - expense (deleted)               → /settings/activity-log (entity is gone)
- * - settlement (any)                → /split
- * - settlement_batch                → /split
- * - otherwise                       → null
+ * Rules are deliberately aligned with `getNotificationHref` in
+ * `src/lib/notification-navigation.ts` so in-app clicks and email clicks land
+ * on the same page. Keep the two in sync when either changes.
+ *
+ * - expense (not deleted) + valid entityId → /expense/:entityId (edit page)
+ * - expense (not deleted), no entityId     → /records (list fallback, mirrors
+ *                                            getNotificationHref for expense_added/updated)
+ * - expense (deleted)                      → /settings/activity-log (entity gone)
+ * - settlement (any)                       → /split
+ * - settlement_batch                       → /split
+ * - otherwise                              → null
  */
 export function buildDeepLinkUrl(details: EmailDetails | undefined, baseUrl: string): string | null {
   if (!details) return null
@@ -252,12 +278,15 @@ export function buildDeepLinkUrl(details: EmailDetails | undefined, baseUrl: str
   const base = baseUrl.replace(/\/+$/, '')
 
   switch (details.kind) {
-    case 'expense':
+    case 'expense': {
       if (details.deleted) return `${base}/settings/activity-log`
-      if (details.entityId && details.entityId.trim()) {
-        return `${base}/expense/${encodeURIComponent(details.entityId)}`
-      }
-      return null
+      const id = details.entityId?.trim()
+      // Defensive: reject malformed ids before embedding in URL.
+      if (id && isValidEntityId(id)) return `${base}/expense/${encodeURIComponent(id)}`
+      // No entityId (or invalid): fall back to records list, matching
+      // getNotificationHref behaviour for expense_added / expense_updated.
+      return `${base}/records`
+    }
     case 'settlement':
       return `${base}/split`
     case 'settlement_batch':
@@ -266,19 +295,45 @@ export function buildDeepLinkUrl(details: EmailDetails | undefined, baseUrl: str
 }
 
 /**
+ * Pick the footer label for the deep link based on the notification kind.
+ *
+ * - expense (deleted)  → "查看紀錄" (routes to activity log)
+ * - expense (active)   → "查看此筆" (routes to edit page or records list)
+ * - settlement / batch → "前往結算" (routes to /split, a list page — "查看此筆"
+ *                         would be misleading because there is no entity detail page)
+ */
+function pickDeepLinkLabel(details: EmailDetails | undefined): string {
+  if (!details) return '查看此筆'
+  switch (details.kind) {
+    case 'expense':
+      return details.deleted ? '查看紀錄' : '查看此筆'
+    case 'settlement':
+    case 'settlement_batch':
+      return '前往結算'
+  }
+}
+
+/**
  * Build the plain-text email footer with optional deep link. (Issue #215)
  *
  * - When a deep link is available AND differs from the home URL, show both:
- *     查看此筆：{DEEP_LINK}
+ *     {label}：{DEEP_LINK}
  *     前往首頁：{APP_URL}
  * - Otherwise show a single generic "前往查看" line (backward-compat).
+ *
+ * The label is chosen by `pickDeepLinkLabel` so settlement links read
+ * "前往結算" instead of "查看此筆".
  */
 function buildEmailFooter(details: EmailDetails | undefined): string {
   const deepLink = buildDeepLinkUrl(details, APP_URL)
   const homeUrl = APP_URL.replace(/\/+$/, '')
 
-  if (deepLink && deepLink !== homeUrl && deepLink !== APP_URL) {
-    return `—\n查看此筆：${deepLink}\n前往首頁：${APP_URL}\n${UNSUBSCRIBE_HINT}`
+  // `buildDeepLinkUrl` uses `base = APP_URL.replace(/\/+$/, '')` so its output
+  // can never literally equal APP_URL (with trailing slash) unless both are
+  // effectively empty. Comparing against homeUrl is sufficient.
+  if (deepLink && deepLink !== homeUrl) {
+    const label = pickDeepLinkLabel(details)
+    return `—\n${label}：${deepLink}\n前往首頁：${APP_URL}\n${UNSUBSCRIBE_HINT}`
   }
   return `—\n前往查看：${APP_URL}\n${UNSUBSCRIBE_HINT}`
 }

--- a/src/lib/services/email-notification.ts
+++ b/src/lib/services/email-notification.ts
@@ -48,9 +48,19 @@ export type EmailDetails =
       description: string
       amount: number
       isShared: boolean
+      /** Category label, e.g. "餐飲". Renders as "類別：餐飲" when present. (Issue #215) */
+      category?: string
       payerName?: string
       splits?: Array<{ name: string; share: number }>
       note?: string
+      /** Firestore document id — used to build a deep link to the edit page. (Issue #215) */
+      entityId?: string
+      /**
+       * Set to true when the expense has been deleted.
+       * Deep link routes to /settings/activity-log instead of /expense/:id
+       * because the entity no longer exists. (Issue #215)
+       */
+      deleted?: boolean
     }
   | {
       kind: 'settlement'
@@ -58,6 +68,13 @@ export type EmailDetails =
       fromName: string
       toName: string
       amount: number
+      /** Firestore document id — used to confirm the entity exists. (Issue #215) */
+      entityId?: string
+      /**
+       * Set to true when the settlement has been deleted.
+       * Deep link still routes to /split (the settlement history page). (Issue #215)
+       */
+      deleted?: boolean
     }
   | {
       kind: 'settlement_batch'
@@ -151,6 +168,9 @@ function buildExpenseSection(d: Extract<EmailDetails, { kind: 'expense' }>): str
   lines.push(`項目：${truncate(d.description)}`)
   lines.push(`金額：${fmtAmount(d.amount)}`)
   lines.push(`日期：${formatEmailDate(d.date)}`)
+  if (d.category) {
+    lines.push(`類別：${truncate(d.category)}`)
+  }
   if (d.payerName) {
     lines.push(`付款人：${truncate(d.payerName)}`)
   }
@@ -213,7 +233,55 @@ function buildDetailsSection(details: EmailDetails): string {
   return buildSettlementBatchSection(details)
 }
 
-const EMAIL_FOOTER = `—\n前往查看：${APP_URL}\n若不想再收到此類郵件，請到 設定 → 🔔 Email 通知 關閉開關。`
+const UNSUBSCRIBE_HINT = '若不想再收到此類郵件，請到 設定 → 🔔 Email 通知 關閉開關。'
+
+/**
+ * Build the entity-specific deep link URL, or null when no meaningful link can
+ * be derived. Exported for unit-testability. (Issue #215)
+ *
+ * Rules:
+ * - expense (not deleted) + entityId → /expense/:entityId (edit page)
+ * - expense (deleted)               → /settings/activity-log (entity is gone)
+ * - settlement (any)                → /split
+ * - settlement_batch                → /split
+ * - otherwise                       → null
+ */
+export function buildDeepLinkUrl(details: EmailDetails | undefined, baseUrl: string): string | null {
+  if (!details) return null
+  // Strip trailing slash to avoid double-slashes in concatenation.
+  const base = baseUrl.replace(/\/+$/, '')
+
+  switch (details.kind) {
+    case 'expense':
+      if (details.deleted) return `${base}/settings/activity-log`
+      if (details.entityId && details.entityId.trim()) {
+        return `${base}/expense/${encodeURIComponent(details.entityId)}`
+      }
+      return null
+    case 'settlement':
+      return `${base}/split`
+    case 'settlement_batch':
+      return `${base}/split`
+  }
+}
+
+/**
+ * Build the plain-text email footer with optional deep link. (Issue #215)
+ *
+ * - When a deep link is available AND differs from the home URL, show both:
+ *     查看此筆：{DEEP_LINK}
+ *     前往首頁：{APP_URL}
+ * - Otherwise show a single generic "前往查看" line (backward-compat).
+ */
+function buildEmailFooter(details: EmailDetails | undefined): string {
+  const deepLink = buildDeepLinkUrl(details, APP_URL)
+  const homeUrl = APP_URL.replace(/\/+$/, '')
+
+  if (deepLink && deepLink !== homeUrl && deepLink !== APP_URL) {
+    return `—\n查看此筆：${deepLink}\n前往首頁：${APP_URL}\n${UNSUBSCRIBE_HINT}`
+  }
+  return `—\n前往查看：${APP_URL}\n${UNSUBSCRIBE_HINT}`
+}
 
 export function buildEmailPayload(args: {
   title: string
@@ -227,12 +295,14 @@ export function buildEmailPayload(args: {
   // Body is plain text (not a header), so CRLF is allowed — just avoid the
   // hardcoded Tailscale URL by routing via env var.
 
+  const footer = buildEmailFooter(args.details)
+
   let text: string
   if (args.details) {
     const detailSection = buildDetailsSection(args.details)
-    text = `${args.body}\n\n${detailSection}\n\n${EMAIL_FOOTER}`
+    text = `${args.body}\n\n${detailSection}\n\n${footer}`
   } else {
-    text = `${args.body}\n\n${EMAIL_FOOTER}`
+    text = `${args.body}\n\n${footer}`
   }
 
   return {

--- a/src/lib/services/expense-service.ts
+++ b/src/lib/services/expense-service.ts
@@ -115,11 +115,13 @@ export async function addExpense(
         description: input.description,
         amount: input.amount,
         isShared: input.isShared,
+        category: input.category,
         payerName: input.payerName,
         splits: input.splits
           .filter((s) => s.isParticipant && s.shareAmount > 0)
           .map((s) => ({ name: s.memberName, share: s.shareAmount })),
         note: input.note,
+        entityId: id,
       },
     })
   }
@@ -136,6 +138,7 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
   let prevAmount = 0
   let prevDate: Date | undefined
   let prevPayerName: string | undefined
+  let prevCategory: string | undefined
   let prevSplits: Array<{ name: string; share: number }> | undefined
   try {
     const snap = await getDoc(ref)
@@ -146,6 +149,7 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
         amount?: number
         date?: { toDate(): Date }
         payerName?: string
+        category?: string
         splits?: Array<{ memberName?: string; shareAmount?: number; isParticipant?: boolean }>
       }
       prevShared = !!d.isShared
@@ -153,6 +157,7 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
       prevAmount = d.amount ?? 0
       prevDate = d.date ? d.date.toDate() : undefined
       prevPayerName = d.payerName
+      prevCategory = d.category
       if (d.splits) {
         prevSplits = d.splits
           .filter((s) => s.isParticipant && (s.shareAmount ?? 0) > 0)
@@ -201,6 +206,7 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
           .filter((s) => s.isParticipant && s.shareAmount > 0)
           .map((s) => ({ name: s.memberName, share: s.shareAmount }))
       : prevSplits
+    const notifyCategory = input.category ?? prevCategory
     await notifyMembersAboutExpense(groupId, {
       type: 'expense_updated',
       title: '編輯共同支出',
@@ -213,9 +219,11 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
             description,
             amount,
             isShared: notifyIsShared,
+            category: notifyCategory,
             payerName: notifyPayerName,
             splits: notifySplits,
             note: input.note,
+            entityId: expenseId,
           }
         : undefined,
     })
@@ -262,6 +270,7 @@ export async function deleteExpense(groupId: string, expenseId: string, actor?: 
   let amount = 0
   let deleteDate: Date | undefined
   let deletePayerName: string | undefined
+  let deleteCategory: string | undefined
   let deleteSplits: Array<{ name: string; share: number }> | undefined
   try {
     const snap = await getDoc(ref)
@@ -274,6 +283,7 @@ export async function deleteExpense(groupId: string, expenseId: string, actor?: 
         receiptPath?: string | null
         date?: { toDate(): Date }
         payerName?: string
+        category?: string
         splits?: Array<{ memberName?: string; shareAmount?: number; isParticipant?: boolean }>
       }
       wasShared = !!d.isShared
@@ -281,6 +291,7 @@ export async function deleteExpense(groupId: string, expenseId: string, actor?: 
       amount = d.amount ?? 0
       deleteDate = d.date ? d.date.toDate() : undefined
       deletePayerName = d.payerName
+      deleteCategory = d.category
       if (d.splits) {
         deleteSplits = d.splits
           .filter((s) => s.isParticipant && (s.shareAmount ?? 0) > 0)
@@ -321,8 +332,11 @@ export async function deleteExpense(groupId: string, expenseId: string, actor?: 
             description,
             amount,
             isShared: true,
+            category: deleteCategory,
             payerName: deletePayerName,
             splits: deleteSplits,
+            deleted: true,
+            entityId: expenseId,
           }
         : undefined,
     })

--- a/src/lib/services/expense-service.ts
+++ b/src/lib/services/expense-service.ts
@@ -206,6 +206,10 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
           .filter((s) => s.isParticipant && s.shareAmount > 0)
           .map((s) => ({ name: s.memberName, share: s.shareAmount }))
       : prevSplits
+    // input.category ?? prevCategory: prefer the edited value; fall back to
+    // pre-update snapshot when the user didn't change category. Empty string
+    // (user cleared category) is kept as '' — buildExpenseSection will omit
+    // the 類別 row since '' is falsy.
     const notifyCategory = input.category ?? prevCategory
     await notifyMembersAboutExpense(groupId, {
       type: 'expense_updated',

--- a/src/lib/services/settlement-service.ts
+++ b/src/lib/services/settlement-service.ts
@@ -79,6 +79,7 @@ export async function addSettlement(groupId: string, data: NewSettlement, actor?
         fromName: data.fromMemberName,
         toName: data.toMemberName,
         amount: data.amount,
+        entityId: ref.id,
       },
     })
   } catch (e) {
@@ -246,6 +247,8 @@ export async function deleteSettlement(groupId: string, settlementId: string, ac
               fromName: deleteFromName,
               toName: deleteToName,
               amount: deleteAmount,
+              deleted: true,
+              entityId: settlementId,
             }
           : undefined,
     })


### PR DESCRIPTION
## 摘要

延伸 PR #214，email 通知再擴充 2 項：
1. **類別**：「類別：餐飲」行，幫助使用者一秒判斷消費類型
2. **深度連結**：email footer 多一行「查看此筆」直達該筆 expense/settlement

## 變更

### EmailDetails union 擴展

\`\`\`ts
expense:    { ...既有, category?, entityId?, deleted? }
settlement: { ...既有, entityId?, deleted? }
batch:      no entityId（不是單一 entity）
\`\`\`

### Email footer 新格式

有 details → 兩行：
\`\`\`
—
查看此筆：https://app/expense/e1
前往首頁：https://app/
若不想再收到此類郵件，請到 設定 → 🔔 Email 通知 關閉開關。
\`\`\`

無 details / 無 entityId → 維持單行 \`前往查看\`（向後相容）。

### 深度連結路由

| kind | deleted? | 深度連結 |
|------|---------|---------|
| expense | false | /expense/:id |
| expense | true | /settings/activity-log |
| settlement | any | /split |
| settlement_batch | — | /split |

### 呼叫端

- expense-service (add/update/delete) 全部 wire category + entityId
- delete 路徑在 pre-delete snapshot 多讀 category
- settlement-service wire entityId

## 測試

- 11 個新 case：category 有無 / truncation / 各種 kind 深度連結 / deleted flag / encodeURIComponent / 向後相容
- 全專案: **743/743 pass**
- Lint 0 error / Build OK

## Model 分工

- 實作：Sonnet agent
- 下一步 review：Opus agents

Closes #215