### PR TITLE
feat(records): 月份左右 swipe + 金額區間篩選 (Closes #221)

### DIFF
--- a/__tests__/amount-range-filter.test.ts
+++ b/__tests__/amount-range-filter.test.ts
@@ -1,0 +1,76 @@
+import {
+  matchesAmountRange,
+  parseAmountRangeParam,
+  AMOUNT_RANGE_KEYS,
+  AMOUNT_RANGE_LABELS,
+} from '@/lib/amount-range-filter'
+
+describe('matchesAmountRange', () => {
+  it('all matches everything including edges', () => {
+    expect(matchesAmountRange(0, 'all')).toBe(true)
+    expect(matchesAmountRange(999999, 'all')).toBe(true)
+  })
+
+  it.each([
+    [0, true],
+    [50, true],
+    [99.99, true],
+    [100, false],
+    [500, false],
+  ])('under100: %s → %s', (amt, expected) => {
+    expect(matchesAmountRange(amt, 'under100')).toBe(expected)
+  })
+
+  it.each([
+    [99, false],
+    [100, true],
+    [250, true],
+    [499.99, true],
+    [500, false],
+  ])('100-500: %s → %s', (amt, expected) => {
+    expect(matchesAmountRange(amt, '100-500')).toBe(expected)
+  })
+
+  it.each([
+    [499, false],
+    [500, true],
+    [1000, true],
+    [1999.99, true],
+    [2000, false],
+  ])('500-2000: %s → %s', (amt, expected) => {
+    expect(matchesAmountRange(amt, '500-2000')).toBe(expected)
+  })
+
+  it.each([
+    [1999, false],
+    [2000, true],
+    [10000, true],
+  ])('over2000: %s → %s', (amt, expected) => {
+    expect(matchesAmountRange(amt, 'over2000')).toBe(expected)
+  })
+})
+
+describe('parseAmountRangeParam', () => {
+  it.each([
+    [null, 'all'],
+    [undefined, 'all'],
+    ['', 'all'],
+    ['garbage', 'all'],
+    ['42', 'all'],
+    ['all', 'all'],
+    ['under100', 'under100'],
+    ['100-500', '100-500'],
+    ['500-2000', '500-2000'],
+    ['over2000', 'over2000'],
+  ])('%s → %s', (input, expected) => {
+    expect(parseAmountRangeParam(input)).toBe(expected)
+  })
+})
+
+describe('shape invariants', () => {
+  it('every key has a label', () => {
+    for (const k of AMOUNT_RANGE_KEYS) {
+      expect(AMOUNT_RANGE_LABELS[k]).toBeTruthy()
+    }
+  })
+})

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -1,8 +1,15 @@
 'use client'
 
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
+import {
+  parseAmountRangeParam,
+  matchesAmountRange,
+  type AmountRangeKey,
+} from '@/lib/amount-range-filter'
+import { AmountRangeChips } from '@/components/amount-range-chips'
+import { useSwipe } from '@/hooks/use-swipe'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useExpenses } from '@/lib/hooks/use-expenses'
 import { useMembers } from '@/lib/hooks/use-members'
@@ -76,6 +83,21 @@ export default function RecordsPage() {
   const [dateEnd, setDateEnd] = useState(() => searchParams.get('end') || currentMonthRange().end)
   const [payerFilter, setPayerFilter] = useState('')
   const [categoryFilter, setCategoryFilter] = useState(() => searchParams.get('category') ?? '')
+  // Amount-range quick filter (Issue #221). Initial value from URL; sync back
+  // to URL on change so the chip selection persists across reloads and can be
+  // shared via link.
+  const [amountRange, setAmountRange] = useState<AmountRangeKey>(() =>
+    parseAmountRangeParam(searchParams.get('amount')),
+  )
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    if (amountRange === 'all') params.delete('amount')
+    else params.set('amount', amountRange)
+    const qs = params.toString()
+    const newUrl = qs ? `${window.location.pathname}?${qs}` : window.location.pathname
+    window.history.replaceState(null, '', newUrl)
+  }, [amountRange])
 
   // Derived: which month does the current date filter represent?
   // - Exact-month range → show prev/next month navigation
@@ -146,9 +168,12 @@ export default function RecordsPage() {
       // Category filter (match by name since expense stores category name)
       if (categoryFilter && e.category !== categoryFilter) return false
 
+      // Amount range filter (Issue #221)
+      if (!matchesAmountRange(e.amount, amountRange)) return false
+
       return true
     })
