### PR TITLE
feat(email): updateExpense 通知顯示「編輯前→編輯後」差異 (Closes #216)

### DIFF
--- a/__tests__/email-notification.test.ts
+++ b/__tests__/email-notification.test.ts
@@ -755,6 +755,37 @@ describe('buildEmailPayload — expense changes diff (Issue #216)', () => {
     expect(p.text).toContain('t'.repeat(500) + '…')
   })
 
+  // --- Issue #218: note redaction and description non-redaction ---
+
+  it('備註 change: from is redacted to （已修改）, to is still shown', () => {
+    const details: EmailDetails = {
+      ...baseDetails,
+      changes: [{ label: '備註', from: '原本的私密備忘', to: '新的備注' }],
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('  - 備註：（已修改） → 新的備注')
+    expect(p.text).not.toContain('原本的私密備忘')
+  })
+
+  it('non-note change: from value is NOT redacted (regression)', () => {
+    const details: EmailDetails = {
+      ...baseDetails,
+      changes: [{ label: '金額', from: 'NT$ 100', to: 'NT$ 200' }],
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('  - 金額：NT$ 100 → NT$ 200')
+  })
+
+  it('描述 change is NOT redacted (description is the public expense identifier)', () => {
+    const details: EmailDetails = {
+      ...baseDetails,
+      changes: [{ label: '描述', from: '早餐', to: '早午餐' }],
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('  - 描述：早餐 → 早午餐')
+    expect(p.text).not.toContain('（已修改）')
+  })
+
   it('backward compat: expense without changes still renders normal body (regression from #214/#217)', () => {
     // No changes field at all — should render exactly like pre-#216
     const details: EmailDetails = {

--- a/__tests__/email-notification.test.ts
+++ b/__tests__/email-notification.test.ts
@@ -695,3 +695,86 @@ describe('isValidEntityId (Issue #217)', () => {
     expect(isValidEntityId('a b')).toBe(false)
   })
 })
+
+// --- Issue #216: expense edit diff rendering ---
+
+describe('buildEmailPayload — expense changes diff (Issue #216)', () => {
+  const baseDetails: EmailDetails = {
+    kind: 'expense',
+    date: new Date('2026-04-19T00:00:00Z'),
+    description: '午餐',
+    amount: 200,
+    isShared: true,
+  }
+
+  it('body contains 變更： heading when changes are present', () => {
+    const details: EmailDetails = {
+      ...baseDetails,
+      changes: [{ label: '金額', from: 'NT$ 100', to: 'NT$ 200' }],
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('變更：')
+  })
+
+  it('body contains each change entry in - label：from → to format', () => {
+    const details: EmailDetails = {
+      ...baseDetails,
+      changes: [
+        { label: '金額', from: 'NT$ 100', to: 'NT$ 200' },
+        { label: '描述', from: '早餐', to: '早午餐' },
+        { label: '類別', from: '餐飲', to: '外食' },
+      ],
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('  - 金額：NT$ 100 → NT$ 200')
+    expect(p.text).toContain('  - 描述：早餐 → 早午餐')
+    expect(p.text).toContain('  - 類別：餐飲 → 外食')
+  })
+
+  it('body does NOT contain 變更： when changes is empty array', () => {
+    const details: EmailDetails = { ...baseDetails, changes: [] }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).not.toContain('變更：')
+  })
+
+  it('body does NOT contain 變更： when changes is undefined', () => {
+    const details: EmailDetails = { ...baseDetails, changes: undefined }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).not.toContain('變更：')
+  })
+
+  it('long from/to values are truncated with …', () => {
+    const longFrom = 'f'.repeat(501)
+    const longTo = 't'.repeat(502)
+    const details: EmailDetails = {
+      ...baseDetails,
+      changes: [{ label: '描述', from: longFrom, to: longTo }],
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('f'.repeat(500) + '…')
+    expect(p.text).toContain('t'.repeat(500) + '…')
+  })
+
+  it('backward compat: expense without changes still renders normal body (regression from #214/#217)', () => {
+    // No changes field at all — should render exactly like pre-#216
+    const details: EmailDetails = {
+      kind: 'expense',
+      date: new Date('2026-04-19T00:00:00Z'),
+      description: '午餐',
+      amount: 300,
+      isShared: true,
+      payerName: '爸爸',
+      splits: [
+        { name: '爸爸', share: 150 },
+        { name: '媽媽', share: 150 },
+      ],
+      note: '家庭聚餐',
+    }
+    const p = buildEmailPayload({ title: 't', body: 'b', details })
+    expect(p.text).toContain('項目：午餐')
+    expect(p.text).toContain('金額：')
+    expect(p.text).toContain('分攤（2 人）')
+    expect(p.text).toContain('備註：家庭聚餐')
+    expect(p.text).not.toContain('變更：')
+  })
+})

--- a/__tests__/expense-diff.test.ts
+++ b/__tests__/expense-diff.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for diffExpense — pure function, no Firebase dependency.
+ * Target: 12-15 cases covering Issue #216 spec.
+ */
+
+// diffExpense imports formatEmailDate from email-notification; mock Firebase so the
+// module can load without a real Firebase project.
+jest.mock('@/lib/firebase', () => ({ db: {}, auth: {}, storage: {} }))
+jest.mock('firebase/firestore', () => ({
+  addDoc: jest.fn(),
+  collection: jest.fn(),
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+  serverTimestamp: jest.fn(),
+}))
+jest.mock('@/lib/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}))
+
+import { diffExpense } from '@/lib/expense-diff'
+import type { ExpenseSnapshot, ExpenseChange } from '@/lib/expense-diff'
+
+// Helper to extract labels from a change list
+function labels(changes: ExpenseChange[]): string[] {
+  return changes.map((c) => c.label)
+}
+
+describe('diffExpense', () => {
+  // 1. All identical fields → empty diff
+  it('returns [] when before and after are identical', () => {
+    const snap: ExpenseSnapshot = {
+      description: '早餐',
+      amount: 100,
+      category: '餐飲',
+      date: new Date('2026-04-19T00:00:00Z'),
+      payerName: '爸爸',
+      isShared: true,
+      splitMethod: 'equal',
+      paymentMethod: 'cash',
+      note: '好吃',
+    }
+    expect(diffExpense(snap, { ...snap })).toEqual([])
+  })
+
+  // 2. Only amount changed
+  it('detects amount change with NT$ formatted values', () => {
+    const changes = diffExpense({ amount: 100 }, { amount: 200 })
+    expect(labels(changes)).toEqual(['金額'])
+    expect(changes[0].from).toBe('NT$ 100')
+    expect(changes[0].to).toBe('NT$ 200')
+  })
+
+  // 3. Only description changed
+  it('detects description change', () => {
+    const changes = diffExpense({ description: '早餐' }, { description: '早午餐' })
+    expect(labels(changes)).toEqual(['描述'])
+    expect(changes[0].from).toBe('早餐')
+    expect(changes[0].to).toBe('早午餐')
+  })
+
+  // 4a. Category changed from value to value
+  it('detects category change', () => {
+    const changes = diffExpense({ category: '餐飲' }, { category: '外食' })
+    expect(labels(changes)).toEqual(['類別'])
+    expect(changes[0].from).toBe('餐飲')
+    expect(changes[0].to).toBe('外食')
+  })
+
+  // 4b. Category empty → value ('' treated as absent)
+  it('detects category change from empty string to value', () => {
+    const changes = diffExpense({ category: '' }, { category: '餐飲' })
+    expect(labels(changes)).toEqual(['類別'])
+    expect(changes[0].from).toBe('（無）')
+    expect(changes[0].to).toBe('餐飲')
+  })
+
+  // 4c. Category value → empty string
+  it('detects category change from value to empty string', () => {
+    const changes = diffExpense({ category: '餐飲' }, { category: '' })
+    expect(labels(changes)).toEqual(['類別'])
+    expect(changes[0].from).toBe('餐飲')
+    expect(changes[0].to).toBe('（無）')
+  })
+
+  // 5. isShared toggled
+  it('detects isShared toggle true → false', () => {
+    const changes = diffExpense({ isShared: true }, { isShared: false })
+    expect(labels(changes)).toEqual(['類型'])
+    expect(changes[0].from).toBe('共同')
+    expect(changes[0].to).toBe('個人')
+  })
+
+  it('detects isShared toggle false → true', () => {
+    const changes = diffExpense({ isShared: false }, { isShared: true })
+    expect(changes[0].from).toBe('個人')
+    expect(changes[0].to).toBe('共同')
+  })
+
+  // 6. paymentMethod change renders via paymentLabel mapping
+  it('detects paymentMethod change with Chinese labels', () => {
+    const changes = diffExpense({ paymentMethod: 'cash' }, { paymentMethod: 'creditCard' })
+    expect(labels(changes)).toEqual(['付款方式'])
+    expect(changes[0].from).toBe('現金')
+    expect(changes[0].to).toBe('信用卡')
+  })
+
+  // 7. Date change via Firestore-style Timestamp object → compared correctly
+  it('detects date change (Timestamp-like objects)', () => {
+    const d1 = { toDate: () => new Date('2026-04-18T00:00:00Z') }
+    const d2 = { toDate: () => new Date('2026-04-19T00:00:00Z') }
+    const changes = diffExpense({ date: d1 }, { date: d2 })
+    expect(labels(changes)).toEqual(['日期'])
+    // Formatted as YYYY-MM-DD in Asia/Taipei
+    expect(changes[0].from).toMatch(/2026-04-1[89]/)
+    expect(changes[0].to).toMatch(/2026-04-1[89]/)
+  })
+
+  // 8. Same-day date but different timestamp → should NOT be a change (same getTime())
+  it('does not flag a change when before and after date have the same timestamp', () => {
+    const ts = new Date('2026-04-19T08:00:00Z')
+    const changes = diffExpense({ date: ts }, { date: new Date(ts.getTime()) })
+    expect(changes).toEqual([])
+  })
+
+  // 9a. Note null / undefined / '' are all equivalent → no change
+  it('treats null, undefined, and empty string note as equivalent', () => {
+    expect(diffExpense({ note: null }, { note: undefined })).toEqual([])
+    expect(diffExpense({ note: undefined }, { note: '' })).toEqual([])
+    expect(diffExpense({ note: null }, { note: '' })).toEqual([])
+  })
+
+  // 9b. '' → 'hello' IS a change
+  it('detects note change from empty to non-empty', () => {
+    const changes = diffExpense({ note: '' }, { note: '好吃' })
+    expect(labels(changes)).toEqual(['備註'])
+    expect(changes[0].from).toBe('（無）')
+    expect(changes[0].to).toBe('好吃')
+  })
+
+  // 10. Multiple simultaneous changes in stable order
+  it('returns multiple changes in field iteration order', () => {
+    const before: ExpenseSnapshot = { description: '早餐', amount: 100, category: '餐飲' }
+    const after: ExpenseSnapshot = { description: '早午餐', amount: 200, category: '外食' }
+    const changes = diffExpense(before, after)
+    expect(labels(changes)).toEqual(['描述', '金額', '類別'])
+  })
+
+  // 11. Missing field in before (undefined) → rendered as '（無）'
+  it('renders undefined before field as （無）', () => {
+    const changes = diffExpense({}, { category: '餐飲' })
+    expect(labels(changes)).toEqual(['類別'])
+    expect(changes[0].from).toBe('（無）')
+    expect(changes[0].to).toBe('餐飲')
+  })
+
+  // 12. Splits are never in the diff output
+  it('does not produce any split-related entry even if snapshots differ', () => {
+    // ExpenseSnapshot intentionally has no splits field;
+    // this test confirms diffExpense never outputs a splits label.
+    const changes = diffExpense(
+      { description: '午餐', amount: 150 },
+      { description: '午餐', amount: 150 },
+    )
+    const hasSpliLabel = changes.some((c) => c.label.includes('分攤') || c.label.includes('split'))
+    expect(hasSpliLabel).toBe(false)
+    expect(changes).toEqual([])
+  })
+
+  // 13. Null amount in before → （無）
+  it('renders null amount before as （無）', () => {
+    const changes = diffExpense({ amount: null }, { amount: 300 })
+    expect(labels(changes)).toEqual(['金額'])
+    expect(changes[0].from).toBe('（無）')
+    expect(changes[0].to).toBe('NT$ 300')
+  })
+
+  // 14. splitMethod change
+  it('detects splitMethod change', () => {
+    const changes = diffExpense({ splitMethod: 'equal' }, { splitMethod: 'custom' })
+    expect(labels(changes)).toEqual(['分帳方式'])
+    expect(changes[0].from).toBe('equal')
+    expect(changes[0].to).toBe('custom')
+  })
+
+  // 15. payerName change
+  it('detects payerName change', () => {
+    const changes = diffExpense({ payerName: '爸爸' }, { payerName: '媽媽' })
+    expect(labels(changes)).toEqual(['付款人'])
+    expect(changes[0].from).toBe('爸爸')
+    expect(changes[0].to).toBe('媽媽')
+  })
+})

--- a/src/lib/email-date-format.ts
+++ b/src/lib/email-date-format.ts
@@ -1,0 +1,41 @@
+/**
+ * YYYY-MM-DD date formatter pinned to Asia/Taipei timezone.
+ * Extracted into a standalone module to break the circular dependency between
+ * expense-diff.ts (pure utility layer) and email-notification.ts (service layer).
+ *
+ * Both files import from here; neither imports the other.
+ */
+
+/**
+ * YYYY-MM-DD date formatter pinned to Asia/Taipei timezone.
+ * Handles both native Date and Firestore Timestamp-like objects.
+ * Try/catch mirrors the coerceDate pattern used elsewhere in this repo for
+ * Firestore Timestamp duck-type inputs.
+ *
+ * Locale + timezone fixed to Asia/Taipei so all recipients (regardless of
+ * where the server runs) see the expense's local date. en-CA locale gives
+ * YYYY-MM-DD; pinning timezone to Asia/Taipei keeps dates stable regardless
+ * of server deployment location.
+ */
+export function formatEmailDate(d: Date | { toDate(): Date } | null | undefined): string {
+  if (!d) return ''
+  let date: Date
+  try {
+    if (d instanceof Date) {
+      date = d
+    } else if (typeof (d as { toDate?: unknown }).toDate === 'function') {
+      date = (d as { toDate(): Date }).toDate()
+    } else {
+      return ''
+    }
+  } catch {
+    return ''
+  }
+  if (!(date instanceof Date) || !Number.isFinite(date.getTime())) return ''
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Taipei',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date)
+}

--- a/src/lib/expense-diff.ts
+++ b/src/lib/expense-diff.ts
@@ -3,7 +3,7 @@
  * No Firebase imports — fully unit-testable in isolation.
  */
 import { paymentLabel } from '@/lib/utils'
-import { formatEmailDate } from '@/lib/services/email-notification'
+import { formatEmailDate } from '@/lib/email-date-format'
 
 /**
  * Minimal snapshot of an expense's diffable scalar fields.

--- a/src/lib/expense-diff.ts
+++ b/src/lib/expense-diff.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure diff utility for expense edits (Issue #216).
+ * No Firebase imports — fully unit-testable in isolation.
+ */
+import { paymentLabel } from '@/lib/utils'
+import { formatEmailDate } from '@/lib/services/email-notification'
+
+/**
+ * Minimal snapshot of an expense's diffable scalar fields.
+ * Splits are intentionally excluded (too complex to diff inline).
+ */
+export interface ExpenseSnapshot {
+  description?: string | null
+  amount?: number | null
+  category?: string | null
+  date?: Date | { toDate(): Date } | null
+  payerName?: string | null
+  isShared?: boolean | null
+  splitMethod?: string | null
+  paymentMethod?: string | null
+  note?: string | null
+}
+
+/**
+ * A single field that changed between before and after states.
+ */
+export interface ExpenseChange {
+  /** Chinese human label for the field */
+  label: string
+  /** Formatted old value (for display) */
+  from: string
+  /** Formatted new value (for display) */
+  to: string
+}
+
+// Canonical iteration order for stable multi-field diffs
+type DiffableField = 'description' | 'amount' | 'category' | 'date' | 'payerName' | 'isShared' | 'splitMethod' | 'paymentMethod' | 'note'
+
+const FIELD_LABELS: Record<DiffableField, string> = {
+  description: '描述',
+  amount: '金額',
+  category: '類別',
+  date: '日期',
+  payerName: '付款人',
+  isShared: '類型',
+  splitMethod: '分帳方式',
+  paymentMethod: '付款方式',
+  note: '備註',
+}
+
+/**
+ * Coerce a date-like value to a Date, or return null on failure.
+ */
+function toDateSafe(d: Date | { toDate(): Date } | null | undefined): Date | null {
+  if (!d) return null
+  try {
+    if (d instanceof Date) return d
+    if (typeof (d as { toDate?: unknown }).toDate === 'function') {
+      return (d as { toDate(): Date }).toDate()
+    }
+  } catch {
+    // best-effort
+  }
+  return null
+}
+
+/**
+ * Normalize a nullable/undefined string to '' for comparison purposes.
+ * null, undefined, and '' are all treated as equivalent (absent).
+ */
+function normalizeStr(v: string | null | undefined): string {
+  return v ?? ''
+}
+
+/**
+ * Format a value for display in the diff section.
+ * Returns '（無）' when the value is absent.
+ */
+function formatValue(field: DiffableField, value: unknown): string {
+  if (field === 'amount') {
+    if (value === null || value === undefined) return '（無）'
+    return `NT$ ${(value as number).toLocaleString('zh-TW')}`
+  }
+  if (field === 'date') {
+    const formatted = formatEmailDate(value as Date | { toDate(): Date } | null | undefined)
+    return formatted || '（無）'
+  }
+  if (field === 'isShared') {
+    if (value === null || value === undefined) return '（無）'
+    return (value as boolean) ? '共同' : '個人'
+  }
+  if (field === 'paymentMethod') {
+    const s = normalizeStr(value as string | null | undefined)
+    if (!s) return '（無）'
+    return paymentLabel(s)
+  }
+  // String fields: description, category, payerName, splitMethod, note
+  const s = normalizeStr(value as string | null | undefined)
+  return s || '（無）'
+}
+
+/**
+ * Compare before and after expense snapshots and return a list of changed
+ * fields in stable iteration order. Splits are never included.
+ *
+ * Special handling:
+ * - note: null / undefined / '' are all treated as equivalent (no change).
+ * - date: compared via getTime() after coercion.
+ * - amounts: strict number equality.
+ */
+export function diffExpense(before: ExpenseSnapshot, after: ExpenseSnapshot): ExpenseChange[] {
+  const changes: ExpenseChange[] = []
+
+  const fields: DiffableField[] = [
+    'description',
+    'amount',
+    'category',
+    'date',
+    'payerName',
+    'isShared',
+    'splitMethod',
+    'paymentMethod',
+    'note',
+  ]
+
+  for (const field of fields) {
+    const bv = before[field]
+    const av = after[field]
+
+    if (field === 'date') {
+      // Compare via getTime() so different Timestamp objects for the same instant
+      // don't produce a spurious diff
+      const bd = toDateSafe(bv as Date | { toDate(): Date } | null | undefined)
+      const ad = toDateSafe(av as Date | { toDate(): Date } | null | undefined)
+      const bTime = bd ? bd.getTime() : null
+      const aTime = ad ? ad.getTime() : null
+      if (bTime === aTime) continue
+      changes.push({
+        label: FIELD_LABELS[field],
+        from: formatValue(field, bv),
+        to: formatValue(field, av),
+      })
+      continue
+    }
+
+    if (field === 'note') {
+      // null / undefined / '' are all equivalent for note
+      const bNorm = normalizeStr(bv as string | null | undefined)
+      const aNorm = normalizeStr(av as string | null | undefined)
+      if (bNorm === aNorm) continue
+      changes.push({
+        label: FIELD_LABELS[field],
+        from: formatValue(field, bv),
+        to: formatValue(field, av),
+      })
+      continue
+    }
+
+    if (field === 'amount') {
+      const bn = bv as number | null | undefined
+      const an = av as number | null | undefined
+      if (bn === an) continue
+      changes.push({
+        label: FIELD_LABELS[field],
+        from: formatValue(field, bv),
+        to: formatValue(field, av),
+      })
+      continue
+    }
+
+    if (field === 'isShared') {
+      const bb = bv as boolean | null | undefined
+      const ab = av as boolean | null | undefined
+      if (bb === ab) continue
+      changes.push({
+        label: FIELD_LABELS[field],
+        from: formatValue(field, bv),
+        to: formatValue(field, av),
+      })
+      continue
+    }
+
+    // String fields: description, category, payerName, splitMethod, paymentMethod
+    const bStr = normalizeStr(bv as string | null | undefined)
+    const aStr = normalizeStr(av as string | null | undefined)
+    if (bStr === aStr) continue
+    changes.push({
+      label: FIELD_LABELS[field],
+      from: formatValue(field, bv),
+      to: formatValue(field, av),
+    })
+  }
+
+  return changes
+}

--- a/src/lib/services/email-notification.ts
+++ b/src/lib/services/email-notification.ts
@@ -1,6 +1,7 @@
 import { addDoc, collection, doc, getDoc, serverTimestamp } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
 import { logger } from '@/lib/logger'
+import type { ExpenseChange } from '@/lib/expense-diff'
 
 /**
  * Email notification pipeline for in-app notifications (Issue #187).
@@ -65,6 +66,12 @@ export type EmailDetails =
        * kind, not the current entity state. (Issue #215)
        */
       deleted?: boolean
+      /**
+       * List of changed fields for edit notifications. When present and non-empty,
+       * renders a "變更：" section in the email body so recipients can see what
+       * changed. Undefined or empty array → section omitted. (Issue #216)
+       */
+      changes?: ExpenseChange[]
     }
   | {
       kind: 'settlement'
@@ -192,6 +199,13 @@ function buildExpenseSection(d: Extract<EmailDetails, { kind: 'expense' }>): str
     const splitLines = d.splits.map((s) => `  - ${truncate(s.name)}  ${fmtAmount(s.share)}`)
     lines.push(`分攤（${d.splits.length} 人）：`)
     lines.push(...splitLines)
+  }
+
+  if (d.changes && d.changes.length > 0) {
+    lines.push('變更：')
+    for (const c of d.changes) {
+      lines.push(`  - ${c.label}：${truncate(c.from, EMAIL_FIELD_LIMIT)} → ${truncate(c.to, EMAIL_FIELD_LIMIT)}`)
+    }
   }
 
   if (d.note) {

--- a/src/lib/services/email-notification.ts
+++ b/src/lib/services/email-notification.ts
@@ -2,6 +2,9 @@ import { addDoc, collection, doc, getDoc, serverTimestamp } from 'firebase/fires
 import { db } from '@/lib/firebase'
 import { logger } from '@/lib/logger'
 import type { ExpenseChange } from '@/lib/expense-diff'
+// Import for internal use; also re-exported below for backward-compat callers.
+import { formatEmailDate } from '@/lib/email-date-format'
+export { formatEmailDate } from '@/lib/email-date-format'
 
 /**
  * Email notification pipeline for in-app notifications (Issue #187).
@@ -134,40 +137,6 @@ function truncate(s: string, limit: number = EMAIL_FIELD_LIMIT): string {
 }
 
 /**
- * YYYY-MM-DD date formatter pinned to Asia/Taipei timezone.
- * Handles both native Date and Firestore Timestamp-like objects.
- * Try/catch mirrors the coerceDate pattern used elsewhere in this repo for
- * Firestore Timestamp duck-type inputs.
- *
- * Locale + timezone fixed to Asia/Taipei so all recipients (regardless of
- * where the server runs) see the expense's local date. en-CA locale gives
- * YYYY-MM-DD; pinning timezone to Asia/Taipei keeps dates stable regardless
- * of server deployment location.
- */
-export function formatEmailDate(d: Date | { toDate(): Date } | null | undefined): string {
-  if (!d) return ''
-  let date: Date
-  try {
-    if (d instanceof Date) {
-      date = d
-    } else if (typeof (d as { toDate?: unknown }).toDate === 'function') {
-      date = (d as { toDate(): Date }).toDate()
-    } else {
-      return ''
-    }
-  } catch {
-    return ''
-  }
-  if (!(date instanceof Date) || !Number.isFinite(date.getTime())) return ''
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'Asia/Taipei',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(date)
-}
-
-/**
  * Format an amount as NT$ 1,000 using locale-aware thousands separator.
  * Pinning to zh-TW ensures thousand separators even on small-ICU Node builds.
  */
@@ -204,7 +173,13 @@ function buildExpenseSection(d: Extract<EmailDetails, { kind: 'expense' }>): str
   if (d.changes && d.changes.length > 0) {
     lines.push('變更：')
     for (const c of d.changes) {
-      lines.push(`  - ${c.label}：${truncate(c.from, EMAIL_FIELD_LIMIT)} → ${truncate(c.to, EMAIL_FIELD_LIMIT)}`)
+      // Security: redact the old value of free-text notes to prevent leaking
+      // personal memo content to all group members via email. The new value
+      // is shown so recipients know the note was changed. Description is NOT
+      // redacted — it is the public identifier for the expense. (Issue #218)
+      const from = c.label === '備註' ? '（已修改）' : truncate(c.from, EMAIL_FIELD_LIMIT)
+      const to = truncate(c.to, EMAIL_FIELD_LIMIT)
+      lines.push(`  - ${c.label}：${from} → ${to}`)
     }
   }
 

--- a/src/lib/services/expense-service.ts
+++ b/src/lib/services/expense-service.ts
@@ -144,6 +144,9 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
   let prevCategory: string | undefined
   let prevSplits: Array<{ name: string; share: number }> | undefined
   let beforeSnapshot: ExpenseSnapshot = {}
+  // FIX #218: track whether the pre-update Firestore read failed so we can
+  // suppress the diff section rather than emitting false "（無）→ value" changes.
+  let snapshotReadFailed = false
   try {
     const snap = await getDoc(ref)
     if (snap.exists()) {
@@ -184,6 +187,7 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
     }
   } catch (e) {
     logger.error('[ExpenseService] Failed to read pre-update snapshot:', e)
+    snapshotReadFailed = true
   }
 
   const { receiptPaths, note, ...rest } = input
@@ -231,16 +235,21 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
     const notifyCategory = input.category ?? prevCategory
 
     // Compute field-level diff for the "what changed" section in the email. (Issue #216)
+    // FIX #218: when input is Partial<ExpenseInput>, undefined fields mean "not
+    // changed by this update". Fall back to the beforeSnapshot value so diffExpense
+    // doesn't report a spurious "午餐 → （無）" change for unmodified fields.
+    // Special-case note: `undefined` = field absent from partial update (no change);
+    // `''` or `null` = user explicitly cleared the note.
     const afterSnapshot: ExpenseSnapshot = {
-      description: input.description,
-      amount: input.amount,
-      category: input.category,
-      date: input.date,
-      payerName: input.payerName,
-      isShared: input.isShared,
-      splitMethod: input.splitMethod,
-      paymentMethod: input.paymentMethod,
-      note: input.note,
+      description: input.description ?? beforeSnapshot.description,
+      amount: input.amount ?? beforeSnapshot.amount,
+      category: input.category ?? beforeSnapshot.category,
+      date: input.date ?? beforeSnapshot.date,
+      payerName: input.payerName ?? beforeSnapshot.payerName,
+      isShared: input.isShared ?? beforeSnapshot.isShared,
+      splitMethod: input.splitMethod ?? beforeSnapshot.splitMethod,
+      paymentMethod: input.paymentMethod ?? beforeSnapshot.paymentMethod,
+      note: input.note !== undefined ? input.note : beforeSnapshot.note,
     }
     const changes = diffExpense(beforeSnapshot, afterSnapshot)
 
@@ -261,7 +270,9 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
             splits: notifySplits,
             note: input.note,
             entityId: expenseId,
-            changes: changes.length > 0 ? changes : undefined,
+            // FIX #218: omit changes when the pre-update read failed — better
+            // to show no diff than to display "（無）→ value" false diffs.
+            changes: (!snapshotReadFailed && changes.length > 0) ? changes : undefined,
           }
         : undefined,
     })

--- a/src/lib/services/expense-service.ts
+++ b/src/lib/services/expense-service.ts
@@ -7,6 +7,8 @@ import type { EmailDetails } from './email-notification'
 import { deleteReceiptImages, normalizeReceiptPaths } from './image-upload'
 import { currency } from '@/lib/utils'
 import type { Expense, SplitDetail, SplitMethod, PaymentMethod } from '@/lib/types'
+import { diffExpense } from '@/lib/expense-diff'
+import type { ExpenseSnapshot } from '@/lib/expense-diff'
 
 import { logger } from '@/lib/logger'
 
@@ -132,7 +134,8 @@ export async function addExpense(
 export async function updateExpense(groupId: string, expenseId: string, input: Partial<ExpenseInput>, actor?: Actor): Promise<void> {
   const ref = doc(db, 'groups', groupId, 'expenses', expenseId)
 
-  // Read the previous state so we can notify when either old or new was shared.
+  // Read the previous state so we can notify when either old or new was shared,
+  // and to compute the field-level diff for the edit notification. (Issue #216)
   let prevShared = false
   let prevDescription = ''
   let prevAmount = 0
@@ -140,6 +143,7 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
   let prevPayerName: string | undefined
   let prevCategory: string | undefined
   let prevSplits: Array<{ name: string; share: number }> | undefined
+  let beforeSnapshot: ExpenseSnapshot = {}
   try {
     const snap = await getDoc(ref)
     if (snap.exists()) {
@@ -150,6 +154,9 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
         date?: { toDate(): Date }
         payerName?: string
         category?: string
+        splitMethod?: string
+        paymentMethod?: string
+        note?: string
         splits?: Array<{ memberName?: string; shareAmount?: number; isParticipant?: boolean }>
       }
       prevShared = !!d.isShared
@@ -162,6 +169,17 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
         prevSplits = d.splits
           .filter((s) => s.isParticipant && (s.shareAmount ?? 0) > 0)
           .map((s) => ({ name: s.memberName ?? '', share: s.shareAmount ?? 0 }))
+      }
+      beforeSnapshot = {
+        description: d.description,
+        amount: d.amount,
+        category: d.category,
+        date: d.date,
+        payerName: d.payerName,
+        isShared: d.isShared,
+        splitMethod: d.splitMethod,
+        paymentMethod: d.paymentMethod,
+        note: d.note,
       }
     }
   } catch (e) {
@@ -211,6 +229,21 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
     // (user cleared category) is kept as '' — buildExpenseSection will omit
     // the 類別 row since '' is falsy.
     const notifyCategory = input.category ?? prevCategory
+
+    // Compute field-level diff for the "what changed" section in the email. (Issue #216)
+    const afterSnapshot: ExpenseSnapshot = {
+      description: input.description,
+      amount: input.amount,
+      category: input.category,
+      date: input.date,
+      payerName: input.payerName,
+      isShared: input.isShared,
+      splitMethod: input.splitMethod,
+      paymentMethod: input.paymentMethod,
+      note: input.note,
+    }
+    const changes = diffExpense(beforeSnapshot, afterSnapshot)
+
     await notifyMembersAboutExpense(groupId, {
       type: 'expense_updated',
       title: '編輯共同支出',
@@ -228,6 +261,7 @@ export async function updateExpense(groupId: string, expenseId: string, input: P
             splits: notifySplits,
             note: input.note,
             entityId: expenseId,
+            changes: changes.length > 0 ? changes : undefined,
           }
         : undefined,
     })


### PR DESCRIPTION
## 摘要

updateExpense 通知原本只寫「爸爸編輯了 午餐（NT\$ 300）」，不告訴收件人改了什麼。多人協作透明度關鍵——現在 email body 會列出所有變動欄位的 before → after。

## 設計

### 新純函式 \`diffExpense\`

\`src/lib/expense-diff.ts\`：

- 比較 9 個欄位（description / amount / category / date / payerName / isShared / splitMethod / paymentMethod / note）
- 固定順序輸出，便於閱讀
- 空值正規化：null / undefined / '' 視為等價
- date 用 getTime() 比對，避免毫秒精度誤報
- paymentMethod 透過 \`paymentLabel\` 轉為中文顯示
- splits 刻意 skip（太複雜，本輪不處理）

### Email body 新「變更：」區塊

\`\`\`
{actor} 編輯了共同支出

項目：早餐
金額：NT\$ 200
類別：外食
日期：2026-04-19
付款人：爸爸
分攤（3 人）：
  - 爸爸  NT\$ 67
  - 媽媽  NT\$ 67
  - 女兒  NT\$ 66

變更：
  - 金額：NT\$ 100 → NT\$ 200
  - 描述：早餐 → 早午餐
  - 類別：餐飲 → 外食

—
查看此筆：https://app/expense/e1
...
\`\`\`

只在 changes 非空時顯示 `變更：` 標題；空陣列或 undefined 不渲染（向後相容）。

### 呼叫端

\`updateExpense\` 擴充 pre-update snapshot 讀 9 個欄位，update 成功後呼叫 \`diffExpense(before, input)\` 產生 changes 傳入 details。

## 測試

- \`__tests__/expense-diff.test.ts\`：15 個 case（單一欄位 / 多欄位 / Firestore Timestamp / 日期 normalization / null-empty 等價 / splits 不在 diff 中）
- \`__tests__/email-notification.test.ts\`：+6 個 case（變更區塊渲染 / 空陣列略過 / truncate / backward compat）
- 全專案：**781/781 pass**
- Lint 0 error / Build OK

## 變更

\`\`\`
__tests__/email-notification.test.ts   |  83 +++
__tests__/expense-diff.test.ts         | 192 +++
src/lib/expense-diff.ts                | 195 +++
src/lib/services/email-notification.ts |  14 +
src/lib/services/expense-service.ts    |  36 +/-
\`\`\`

## Scope
- 純擴展，不動 Firestore rules / CI / deps
- 不衝突 #217 剛 merged 的類別/深度連結
- 中型以下

## Model 分工
- 實作：Sonnet agent
- Review 下一步：Opus agents

Closes #216