### PR TITLE
feat(quick-add): 「↺ 同上筆」一鍵複製最近一筆支出 (Closes #219)

### DIFF
--- a/__tests__/quick-add-duplicate.test.ts
+++ b/__tests__/quick-add-duplicate.test.ts
@@ -1,0 +1,25 @@
+import { buildDuplicateHref } from '@/lib/quick-add-duplicate'
+
+describe('buildDuplicateHref', () => {
+  it('returns null when id is undefined', () => {
+    expect(buildDuplicateHref(undefined)).toBeNull()
+  })
+
+  it('returns null when id is null', () => {
+    expect(buildDuplicateHref(null)).toBeNull()
+  })
+
+  it('returns null when id is empty string', () => {
+    expect(buildDuplicateHref('')).toBeNull()
+  })
+
+  it('builds href with a normal id', () => {
+    expect(buildDuplicateHref('abc123')).toBe('/expense/new?duplicate=abc123')
+  })
+
+  it('URL-encodes ids that contain special characters', () => {
+    // Firestore ids are URL-safe in practice, but the helper must not break
+    // if an id ever contains reserved chars (e.g. from legacy imports).
+    expect(buildDuplicateHref('a/b c')).toBe('/expense/new?duplicate=a%2Fb%20c')
+  })
+})

--- a/src/components/quick-add-bar.tsx
+++ b/src/components/quick-add-bar.tsx
@@ -6,6 +6,7 @@ import { useGroup } from '@/lib/hooks/use-group'
 import { useMembers } from '@/lib/hooks/use-members'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { useCurrentMember } from '@/lib/hooks/use-current-member'
+import { useExpenses, useRecentExpenses } from '@/lib/hooks/use-expenses'
 import { useAuth } from '@/lib/auth'
 import { addExpense, type ExpenseInput } from '@/lib/services/expense-service'
 import { parseExpense } from '@/lib/services/local-expense-parser'
@@ -13,6 +14,7 @@ import { learnFromExpense, suggestCategory, isAuthError } from '@/lib/services/t
 import { useToast } from '@/components/toast'
 import { useSubmitGuard } from '@/lib/hooks/use-submit-guard'
 import { buildDraftKey, parseDraft, serializeDraft } from '@/lib/quick-add-draft'
+import { buildDuplicateHref } from '@/lib/quick-add-duplicate'
 import { logger } from '@/lib/logger'
 
 export function QuickAddBar() {
@@ -20,8 +22,12 @@ export function QuickAddBar() {
   const { members } = useMembers()
   const { categories } = useCategories()
   const { currentMemberId } = useCurrentMember(group?.id)
+  const { expenses } = useExpenses()
   const { user } = useAuth()
   const { addToast } = useToast()
+
+  const [lastExpense] = useRecentExpenses(expenses, 1)
+  const duplicateHref = buildDuplicateHref(lastExpense?.id)
 
   const [expanded, setExpanded] = useState(false)
   const [description, setDescription] = useState('')
@@ -214,15 +220,37 @@ export function QuickAddBar() {
 
   if (!expanded) {
     return (
-      <button
-        onClick={() => setExpanded(true)}
-        className="w-full card p-4 text-left text-[var(--muted-foreground)] hover:border-[var(--primary)] transition-colors cursor-text"
-      >
-        <span className="flex items-center gap-2">
-          <span>⚡</span>
-          <span>快速記帳...</span>
-        </span>
-      </button>
+      <div className="flex gap-2">
+        <button
+          onClick={() => setExpanded(true)}
+          className="flex-1 card p-4 text-left text-[var(--muted-foreground)] hover:border-[var(--primary)] transition-colors cursor-text"
+        >
+          <span className="flex items-center gap-2">
+            <span>⚡</span>
+            <span>快速記帳...</span>
+          </span>
+        </button>
+        {duplicateHref ? (
+          <Link
+            href={duplicateHref}
+            aria-label="複製最近一筆支出"
+            title="複製最近一筆支出"
+            className="card px-4 flex items-center justify-center text-sm text-[var(--muted-foreground)] hover:border-[var(--primary)] hover:text-[var(--foreground)] transition-colors whitespace-nowrap"
+          >
+            ↺ 同上筆
+          </Link>
+        ) : (
+          <button
+            type="button"
+            disabled
+            aria-label="尚無可複製的支出"
+            title="尚無可複製的支出"
+            className="card px-4 flex items-center justify-center text-sm text-[var(--muted-foreground)] opacity-40 cursor-not-allowed whitespace-nowrap"
+          >
+            ↺ 同上筆
+          </button>
+        )}
+      </div>
     )
   }
 

--- a/src/lib/quick-add-duplicate.ts
+++ b/src/lib/quick-add-duplicate.ts
@@ -1,0 +1,12 @@
+/**
+ * Helper for QuickAddBar's "↺ 同上筆" shortcut (Issue #219).
+ *
+ * Returns the href to /expense/new with a ?duplicate=<id> param so the
+ * existing full-form duplicate path pre-fills everything (description,
+ * amount, category, splits, payer, isShared). Returns null when there
+ * is no recent expense to copy — caller renders a disabled placeholder.
+ */
+export function buildDuplicateHref(lastExpenseId: string | undefined | null): string | null {
+  if (!lastExpenseId) return null
+  return `/expense/new?duplicate=${encodeURIComponent(lastExpenseId)}`
+}


### PR DESCRIPTION
## Summary
- 在 QuickAddBar collapsed 狀態新增「↺ 同上筆」按鈕，連結 \`/expense/new?duplicate=<id>\`，重用既有 \`duplicateFrom\` 路徑
- 完整複製 description/amount/category/splits/payerId/isShared；日期保留今天
- 無最近記錄時 button disabled（視覺灰化 + tooltip 提示）

## Why
QuickAddBar 原本要手動打描述等 autocomplete。日常最常發生「跟剛剛一樣」的情境（每日便當、同家早餐）需要更快路徑。重用既有 \`?duplicate=\` 深連結避免重寫複製邏輯，所有 expense 類型（shared/personal）都支援。

## Changes
- \`src/components/quick-add-bar.tsx\` — collapsed 雙按鈕 layout
- \`src/lib/quick-add-duplicate.ts\` — 抽出 \`buildDuplicateHref\` 純函式
- \`__tests__/quick-add-duplicate.test.ts\` — 5 tests（null/undefined/empty/normal/URL encode）

## Test plan
- [x] Jest: \`npx jest __tests__/quick-add-duplicate.test.ts\` — 5 passed
- [x] Lint 乾淨
- [x] \`tsc --noEmit\` 乾淨
- [ ] 手動驗證（部署後）：
  - 無最近支出的群組 → button disabled
  - 有最近支出 → 點擊進入 /expense/new 且欄位預填

Closes #219