-  }, [expenses, filter, searchQuery, dateStart, dateEnd, payerFilter, categoryFilter])
+  }, [expenses, filter, searchQuery, dateStart, dateEnd, payerFilter, categoryFilter, amountRange])
 
   const grouped = useMemo(() => {
     const map = new Map<string, Expense[]>()
@@ -174,6 +199,7 @@ export default function RecordsPage() {
     setDateEnd(curr.end)
     setPayerFilter('')
     setCategoryFilter('')
+    setAmountRange('all')
   }
 
   function handleExportCSV() {
@@ -227,8 +253,21 @@ export default function RecordsPage() {
     }
   }
 
+  // Swipe: left = next month, right = previous month. Only fires when the
+  // view is on an exact month (not a custom range). Touch-only so desktop
+  // mouse users aren't affected.
+  const swipeRef = useRef<HTMLDivElement | null>(null)
+  useSwipe(swipeRef, {
+    onSwipeLeft: () => {
+      if (monthNav.kind === 'month') jumpToMonth(1)
+    },
+    onSwipeRight: () => {
+      if (monthNav.kind === 'month') jumpToMonth(-1)
+    },
+  })
+
   return (
-    <div className="p-4 md:p-8 max-w-5xl mx-auto">
+    <div ref={swipeRef} className="p-4 md:p-8 max-w-5xl mx-auto">
       {/* Header row */}
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-bold">所有記錄</h1>
@@ -309,6 +348,11 @@ export default function RecordsPage() {
           onDateRangeChange={(s, e) => { setDateStart(s); setDateEnd(e) }}
           onCategoryChange={setCategoryFilter}
         />
+      </div>
+
+      {/* Amount-range chips (Issue #221) */}
+      <div className="mb-3">
+        <AmountRangeChips value={amountRange} onChange={setAmountRange} />
       </div>
 
       {/* Search bar + advanced toggle */}

--- a/src/components/amount-range-chips.tsx
+++ b/src/components/amount-range-chips.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import {
+  AMOUNT_RANGE_KEYS,
+  AMOUNT_RANGE_LABELS,
+  type AmountRangeKey,
+} from '@/lib/amount-range-filter'
+
+interface AmountRangeChipsProps {
+  value: AmountRangeKey
+  onChange: (_next: AmountRangeKey) => void
+  className?: string
+}
+
+export function AmountRangeChips({ value, onChange, className }: AmountRangeChipsProps) {
+  return (
+    <div className={`flex flex-wrap gap-1.5 ${className ?? ''}`} role="group" aria-label="金額區間篩選">
+      {AMOUNT_RANGE_KEYS.map((k) => {
+        const selected = value === k
+        return (
+          <button
+            key={k}
+            type="button"
+            onClick={() => onChange(k)}
+            aria-pressed={selected}
+            className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
+              selected
+                ? 'bg-[var(--primary)] text-white'
+                : 'bg-[var(--muted)] text-[var(--muted-foreground)] hover:bg-[var(--border)]'
+            }`}
+          >
+            {AMOUNT_RANGE_LABELS[k]}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/hooks/use-swipe.ts
+++ b/src/hooks/use-swipe.ts
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, type RefObject } from 'react'
+
+interface SwipeOptions {
+  onSwipeLeft?: () => void
+  onSwipeRight?: () => void
+  /** Minimum horizontal distance in px before a swipe counts. */
+  threshold?: number
+  /** Horizontal must be this many times bigger than vertical to avoid vertical scroll hijack. */
+  horizontalRatio?: number
+}
+
+/**
+ * Lightweight touch-swipe detector for mobile navigation gestures.
+ *
+ * Attaches `touchstart`/`touchend` listeners to the referenced element and
+ * fires the corresponding callback when the swipe is predominantly
+ * horizontal and exceeds `threshold`. Uses `passive: true` so it doesn't
+ * block vertical scrolling. Used by /records to let users left-swipe to
+ * next month, right-swipe to previous month (Issue #221).
+ */
+export function useSwipe(
+  ref: RefObject<HTMLElement | null>,
+  { onSwipeLeft, onSwipeRight, threshold = 60, horizontalRatio = 1.5 }: SwipeOptions,
+): void {
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    let startX = 0
+    let startY = 0
+    let tracking = false
+
+    const onStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) {
+        tracking = false
+        return
+      }
+      const t = e.touches[0]
+      startX = t.clientX
+      startY = t.clientY
+      tracking = true
+    }
+
+    const onEnd = (e: TouchEvent) => {
+      if (!tracking) return
+      tracking = false
+      const t = e.changedTouches[0]
+      if (!t) return
+      const dx = t.clientX - startX
+      const dy = t.clientY - startY
+      if (Math.abs(dx) < threshold) return
+      if (Math.abs(dx) < Math.abs(dy) * horizontalRatio) return
+      if (dx < 0) onSwipeLeft?.()
+      else onSwipeRight?.()
+    }
+
+    el.addEventListener('touchstart', onStart, { passive: true })
+    el.addEventListener('touchend', onEnd, { passive: true })
+    return () => {
+      el.removeEventListener('touchstart', onStart)
+      el.removeEventListener('touchend', onEnd)
+    }
+  }, [ref, onSwipeLeft, onSwipeRight, threshold, horizontalRatio])
+}

--- a/src/lib/amount-range-filter.ts
+++ b/src/lib/amount-range-filter.ts
@@ -1,0 +1,64 @@
+/**
+ * Amount-range filter for the records page (Issue #221).
+ *
+ * Defines the canonical set of quick ranges users can pick to narrow
+ * records by transaction amount, plus parse/predicate helpers. Kept as
+ * pure functions so the page logic stays testable.
+ */
+export type AmountRangeKey =
+  | 'all'
+  | 'under100'
+  | '100-500'
+  | '500-2000'
+  | 'over2000'
+
+export const AMOUNT_RANGE_KEYS: readonly AmountRangeKey[] = [
+  'all',
+  'under100',
+  '100-500',
+  '500-2000',
+  'over2000',
+]
+
+export const AMOUNT_RANGE_LABELS: Record<AmountRangeKey, string> = {
+  all: '全部',
+  under100: '<100',
+  '100-500': '100–500',
+  '500-2000': '500–2000',
+  over2000: '>2000',
+}
+
+export function matchesAmountRange(amount: number, key: AmountRangeKey): boolean {
+  switch (key) {
+    case 'all':
+      return true
+    case 'under100':
+      return amount < 100
+    case '100-500':
+      return amount >= 100 && amount < 500
+    case '500-2000':
+      return amount >= 500 && amount < 2000
+    case 'over2000':
+      return amount >= 2000
+  }
+}
+
+/**
+ * Parse a `?amount=` query param value into a valid range key.
+ * Returns 'all' for missing / unknown / empty values so callers always
+ * get a usable value without narrowing.
+ */
+export function parseAmountRangeParam(
+  param: string | null | undefined,
+): AmountRangeKey {
+  if (!param) return 'all'
+  switch (param) {
+    case 'under100':
+    case '100-500':
+    case '500-2000':
+    case 'over2000':
+      return param
+    default:
+      return 'all'
+  }
+}


### PR DESCRIPTION
## Summary
1. **月份 swipe**：手機左滑 → 下一個月、右滑 → 上一個月。桌機既有 \`◀ ▶\` 按鈕保留。
2. **金額區間 chips**：\`全部 / <100 / 100–500 / 500–2000 / >2000\`，URL 同步 \`?amount=100-500\`。

## Why
切月份要點下拉、找大額/小額支出沒有快速路徑——兩者都是家人日常回顧時會卡住的動作。

## Architecture
- 純邏輯（\`matchesAmountRange\` / \`parseAmountRangeParam\`）放 \`src/lib/amount-range-filter.ts\`，高測試覆蓋。
- \`useSwipe\` 抽成 generic hook（\`src/hooks/use-swipe.ts\`），只 bind \`touchstart/touchend\` passive listener，不 block 垂直捲動。
- URL sync 用 \`window.history.replaceState\` — avoid Next router re-render，chip 切換不重新渲染整頁。

## Changes
- \`src/lib/amount-range-filter.ts\`
- \`src/components/amount-range-chips.tsx\`
- \`src/hooks/use-swipe.ts\`
- \`src/app/(auth)/records/page.tsx\` — state + URL sync + swipe + chip row
- \`__tests__/amount-range-filter.test.ts\` — 30 cases（邊界、null、param parse）

## Test plan
- [x] 30 unit tests pass
- [x] \`tsc --noEmit\` 乾淨
- [x] lint 乾淨（pre-existing unrelated warning unchanged）
- [ ] 部署後手動驗證：
  - 手機左右 swipe 切月
  - 點 \`100–500\` chip 只顯示該區間、URL 變為 \`?amount=100-500\`
  - 點 \`全部\` URL 清除
  - 清除所有篩選時 chip 回到 \`全部\`

Closes #221