### PR TITLE
feat(quick-add): 🎤 語音記帳 (Closes #229)

### DIFF
--- a/__tests__/use-speech-recognition.test.ts
+++ b/__tests__/use-speech-recognition.test.ts
@@ -1,0 +1,52 @@
+import {
+  isSpeechRecognitionSupported,
+  mapSpeechError,
+} from '@/hooks/use-speech-recognition'
+
+describe('isSpeechRecognitionSupported', () => {
+  const originalWindow = globalThis.window
+
+  afterEach(() => {
+    // @ts-expect-error restore original window after test
+    globalThis.window = originalWindow
+  })
+
+  it('returns false when window is undefined (SSR)', () => {
+    // @ts-expect-error simulate SSR by removing window
+    delete globalThis.window
+    expect(isSpeechRecognitionSupported()).toBe(false)
+  })
+
+  it('returns true when SpeechRecognition is on window', () => {
+    // @ts-expect-error assigning mock window for feature-detection test
+    globalThis.window = { SpeechRecognition: function () {} }
+    expect(isSpeechRecognitionSupported()).toBe(true)
+  })
+
+  it('returns true when only webkitSpeechRecognition is on window', () => {
+    // @ts-expect-error assigning mock window with vendor-prefixed API
+    globalThis.window = { webkitSpeechRecognition: function () {} }
+    expect(isSpeechRecognitionSupported()).toBe(true)
+  })
+
+  it('returns false when neither constructor is present', () => {
+    // @ts-expect-error assigning empty window to assert neither API present
+    globalThis.window = {}
+    expect(isSpeechRecognitionSupported()).toBe(false)
+  })
+})
+
+describe('mapSpeechError', () => {
+  it.each([
+    ['not-allowed', 'permission_denied'],
+    ['service-not-allowed', 'permission_denied'],
+    ['no-speech', 'no_speech'],
+    ['network', 'network'],
+    ['aborted', 'aborted'],
+    ['unknown-err', 'other'],
+    ['', 'other'],
+    ['something-else', 'other'],
+  ])('maps "%s" to "%s"', (raw, expected) => {
+    expect(mapSpeechError(raw)).toBe(expected)
+  })
+})

--- a/src/components/quick-add-bar.tsx
+++ b/src/components/quick-add-bar.tsx
@@ -17,7 +17,25 @@ import { buildDraftKey, parseDraft, serializeDraft } from '@/lib/quick-add-draft
 import { buildDuplicateHref } from '@/lib/quick-add-duplicate'
 import { evaluateAmountExpression } from '@/lib/amount-expression'
 import { AmountChips } from '@/components/amount-chips'
+import { useSpeechRecognition, type SpeechErrorCode } from '@/hooks/use-speech-recognition'
 import { logger } from '@/lib/logger'
+
+function speechErrorMessage(code: SpeechErrorCode): string {
+  switch (code) {
+    case 'permission_denied':
+      return '麥克風權限被拒，請到瀏覽器設定允許'
+    case 'no_speech':
+      return '沒聽到任何語音，請再試一次'
+    case 'network':
+      return '語音辨識網路錯誤'
+    case 'aborted':
+      return '' // user cancelled, no toast
+    case 'not_supported':
+      return '此瀏覽器不支援語音辨識'
+    default:
+      return '語音辨識失敗，請改用打字'
+  }
+}
 
 export function QuickAddBar() {
   const { group } = useGroup()
@@ -37,6 +55,28 @@ export function QuickAddBar() {
   const [category, setCategory] = useState('')
   const [autoFilled, setAutoFilled] = useState(false)
   const { inFlight: saving, run: runSubmit } = useSubmitGuard()
+
+  // Voice input (Issue #229). Feature-detected; button hidden on Firefox etc.
+  const speech = useSpeechRecognition('zh-TW')
+  useEffect(() => {
+    if (!speech.transcript) return
+    try {
+      const parsed = parseExpense(speech.transcript)
+      setDescription(parsed.description || speech.transcript)
+      if (parsed.amount > 0) setAmount(String(parsed.amount))
+      if (parsed.category && parsed.category !== '其他') setCategory(parsed.category)
+      setExpanded(true)
+      speech.reset()
+    } catch (e) {
+      logger.error('[QuickAdd] voice parse failed', e)
+    }
+  }, [speech.transcript, speech])
+  useEffect(() => {
+    if (!speech.error) return
+    const msg = speechErrorMessage(speech.error)
+    if (msg) addToast(msg, 'warning')
+    speech.reset()
+  }, [speech.error, speech, addToast])
 
   const activeCategories = useMemo(
     () => categories.filter((c) => c.isActive).map((c) => c.name).slice(0, 6),
@@ -237,6 +277,22 @@ export function QuickAddBar() {
             <span>快速記帳...</span>
           </span>
         </button>
+        {speech.supported && (
+          <button
+            type="button"
+            onClick={() => (speech.listening ? speech.stop() : speech.start())}
+            aria-label={speech.listening ? '停止錄音' : '語音記帳'}
+            title={speech.listening ? '聽取中… 點擊停止' : '語音記帳'}
+            aria-pressed={speech.listening}
+            className={`card px-4 flex items-center justify-center text-lg transition-colors whitespace-nowrap ${
+              speech.listening
+                ? 'bg-[var(--primary)] text-white border-[var(--primary)] animate-pulse'
+                : 'text-[var(--muted-foreground)] hover:border-[var(--primary)] hover:text-[var(--foreground)]'
+            }`}
+          >
+            🎤
+          </button>
+        )}
         {duplicateHref ? (
           <Link
             href={duplicateHref}

--- a/src/hooks/use-speech-recognition.ts
+++ b/src/hooks/use-speech-recognition.ts
@@ -1,0 +1,134 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Web Speech API wrapper for voice-to-text in Traditional Chinese (Issue #229).
+ *
+ * Feature detects `SpeechRecognition` / `webkitSpeechRecognition` and exposes
+ * a stable hook API. Browsers without support (Firefox desktop, very old Safari)
+ * get `supported: false` and the UI hides the button.
+ *
+ * Not typed against the TS DOM lib because the underlying interface is still
+ * vendor-prefixed in Chrome/Safari; we model only the subset we use.
+ */
+
+export type SpeechErrorCode =
+  | 'not_supported'
+  | 'permission_denied'
+  | 'no_speech'
+  | 'network'
+  | 'aborted'
+  | 'other'
+
+export interface UseSpeechRecognitionState {
+  supported: boolean
+  listening: boolean
+  error: SpeechErrorCode | null
+  transcript: string
+  start: () => void
+  stop: () => void
+  reset: () => void
+}
+
+interface MinimalRecognition {
+  lang: string
+  continuous: boolean
+  interimResults: boolean
+  start(): void
+  stop(): void
+  abort(): void
+  onresult: ((_event: { results: ArrayLike<{ 0: { transcript: string }; isFinal: boolean }> }) => void) | null
+  onerror: ((_event: { error: string }) => void) | null
+  onend: (() => void) | null
+}
+
+export function isSpeechRecognitionSupported(): boolean {
+  if (typeof window === 'undefined') return false
+  const w = window as unknown as Record<string, unknown>
+  return 'SpeechRecognition' in w || 'webkitSpeechRecognition' in w
+}
+
+export function mapSpeechError(raw: string): SpeechErrorCode {
+  switch (raw) {
+    case 'not-allowed':
+    case 'service-not-allowed':
+      return 'permission_denied'
+    case 'no-speech':
+      return 'no_speech'
+    case 'network':
+      return 'network'
+    case 'aborted':
+      return 'aborted'
+    default:
+      return 'other'
+  }
+}
+
+export function useSpeechRecognition(lang = 'zh-TW'): UseSpeechRecognitionState {
+  const [supported, setSupported] = useState(false)
+  const [listening, setListening] = useState(false)
+  const [error, setError] = useState<SpeechErrorCode | null>(null)
+  const [transcript, setTranscript] = useState('')
+  const recognitionRef = useRef<MinimalRecognition | null>(null)
+
+  useEffect(() => {
+    setSupported(isSpeechRecognitionSupported())
+  }, [])
+
+  const start = useCallback(() => {
+    if (typeof window === 'undefined') return
+    const w = window as unknown as Record<string, unknown>
+    const Ctor =
+      (w.SpeechRecognition as (new () => MinimalRecognition) | undefined) ??
+      (w.webkitSpeechRecognition as (new () => MinimalRecognition) | undefined)
+    if (!Ctor) {
+      setError('not_supported')
+      return
+    }
+    try {
+      const rec = new Ctor()
+      rec.lang = lang
+      rec.continuous = false
+      rec.interimResults = false
+      rec.onresult = (event) => {
+        const first = event.results[0]
+        if (first && first[0]) setTranscript(first[0].transcript)
+      }
+      rec.onerror = (event) => {
+        setError(mapSpeechError(event.error))
+        setListening(false)
+      }
+      rec.onend = () => {
+        setListening(false)
+      }
+      recognitionRef.current = rec
+      setError(null)
+      setTranscript('')
+      setListening(true)
+      rec.start()
+    } catch {
+      setError('other')
+      setListening(false)
+    }
+  }, [lang])
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop()
+  }, [])
+
+  const reset = useCallback(() => {
+    setTranscript('')
+    setError(null)
+  }, [])
+
+  // Abort any in-flight recognition when the component unmounts so the
+  // browser doesn't keep the mic indicator on screen after navigation.
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort()
+    }
+  }, [])
+
+  return { supported, listening, error, transcript, start, stop, reset }
+}


### PR DESCRIPTION
## Summary
- QuickAddBar collapsed 狀態加 🎤 按鈕
- Web Speech API (zh-TW) → parseExpense → 自動填欄位 + 展開 bar
- Feature-detect hidden on Firefox/舊 Safari

## Implementation
- New hook \`src/hooks/use-speech-recognition.ts\` — minimal typed wrapper 不依賴 TS DOM lib 的 vendor-prefixed types
- Button 狀態：idle → listening (primary + pulse) → transcript 到達就 reset
- 錯誤分類 toast：permission_denied / no_speech / network（aborted 不顯示）

## Security
不送雲端 ASR，僅用瀏覽器內建 Web Speech API。permission 由瀏覽器管理。

## Test plan
- [x] 12 unit tests (isSpeechRecognitionSupported SSR/vendor variants; mapSpeechError 8 codes)
- [x] tsc --noEmit 乾淨
- [x] eslint 乾淨
- [ ] 部署後手動驗證（Chrome mobile / Safari iOS）：
  - 🎤 按鈕出現
  - 允許權限後錄音 → 「午餐 150」→ 欄位填入、bar 展開
  - 拒絕權限 → toast
  - 無語音輸入 → toast

Closes #229