### PR TITLE
feat(expense): 重複支出偵測擴展到個人 (Closes #227)

### DIFF
--- a/__tests__/duplicate-expense-detector.test.ts
+++ b/__tests__/duplicate-expense-detector.test.ts
@@ -1,6 +1,7 @@
 import {
   findPossibleDuplicate,
   DEFAULT_WINDOW_MINUTES,
+  DEFAULT_SELF_WINDOW_MINUTES,
   type DuplicateCandidate,
   type RecentExpenseLike,
 } from '@/lib/duplicate-expense-detector'
@@ -142,5 +143,113 @@ describe('findPossibleDuplicate', () => {
 
   it('empty candidate description short-circuits to null', () => {
     expect(findPossibleDuplicate(cand('', 1200), [rec('e1', '電費', 1200, 1)], NOW)).toBeNull()
+  })
+
+  describe('self-duplicate (Issue #227)', () => {
+    function selfRec(id: string, minutesAgo: number, ownerUid: string): RecentExpenseLike {
+      return {
+        id,
+        description: '便利商店',
+        amount: 79,
+        payerName: '我',
+        createdBy: ownerUid,
+        createdAt: new Date(NOW - minutesAgo * MIN),
+      }
+    }
+
+    it('matches own record at 30 min ago when selfUserId is provided (60-min window)', () => {
+      const recent = [selfRec('s1', 30, 'user-me')]
+      const hit = findPossibleDuplicate(
+        { description: '便利商店', amount: 79, selfUserId: 'user-me' },
+        recent,
+        NOW,
+      )
+      expect(hit?.id).toBe('s1')
+    })
+
+    it('does NOT match own record at 30 min ago when selfUserId is NOT provided (prior behaviour, 5-min window)', () => {
+      const recent = [selfRec('s1', 30, 'user-me')]
+      const hit = findPossibleDuplicate({ description: '便利商店', amount: 79 }, recent, NOW)
+      expect(hit).toBeNull()
+    })
+
+    it('keeps "other" matches at the normal 5-min window even when selfUserId provided', () => {
+      // Partner recorded 10 min ago — outside 5-min window, so still no hit.
+      const recent = [
+        { ...selfRec('o1', 10, 'user-partner'), createdBy: 'user-partner' },
+      ]
+      const hit = findPossibleDuplicate(
+        { description: '便利商店', amount: 79, selfUserId: 'user-me' },
+        recent,
+        NOW,
+      )
+      expect(hit).toBeNull()
+    })
+
+    it('accepts self record at exactly the self-window boundary', () => {
+      const recent = [selfRec('s1', DEFAULT_SELF_WINDOW_MINUTES, 'user-me')]
+      const hit = findPossibleDuplicate(
+        { description: '便利商店', amount: 79, selfUserId: 'user-me' },
+        recent,
+        NOW,
+      )
+      expect(hit?.id).toBe('s1')
+    })
+
+    it('rejects self record beyond self-window', () => {
+      const recent = [selfRec('s1', DEFAULT_SELF_WINDOW_MINUTES + 1, 'user-me')]
+      const hit = findPossibleDuplicate(
+        { description: '便利商店', amount: 79, selfUserId: 'user-me' },
+        recent,
+        NOW,
+      )
+      expect(hit).toBeNull()
+    })
+
+    it('respects custom selfWindowMinutes', () => {
+      const recent = [selfRec('s1', 20, 'user-me')]
+      // Override to 15 min → 20min-ago record rejected
+      const hit1 = findPossibleDuplicate(
+        { description: '便利商店', amount: 79, selfUserId: 'user-me' },
+        recent,
+        NOW,
+        { selfWindowMinutes: 15 },
+      )
+      expect(hit1).toBeNull()
+      // Override to 30 min → 20min-ago record accepted
+      const hit2 = findPossibleDuplicate(
+        { description: '便利商店', amount: 79, selfUserId: 'user-me' },
+        recent,
+        NOW,
+        { selfWindowMinutes: 30 },
+      )
+      expect(hit2?.id).toBe('s1')
+    })
+
+    it('records without createdBy fall back to "other" window classification', () => {
+      // No createdBy means we can't confirm self-match → treat as other (5-min window)
+      const rec30 = { ...selfRec('s1', 30, 'user-me') }
+      delete (rec30 as Partial<RecentExpenseLike>).createdBy
+      const hit = findPossibleDuplicate(
+        { description: '便利商店', amount: 79, selfUserId: 'user-me' },
+        [rec30],
+        NOW,
+      )
+      expect(hit).toBeNull()
+    })
+
+    it('prefers the newest self match when multiple exist', () => {
+      const recent = [
+        selfRec('old', 50, 'user-me'),
+        selfRec('new', 10, 'user-me'),
+        selfRec('mid', 30, 'user-me'),
+      ]
+      const hit = findPossibleDuplicate(
+        { description: '便利商店', amount: 79, selfUserId: 'user-me' },
+        recent,
+        NOW,
+      )
+      expect(hit?.id).toBe('new')
+    })
   })
 })

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -380,6 +380,9 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         // Exclude both edit-target and duplicate-source so the banner doesn't
         // point at "this very record" in either flow.
         isEditingId: existingExpense?.id ?? duplicateFrom?.id,
+        // Enable self-duplicate detection (Issue #227). When the same user
+        // just recorded the same description+amount, warn — 60 min window.
+        selfUserId: user?.uid,
       },
       expenses.map((e) => ({
         id: e.id,
@@ -387,10 +390,11 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         amount: e.amount,
         payerName: e.payerName,
         createdAt: e.createdAt,
+        createdBy: e.createdBy,
       })),
       nowTick,
     )
