### PR TITLE
feat(home): 首頁 section 整併 — 降低垂直密度 (Closes #222)

### DIFF
--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -9,11 +9,13 @@ import { useMembers } from '@/lib/hooks/use-members'
 import { simplifyDebts } from '@/lib/services/split-calculator'
 import { TodaySummary } from '@/components/today-summary'
 import { joinGroupByInviteCode } from '@/lib/services/group-service'
-import { currency, toDate, fmtDate } from '@/lib/utils'
+import { currency } from '@/lib/utils'
 import { QuickAddBar } from '@/components/quick-add-bar'
 import { WeeklyDigest } from '@/components/weekly-digest'
 import { BudgetProgress } from '@/components/budget-progress'
 import { RecentActivitySection } from '@/components/recent-activity-section'
+import { SimpleTabs } from '@/components/simple-tabs'
+import { RecentExpensesList } from '@/components/recent-expenses-list'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { logger } from '@/lib/logger'
 import { useToast } from '@/components/toast'
@@ -84,6 +86,12 @@ export default function HomePage() {
   const recent = useRecentExpenses(expenses, 5)
   const nameMap = useMemo(() => Object.fromEntries(members.map((m) => [m.id, m.name])), [members])
   const debts = useMemo(() => simplifyDebts(expenses, settlements, nameMap), [expenses, settlements, nameMap])
+
+  // Home-page tabs (Issue #222). Two sections that each have two sub-views —
+  // kept inline rather than extracted to wrapper components to avoid extra
+  // state-prop plumbing; content selection is just a local conditional.
+  const [summaryTab, setSummaryTab] = useState<'today' | 'week'>('today')
+  const [timelineTab, setTimelineTab] = useState<'expenses' | 'activity'>('expenses')
 
   // Pending confirmation: auto-generated recurring expenses
   const pendingExpenses = useMemo(() => expenses.filter((e) => e.pendingConfirm), [expenses])
@@ -178,11 +186,22 @@ export default function HomePage() {
         </div>
       )}
 
-      {/* 每週回顧（可關閉） */}
-      <WeeklyDigest expenses={expenses} />
-
-      {/* 今日/本週摘要 */}
-      <TodaySummary expenses={expenses} loading={dataLoading} />
+      {/* 今日/本週摘要 — tabs (Issue #222) */}
+      <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+        <SimpleTabs
+          tabs={[
+            { key: 'today', label: '☀️ 今日 / 本週' },
+            { key: 'week', label: '📅 上週回顧' },
+          ] as const}
+          active={summaryTab}
+          onChange={setSummaryTab}
+        />
+        {summaryTab === 'today' ? (
+          <TodaySummary expenses={expenses} loading={dataLoading} noCard />
+        ) : (
+          <WeeklyDigest expenses={expenses} noCard />
+        )}
+      </div>
 
       {/* 月度預算進度 */}
       <BudgetProgress group={group} expenses={expenses} />
@@ -224,14 +243,11 @@ export default function HomePage() {
           </div>
         </div>
 
-        {/* 誰欠誰 — 左欄 */}
+        {/* 誰欠誰 — 左欄；空狀態折疊為單行避免浪費垂直空間 (Issue #222) */}
         <div className="card p-5 md:p-6 space-y-3 animate-fade-up stagger-2">
           <div className="flex items-center gap-2 font-semibold">💰 誰欠誰</div>
           {debts.length === 0 ? (
-            <div className="text-center py-6">
-              <div className="text-3xl mb-2">🎉</div>
-              <p className="text-[var(--muted-foreground)]">目前沒有未結清的債務</p>
-            </div>
+            <p className="text-sm text-[var(--muted-foreground)]">🎉 目前沒有未結清的債務</p>
           ) : (
             <div className="space-y-2.5">
               {debts.map((d, i) => (
@@ -250,44 +266,21 @@ export default function HomePage() {
           )}
         </div>
 
-        {/* 右欄：最近記錄 + 家庭動態並排 */}
-        <div className="space-y-4 md:space-y-6">
+        {/* 右欄：時間軸 tab（記錄 / 動態）(Issue #222) */}
         <div className="card p-5 md:p-6 space-y-3 animate-fade-up stagger-3">
-          <div className="flex items-center gap-2 font-semibold">📝 最近記錄</div>
-          {recent.length === 0 ? (
-            <div className="text-center py-6">
-              <div className="text-3xl mb-2">📭</div>
-              <p className="text-[var(--muted-foreground)]">還沒有任何記錄，點左下「記帳」開始！</p>
-            </div>
+          <SimpleTabs
+            tabs={[
+              { key: 'expenses', label: '📝 最近記錄' },
+              { key: 'activity', label: '📣 家庭動態' },
+            ] as const}
+            active={timelineTab}
+            onChange={setTimelineTab}
+          />
+          {timelineTab === 'expenses' ? (
+            <RecentExpensesList expenses={recent} />
           ) : (
-            <div className="space-y-1">
-              {recent.map((e) => (
-                <div key={e.id} className="group flex items-center gap-3 py-2 rounded-lg hover:bg-[var(--muted)] px-2 -mx-2 transition-colors">
-                  <div className="w-9 h-9 rounded-lg flex items-center justify-center text-lg flex-shrink-0" style={{ backgroundColor: 'color-mix(in oklch, var(--primary), transparent 85%)' }}>
-                    {e.isShared ? '👥' : '👤'}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium text-sm truncate">{e.description}</div>
-                    <div className="text-xs text-[var(--muted-foreground)]">
-                      {fmtDate(toDate(e.date))} · {e.category} · {e.payerName}付
-                    </div>
-                  </div>
-                  <div className="font-semibold text-sm">{currency(e.amount)}</div>
-                  <button
-                    onClick={() => router.push(`/expense/new?duplicate=${e.id}`)}
-                    title="複製此筆"
-                    className="md:opacity-0 md:group-hover:opacity-100 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-opacity text-xs flex-shrink-0"
-                  >
-                    📋
-                  </button>
-                </div>
-              ))}
-            </div>
+            <RecentActivitySection noCard />
           )}
-        </div>
-
-        {/* 家庭動態 — 右欄最近記錄之下 */}
-        <RecentActivitySection />
         </div>
 
       </div>

--- a/src/components/recent-activity-section.tsx
+++ b/src/components/recent-activity-section.tsx
@@ -8,6 +8,11 @@ import { getActivityIcon, formatRelativeTime } from '@/lib/activity-format'
 
 const RECENT_LIMIT = 6
 
+interface RecentActivitySectionProps {
+  /** Skip card wrapper + header when embedded (e.g. inside RecentTimelineTabs). */
+  noCard?: boolean
+}
+
 /**
  * Home-page feed of the group's most recent activity log entries.
  * Complements "最近記錄" (personal expense stream) with the group-level
@@ -15,7 +20,7 @@ const RECENT_LIMIT = 6
  * own actions never appear in their own notifications page — actions all
  * appear here regardless of actor. Issue #201.
  */
-export function RecentActivitySection() {
+export function RecentActivitySection({ noCard }: RecentActivitySectionProps = {}) {
   const { group } = useGroup()
   const { logs, loading } = useActivityLog(group?.id, RECENT_LIMIT)
   // `now` is held in state so relative labels re-render each minute without
@@ -28,17 +33,19 @@ export function RecentActivitySection() {
 
   if (!group) return null
 
-  return (
-    <div className="card p-5 md:p-6 space-y-3 animate-fade-up stagger-3">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 font-semibold">📣 家庭動態</div>
-        <Link
-          href="/settings/activity-log"
-          className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
-        >
-          查看全部 →
-        </Link>
-      </div>
+  const body = (
+    <>
+      {!noCard && (
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 font-semibold">📣 家庭動態</div>
+          <Link
+            href="/settings/activity-log"
+            className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+          >
+            查看全部 →
+          </Link>
+        </div>
+      )}
 
       {loading ? (
         <div className="text-center py-6 text-sm text-[var(--muted-foreground)]">
@@ -72,6 +79,10 @@ export function RecentActivitySection() {
           ))}
         </div>
       )}
-    </div>
+    </>
+  )
+
+  return noCard ? <div className="space-y-3">{body}</div> : (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up stagger-3">{body}</div>
   )
 }

--- a/src/components/recent-expenses-list.tsx
+++ b/src/components/recent-expenses-list.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { currency, toDate, fmtDate } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface RecentExpensesListProps {
+  expenses: Expense[]
+}
+
+/**
+ * Home-page list of the user's most recent expenses. Extracted from the
+ * previously inline JSX in the home page so it can be embedded inside the
+ * RecentTimelineTabs card (Issue #222).
+ */
+export function RecentExpensesList({ expenses }: RecentExpensesListProps) {
+  const router = useRouter()
+
+  if (expenses.length === 0) {
+    return (
+      <div className="text-center py-6">
+        <div className="text-3xl mb-2">📭</div>
+        <p className="text-[var(--muted-foreground)] text-sm">還沒有任何記錄，點下方「記帳」開始！</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-1">
+      {expenses.map((e) => (
+        <div
+          key={e.id}
+          className="group flex items-center gap-3 py-2 rounded-lg hover:bg-[var(--muted)] px-2 -mx-2 transition-colors"
+        >
+          <div
+            className="w-9 h-9 rounded-lg flex items-center justify-center text-lg flex-shrink-0"
+            style={{ backgroundColor: 'color-mix(in oklch, var(--primary), transparent 85%)' }}
+          >
+            {e.isShared ? '👥' : '👤'}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="font-medium text-sm truncate">{e.description}</div>
+            <div className="text-xs text-[var(--muted-foreground)]">
+              {fmtDate(toDate(e.date))} · {e.category} · {e.payerName}付
+            </div>
+          </div>
+          <div className="font-semibold text-sm">{currency(e.amount)}</div>
+          <button
+            onClick={() => router.push(`/expense/new?duplicate=${e.id}`)}
+            title="複製此筆"
+            aria-label="複製此筆"
+            className="md:opacity-0 md:group-hover:opacity-100 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-opacity text-xs flex-shrink-0"
+          >
+            📋
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/simple-tabs.tsx
+++ b/src/components/simple-tabs.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+interface SimpleTab<K extends string> {
+  key: K
+  label: string
+}
+
+interface SimpleTabsProps<K extends string> {
+  tabs: readonly SimpleTab<K>[]
+  active: K
+  onChange: (_next: K) => void
+  className?: string
+  /** Optional right-aligned slot for actions (links, badges, etc.). */
+  rightSlot?: React.ReactNode
+}
+
+/**
+ * Lightweight horizontal tab bar — one underline-style segmented control
+ * used for "今日 / 本週" and "記錄 / 動態" on the home page (Issue #222).
+ * Keeps the same visual language as the existing pill toggles on /records.
+ */
+export function SimpleTabs<K extends string>({
+  tabs,
+  active,
+  onChange,
+  className,
+  rightSlot,
+}: SimpleTabsProps<K>) {
+  return (
+    <div className={`flex items-center justify-between ${className ?? ''}`}>
+      <div className="flex gap-1 rounded-lg bg-[var(--muted)] p-1" role="tablist">
+        {tabs.map((t) => {
+          const selected = active === t.key
+          return (
+            <button
+              key={t.key}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              onClick={() => onChange(t.key)}
+              className={`px-3 py-1 rounded-md text-xs font-medium transition ${
+                selected
+                  ? 'bg-[var(--card)] text-[var(--foreground)] shadow-sm'
+                  : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)]'
+              }`}
+            >
+              {t.label}
+            </button>
+          )
+        })}
+      </div>
+      {rightSlot}
+    </div>
+  )
+}

--- a/src/components/today-summary.tsx
+++ b/src/components/today-summary.tsx
@@ -8,9 +8,11 @@ import type { Expense } from '@/lib/types'
 interface TodaySummaryProps {
   expenses: Expense[]
   loading?: boolean
+  /** Skip the outer card wrapper when embedded inside another card (e.g. SummaryTabs). */
+  noCard?: boolean
 }
 
-export function TodaySummary({ expenses, loading }: TodaySummaryProps) {
+export function TodaySummary({ expenses, loading, noCard }: TodaySummaryProps) {
   const todayExpenses = useMemo(() => getTodayExpenses(expenses), [expenses])
   const thisWeek = useMemo(() => getWeekExpenses(expenses, 0), [expenses])
   const lastWeekSameRange = useMemo(() => getWeekExpenses(expenses, -1), [expenses])
@@ -54,16 +56,17 @@ export function TodaySummary({ expenses, loading }: TodaySummaryProps) {
   const weekDiff = lastWeekTotal > 0 ? Math.round(((weekTotal - lastWeekTotal) / lastWeekTotal) * 100) : null
 
   if (loading) {
-    return (
-      <div className="card p-5 animate-pulse">
+    const loadingSkeleton = (
+      <div className="animate-pulse">
         <div className="h-4 bg-[var(--muted)] rounded w-24 mb-3" />
         <div className="h-8 bg-[var(--muted)] rounded w-32" />
       </div>
     )
+    return noCard ? loadingSkeleton : <div className="card p-5">{loadingSkeleton}</div>
   }
 
-  return (
-    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+  const content = (
+    <div className="space-y-3">
       <div className="grid grid-cols-3 gap-4">
         {/* 今日支出 */}
         <div className="text-center">
@@ -113,5 +116,9 @@ export function TodaySummary({ expenses, loading }: TodaySummaryProps) {
         </div>
       )}
     </div>
+  )
+
+  return noCard ? content : (
+    <div className="card p-5 md:p-6 animate-fade-up">{content}</div>
   )
 }

--- a/src/components/weekly-digest.tsx
+++ b/src/components/weekly-digest.tsx
@@ -17,9 +17,11 @@ const STORAGE_KEY = 'weekly-digest-dismissed'
 
 interface WeeklyDigestProps {
   expenses: Expense[]
+  /** Skip card wrapper + dismiss button when embedded (e.g. inside SummaryTabs). */
+  noCard?: boolean
 }
 
-export function WeeklyDigest({ expenses }: WeeklyDigestProps) {
+export function WeeklyDigest({ expenses, noCard }: WeeklyDigestProps) {
   const weekId = getISOWeekId()
   const [dismissed, setDismissed] = useState(() => {
     if (typeof window === 'undefined') return true
@@ -57,22 +59,36 @@ export function WeeklyDigest({ expenses }: WeeklyDigestProps) {
     setDismissed(true)
   }
 
-  // Don't show if dismissed, or if no data from last week
-  if (dismissed || lastWeek.length === 0) return null
+  // When embedded (noCard), the dismiss workflow no longer makes sense — the
+  // parent owns visibility via tabs. Skip the localStorage gate in that case.
+  if (!noCard && dismissed) return null
+  if (lastWeek.length === 0) {
+    if (noCard) {
+      return (
+        <div className="text-center py-6">
+          <div className="text-3xl mb-2 opacity-50">📭</div>
+          <p className="text-sm text-[var(--muted-foreground)]">上週還沒有記錄</p>
+        </div>
+      )
+    }
+    return null
+  }
 
   const diff = lastWeekTotal > 0 ? Math.round(((thisWeekTotal - lastWeekTotal) / lastWeekTotal) * 100) : null
 
-  return (
-    <div className="card p-5 space-y-3 animate-fade-up border-l-4 border-l-[var(--primary)]">
-      <div className="flex items-center justify-between">
-        <div className="font-semibold text-sm">📅 上週回顧</div>
-        <button
-          onClick={handleDismiss}
-          className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
-        >
-          知道了
-        </button>
-      </div>
+  const content = (
+    <div className="space-y-3">
+      {!noCard && (
+        <div className="flex items-center justify-between">
+          <div className="font-semibold text-sm">📅 上週回顧</div>
+          <button
+            onClick={handleDismiss}
+            className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+          >
+            知道了
+          </button>
+        </div>
+      )}
 
       <div className="flex items-baseline gap-2">
         <div className="text-2xl font-black" style={{ color: 'var(--primary)' }}>
@@ -127,5 +143,9 @@ export function WeeklyDigest({ expenses }: WeeklyDigestProps) {
         </div>
       )}
     </div>
+  )
+
+  return noCard ? content : (
+    <div className="card p-5 animate-fade-up border-l-4 border-l-[var(--primary)]">{content}</div>
   )
 }


### PR DESCRIPTION
## Summary
依 Issue #222 把首頁從 8 個垂直 section 收斂為 tab 版 layout：

1. **☀️ 今日 / 本週 vs 📅 上週回顧** — 合併為單一 tab 卡片
2. **📝 最近記錄 vs 📣 家庭動態** — 合併為單一 tab 卡片
3. **💰 誰欠誰** 空狀態從 🎉 大卡片（6 行）→ 單行文字

## Why
手機版原本要滑很久才到「誰欠誰」；「最近記錄」與「家庭動態」語意重疊；
WeeklyDigest 與 TodaySummary 都在講週/日數據，堆疊讓資訊密度拉高。
Tab 化後：同樣資訊、更少垂直空間、切換仍一鍵可達。

## Architecture decision
- 兩個 tab state 管在 home page local，未做 wrapper component — 為避免多
  餘的 state-prop plumbing。組合內容就是一個 conditional render。
- 既有 TodaySummary / WeeklyDigest / RecentActivitySection 加 \`noCard\`
  prop，embedded in tab card 時跳過自己的 card 外框與重複標題；保留對外
  API 完全向後相容（未改 call site 的現有使用者）。
- WeeklyDigest \`noCard\` 時跳過 \`localStorage dismiss\` 邏輯——parent
  tab 已負責可見性。
- 新 \`SimpleTabs\` 元件沿用既有 \`/records\` 的 pill-toggle 視覺語言。

## Changes
- **New**: \`src/components/simple-tabs.tsx\`, \`src/components/recent-expenses-list.tsx\`
- **Modified**: \`today-summary.tsx\`, \`weekly-digest.tsx\`, \`recent-activity-section.tsx\` (加 noCard prop)
- **Home page**: \`src/app/(auth)/page.tsx\` layout 重構（仍用既有 hooks，data layer 不動）

## Test plan
- [x] 858 既有 tests 全過（無 regression）
- [x] \`tsc --noEmit\` 乾淨
- [x] eslint 乾淨
- [ ] 未加 unit test：本 PR 全是 UI composition，無新增純邏輯可以單獨測。
  會於 deploy 後手動驗證以下 state × 資料組合：
  - Today tab / Week tab 切換，loading / 有資料 / 空資料
  - Expenses tab / Activity tab 切換，有資料 / 空資料
  - 誰欠誰 = 0 單行顯示
  - 桌面 2 欄 layout 不破
- [x] WeeklyDigest dismiss 行為：當 embedded 時 parent 控制可見性，不再
  使用 localStorage gate（避免 tab 切回永遠 blank 的 bug）

## Risk
最大 risk：RecentActivitySection 的 realtime subscription 順序。但 hook
邏輯未改，僅外層 wrapper 切換可見，behavior 等價。已 type-check + full
jest pass。

Closes #222