-  }, [description, amount, expenses, existingExpense?.id, duplicateFrom?.id, nowTick])
+  }, [description, amount, expenses, existingExpense?.id, duplicateFrom?.id, nowTick, user?.uid])
   // Key includes amount + trimmed description so a dismiss only sticks for
   // the exact (id, amount, desc) combo — editing description reveals a fresh
   // banner rather than silently staying dismissed.
@@ -685,9 +689,19 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
           <div className="flex-1 min-w-0">
             <div className="font-medium">似乎重複了？</div>
             <div className="text-[var(--muted-foreground)] mt-0.5">
-              <span className="font-medium text-[var(--foreground)]">{possibleDuplicate.payerName}</span> 剛剛記了
-              <span className="font-medium text-[var(--foreground)]"> 「{possibleDuplicate.description}」</span>
-              （NT$ {possibleDuplicate.amount.toLocaleString()}），確定要再記一筆？
+              {possibleDuplicate.createdBy && possibleDuplicate.createdBy === user?.uid ? (
+                <>
+                  你先前已記過
+                  <span className="font-medium text-[var(--foreground)]"> 「{possibleDuplicate.description}」</span>
+                  （NT$ {possibleDuplicate.amount.toLocaleString()}），確定要再記一筆？
+                </>
+              ) : (
+                <>
+                  <span className="font-medium text-[var(--foreground)]">{possibleDuplicate.payerName}</span> 剛剛記了
+                  <span className="font-medium text-[var(--foreground)]"> 「{possibleDuplicate.description}」</span>
+                  （NT$ {possibleDuplicate.amount.toLocaleString()}），確定要再記一筆？
+                </>
+              )}
             </div>
           </div>
           <button

--- a/src/lib/duplicate-expense-detector.ts
+++ b/src/lib/duplicate-expense-detector.ts
@@ -10,6 +10,7 @@
  */
 
 export const DEFAULT_WINDOW_MINUTES = 5
+export const DEFAULT_SELF_WINDOW_MINUTES = 60
 // Descriptions of 1 character match too eagerly (e.g. "x") — require at
 // least MIN_DESCRIPTION_LENGTH chars of signal.
 const MIN_DESCRIPTION_LENGTH = 2
@@ -19,6 +20,13 @@ export interface DuplicateCandidate {
   amount: number
   /** When editing an existing expense, pass its id so it's not a self-match. */
   isEditingId?: string
+  /**
+   * Current user's uid. When provided AND a candidate's `createdBy` matches,
+   * the detector widens the time window from `windowMinutes` to
+   * `selfWindowMinutes` (Issue #227). If omitted, only "other" matches fire
+   * (prior behaviour).
+   */
+  selfUserId?: string
 }
 
 export interface RecentExpenseLike {
@@ -28,10 +36,16 @@ export interface RecentExpenseLike {
   payerName: string
   /** Firestore Timestamp or Date — coerceDate handles the duck type. */
   createdAt: unknown
+  /** Optional: the uid of the user who created the record. Used to widen the
+   * match window for self-duplicates (Issue #227). */
+  createdBy?: string
 }
 
 interface Options {
+  /** Time window (minutes) for matches against OTHER members' records. Default 5. */
   windowMinutes?: number
+  /** Time window (minutes) for matches against the current user's OWN records. Default 60. */
+  selfWindowMinutes?: number
 }
 
 function coerceDate(d: unknown): Date | null {
@@ -70,11 +84,12 @@ export function findPossibleDuplicate(
   now: number,
   opts: Options = {},
 ): RecentExpenseLike | null {
-  const { description, amount, isEditingId } = candidate
+  const { description, amount, isEditingId, selfUserId } = candidate
   if (!description || !description.trim()) return null
   if (!amount || amount <= 0) return null
 
-  const window = (opts.windowMinutes ?? DEFAULT_WINDOW_MINUTES) * 60_000
+  const otherWindow = (opts.windowMinutes ?? DEFAULT_WINDOW_MINUTES) * 60_000
+  const selfWindow = (opts.selfWindowMinutes ?? DEFAULT_SELF_WINDOW_MINUTES) * 60_000
 
   let best: { record: RecentExpenseLike; at: number } | null = null
   for (const r of recent) {
@@ -84,6 +99,8 @@ export function findPossibleDuplicate(
     const d = coerceDate(r.createdAt)
     if (!d) continue
     const at = d.getTime()
+    const isSelf = !!selfUserId && r.createdBy === selfUserId
+    const window = isSelf ? selfWindow : otherWindow
     if (now - at > window) continue
     if (!best || at > best.at) best = { record: r, at }
   }


### PR DESCRIPTION
## Summary
- 同一使用者 60 分鐘內記了同款 → 警告「你先前已記過…」
- 他人 5 分鐘內記同款的原行為維持不變
- Backward compat：未傳 selfUserId 時退回舊行為

## Why
#211 做的重複偵測只管「家人剛剛記同款」。但同一個人自己也會重複（網路延遲重送、便利商店 30 分鐘後忘了記再記一次）。此 PR 補上 self check，時間窗放寬到 60 分鐘以容忍延遲發現。

## Changes
- \`src/lib/duplicate-expense-detector.ts\` — 加 \`selfUserId\` / \`selfWindowMinutes\` / \`createdBy\`
- \`src/components/expense-form.tsx\` — 傳 user.uid + e.createdBy，警告文案依 self/other 切換
- \`__tests__/duplicate-expense-detector.test.ts\` — 新 8 cases

## Test plan
- [x] 27 cases pass（19 既有 + 8 新增）
- [x] typecheck 乾淨
- [x] eslint 乾淨（pre-existing unrelated warning unchanged）
- [ ] 部署後手動驗證：
  - 自己 30 min 前記的便利商店 79 元，再打同描述同金額 → 警告「你先前已記過」
  - 他人 3 分鐘前記的 1200 電費，自己要記 → 警告「X 剛剛記了」
  - 自己 2 小時前記的不警告

Closes #227