### PR TITLE
feat(records): 列表 inline 編輯金額與類別 (Closes #230)

### DIFF
--- a/__tests__/scale-splits.test.ts
+++ b/__tests__/scale-splits.test.ts
@@ -1,0 +1,167 @@
+import { recomputeSplitsForAmount } from '@/lib/scale-splits'
+import type { SplitDetail } from '@/lib/types'
+
+function split(
+  memberId: string,
+  memberName: string,
+  shareAmount: number,
+  paidAmount: number,
+  isParticipant = true,
+): SplitDetail {
+  return { memberId, memberName, shareAmount, paidAmount, isParticipant }
+}
+
+describe('recomputeSplitsForAmount', () => {
+  describe('non-shared expenses', () => {
+    it('returns splits unchanged (no-op)', () => {
+      const splits = [split('m1', '爸', 100, 100)]
+      const result = recomputeSplitsForAmount(
+        { isShared: false, splitMethod: 'equal', amount: 100, payerId: 'm1', splits },
+        200,
+      )
+      expect(result).toEqual(splits)
+    })
+  })
+
+  describe('newAmount <= 0', () => {
+    it('returns splits unchanged (invalid target)', () => {
+      const splits = [split('m1', '爸', 100, 100)]
+      const result = recomputeSplitsForAmount(
+        { isShared: true, splitMethod: 'equal', amount: 100, payerId: 'm1', splits },
+        0,
+      )
+      expect(result).toEqual(splits)
+    })
+  })
+
+  describe('equal splits', () => {
+    it('rebuilds for 2 participants, exact division', () => {
+      const splits = [
+        split('m1', '爸', 50, 100),
+        split('m2', '媽', 50, 0),
+      ]
+      const result = recomputeSplitsForAmount(
+        { isShared: true, splitMethod: 'equal', amount: 100, payerId: 'm1', splits },
+        200,
+      )
+      expect(result[0]).toMatchObject({ shareAmount: 100, paidAmount: 200 })
+      expect(result[1]).toMatchObject({ shareAmount: 100, paidAmount: 0 })
+      expect(result[0].shareAmount + result[1].shareAmount).toBe(200)
+    })
+
+    it('rebuilds for 3 participants with remainder on LAST', () => {
+      const splits = [
+        split('m1', '爸', 33, 100),
+        split('m2', '媽', 33, 0),
+        split('m3', '子', 34, 0),
+      ]
+      const result = recomputeSplitsForAmount(
+        { isShared: true, splitMethod: 'equal', amount: 100, payerId: 'm1', splits },
+        301,
+      )
+      // 301/3 = 100.33 → rounded 100, remainder 1 to last
+      expect(result[0].shareAmount).toBe(100)
+      expect(result[1].shareAmount).toBe(100)
+      expect(result[2].shareAmount).toBe(101)
+      expect(result.reduce((s, x) => s + x.shareAmount, 0)).toBe(301)
+    })
+
+    it('skips non-participants (zero share, zero paid unless payer)', () => {
+      const splits = [
+        split('m1', '爸', 100, 200, true),
+        split('m2', '媽', 100, 0, true),
+        split('m3', '客', 0, 0, false),
+      ]
+      const result = recomputeSplitsForAmount(
+        { isShared: true, splitMethod: 'equal', amount: 200, payerId: 'm1', splits },
+        300,
+      )
+      expect(result[0]).toMatchObject({ shareAmount: 150, paidAmount: 300 })
+      expect(result[1]).toMatchObject({ shareAmount: 150, paidAmount: 0 })
+      expect(result[2]).toMatchObject({ shareAmount: 0, paidAmount: 0 })
+    })
+  })
+
+  describe('non-equal splits (percentage / custom)', () => {
+    it('scales proportionally; remainder to last participant', () => {
+      // original: 100 payer pays, split 30 / 70
+      const splits = [
+        split('m1', '爸', 30, 100),
+        split('m2', '媽', 70, 0),
+      ]
+      const result = recomputeSplitsForAmount(
+        { isShared: true, splitMethod: 'custom', amount: 100, payerId: 'm1', splits },
+        200,
+      )
+      // ratio 2 → 60/140
+      expect(result[0]).toMatchObject({ shareAmount: 60, paidAmount: 200 })
+      expect(result[1]).toMatchObject({ shareAmount: 140, paidAmount: 0 })
+      expect(result[0].shareAmount + result[1].shareAmount).toBe(200)
+    })
+
+    it('handles rounding remainder (3x scale on 33/33/34 → 100/100/100 = 300)', () => {
+      const splits = [
+        split('m1', '爸', 33, 100),
+        split('m2', '媽', 33, 0),
+        split('m3', '子', 34, 0),
+      ]
+      const result = recomputeSplitsForAmount(
+        { isShared: true, splitMethod: 'percentage', amount: 100, payerId: 'm1', splits },
+        301,
+      )
+      // ratio 3.01; 33*3.01 = 99.33 → 99, 34*3.01 = 102.34 → 102
+      // sum = 99+99+102 = 300; remainder 1 → last becomes 103
+      expect(result.reduce((s, x) => s + x.shareAmount, 0)).toBe(301)
+      expect(result[2].shareAmount).toBeGreaterThan(result[0].shareAmount)
+    })
+
+    it('falls back to equal rebuild when original amount was 0 (degenerate)', () => {
+      const splits = [
+        split('m1', '爸', 0, 0),
+        split('m2', '媽', 0, 0),
+      ]
+      const result = recomputeSplitsForAmount(
+        { isShared: true, splitMethod: 'custom', amount: 0, payerId: 'm1', splits },
+        200,
+      )
+      expect(result[0].shareAmount).toBe(100)
+      expect(result[1].shareAmount).toBe(100)
+    })
+
+    it('weight method also scales proportionally', () => {
+      const splits = [
+        split('m1', '爸', 20, 100),
+        split('m2', '媽', 80, 0),
+      ]
+      const result = recomputeSplitsForAmount(
+        { isShared: true, splitMethod: 'weight', amount: 100, payerId: 'm1', splits },
+        500,
+      )
+      expect(result[0]).toMatchObject({ shareAmount: 100, paidAmount: 500 })
+      expect(result[1]).toMatchObject({ shareAmount: 400, paidAmount: 0 })
+    })
+  })
+
+  describe('sum invariant', () => {
+    it.each([
+      [7, 13],
+      [100, 333],
+      [999, 1],
+      [1, 100000],
+    ])('sum of participant shares equals new amount (%s → %s)', (oldAmt, newAmt) => {
+      const splits = [
+        split('m1', 'a', 0, oldAmt, true),
+        split('m2', 'b', oldAmt, 0, true),
+      ]
+      // set share sum equal to oldAmt (equal split scenario)
+      splits[0].shareAmount = Math.floor(oldAmt / 2)
+      splits[1].shareAmount = oldAmt - splits[0].shareAmount
+      const result = recomputeSplitsForAmount(
+        { isShared: true, splitMethod: 'custom', amount: oldAmt, payerId: 'm1', splits },
+        newAmt,
+      )
+      const sum = result.reduce((s, x) => s + (x.isParticipant ? x.shareAmount : 0), 0)
+      expect(sum).toBe(newAmt)
+    })
+  })
+})

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -14,7 +14,10 @@ import { useGroup } from '@/lib/hooks/use-group'
 import { useExpenses } from '@/lib/hooks/use-expenses'
 import { useMembers } from '@/lib/hooks/use-members'
 import { useCategories } from '@/lib/hooks/use-categories'
-import { deleteExpense, loadMoreExpenses } from '@/lib/services/expense-service'
+import { deleteExpense, updateExpense, loadMoreExpenses } from '@/lib/services/expense-service'
+import { recomputeSplitsForAmount } from '@/lib/scale-splits'
+import { InlineExpenseEditRow } from '@/components/inline-expense-edit-row'
+import { logger } from '@/lib/logger'
 import { currency, toDate, fmtDateFull, paymentLabel } from '@/lib/utils'
 import { useAuth, getActor } from '@/lib/auth'
 import { useGroupData } from '@/lib/group-data-context'
@@ -45,6 +48,36 @@ export default function RecordsPage() {
   const { user } = useAuth()
   const { addToast } = useToast()
   const searchParams = useSearchParams()
+
+  // Inline edit (Issue #230). Only one row editable at a time.
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const activeCategories = useMemo(
+    () => categories.filter((c) => c.isActive).map((c) => c.name),
+    [categories],
+  )
+
+  async function handleInlineSave(expense: Expense, next: { amount: number; category: string }) {
+    if (!group?.id) return
+    const newSplits = recomputeSplitsForAmount(expense, next.amount)
+    try {
+      await updateExpense(
+        group.id,
+        expense.id,
+        {
+          amount: next.amount,
+          category: next.category,
+          splits: newSplits,
+        },
+        getActor(user),
+      )
+      addToast('已更新金額／類別', 'success')
+      setEditingId(null)
+    } catch (e) {
+      logger.error('[Records] Inline save failed', e)
+      addToast('儲存失敗，請重試', 'error')
+      throw e // let InlineExpenseEditRow surface inline error too
+    }
+  }
 
   // Extra expenses loaded via pagination beyond the initial 200
   const [extraExpenses, setExtraExpenses] = useState<Expense[]>([])
@@ -516,7 +549,18 @@ export default function RecordsPage() {
                   <span className="text-xs text-[var(--muted-foreground)]">{currency(dayTotal)}</span>
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                  {items.map((e) => (
+                  {items.map((e) => editingId === e.id ? (
+                    <InlineExpenseEditRow
+                      key={e.id}
+                      expenseId={e.id}
+                      initialAmount={e.amount}
+                      initialCategory={e.category}
+                      availableCategories={activeCategories}
+                      splitIsEqual={!e.isShared || e.splitMethod === 'equal'}
+                      onSave={(next) => handleInlineSave(e, next)}
+                      onCancel={() => setEditingId(null)}
+                    />
+                  ) : (
                     <div key={e.id} className="card p-4 space-y-2 group relative">
                       <div className="flex items-start gap-3">
                         <div
@@ -560,10 +604,18 @@ export default function RecordsPage() {
                         <div className="font-bold text-lg">{currency(e.amount)}</div>
                       </div>
                       <div className="absolute top-3 right-3 flex gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+                        <button
+                          type="button"
+                          onClick={() => setEditingId(e.id)}
+                          className="p-1.5 rounded-md hover:bg-[var(--muted)] text-[var(--muted-foreground)]"
+                          title="快速改金額／類別"
+                        >
+                          ⚡
+                        </button>
                         <Link
                           href={`/expense/${e.id}?groupId=${group?.id}`}
                           className="p-1.5 rounded-md hover:bg-[var(--muted)] text-[var(--muted-foreground)]"
-                          title="編輯"
+                          title="完整編輯"
                         >
                           ✏️
                         </Link>

--- a/src/components/inline-expense-edit-row.tsx
+++ b/src/components/inline-expense-edit-row.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { evaluateAmountExpression } from '@/lib/amount-expression'
+import { AmountChips } from '@/components/amount-chips'
+
+interface InlineExpenseEditRowProps {
+  /** Original expense — used for fallback values and cancel state. */
+  expenseId: string
+  initialAmount: number
+  initialCategory: string
+  availableCategories: readonly string[]
+  /** When non-equal split, UI shows a notice that ratios will be re-scaled. */
+  splitIsEqual: boolean
+  onSave: (_next: { amount: number; category: string }) => Promise<void>
+  onCancel: () => void
+}
+
+/**
+ * Inline amount/category editor used inside the /records list (Issue #230).
+ * Only exposes amount + category — other fields still require the full
+ * /expense/[id] form. Saves via the passed-in onSave callback; surfaces
+ * errors via throw (caller toasts).
+ */
+export function InlineExpenseEditRow({
+  expenseId,
+  initialAmount,
+  initialCategory,
+  availableCategories,
+  splitIsEqual,
+  onSave,
+  onCancel,
+}: InlineExpenseEditRowProps) {
+  const [amount, setAmount] = useState(String(initialAmount))
+  const [category, setCategory] = useState(initialCategory)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [])
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onCancel])
+
+  async function handleSave() {
+    const parsed = evaluateAmountExpression(amount)
+    if (!parsed.ok || parsed.value <= 0) {
+      setError('金額無效')
+      return
+    }
+    const nextCategory = category.trim() || initialCategory
+    if (parsed.value === initialAmount && nextCategory === initialCategory) {
+      onCancel()
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await onSave({ amount: parsed.value, category: nextCategory })
+    } catch {
+      setError('儲存失敗，請重試')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className="card p-4 space-y-3 border-2"
+      style={{ borderColor: 'var(--primary)' }}
+      data-editing-id={expenseId}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="text-xs text-[var(--muted-foreground)]">
+        快速編輯 — 只改金額 / 類別。描述、日期、分攤對象請用完整編輯。
+      </div>
+
+      <div>
+        <label className="text-xs font-medium text-[var(--muted-foreground)] mb-1 block">金額</label>
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-[var(--muted-foreground)]">NT$</span>
+          <input
+            ref={inputRef}
+            type="text"
+            inputMode="decimal"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            onBlur={() => {
+              const r = evaluateAmountExpression(amount)
+              if (r.ok) setAmount(String(r.value))
+            }}
+            placeholder="0 或 700+150"
+            className="w-full h-10 rounded-lg border border-[var(--border)] bg-[var(--background)] pl-12 pr-3 text-sm"
+          />
+        </div>
+        <AmountChips value={amount} onChange={setAmount} className="mt-2" />
+      </div>
+
+      <div>
+        <label className="text-xs font-medium text-[var(--muted-foreground)] mb-1 block">類別</label>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="w-full h-10 px-3 rounded-lg border border-[var(--border)] bg-[var(--background)] text-sm"
+        >
+          {availableCategories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+          {/* If current category isn't in list (e.g. deactivated) keep it selectable */}
+          {!availableCategories.includes(category) && category && (
+            <option value={category}>{category}（已停用）</option>
+          )}
+        </select>
+      </div>
+
+      {!splitIsEqual && (
+        <p className="text-xs text-[var(--muted-foreground)] bg-[var(--muted)] rounded p-2">
+          此筆為 <strong>客製分攤</strong>，金額改變後分攤比例會自動按新金額等比縮放。
+        </p>
+      )}
+
+      {error && <p className="text-xs text-[var(--destructive)]">{error}</p>}
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="flex-1 py-2 rounded-lg text-sm font-semibold btn-primary btn-press disabled:opacity-50"
+        >
+          {saving ? '儲存中…' : '✓ 儲存'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={saving}
+          className="px-4 py-2 rounded-lg text-sm border border-[var(--border)] hover:bg-[var(--muted)]"
+        >
+          ✗ 取消
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/scale-splits.ts
+++ b/src/lib/scale-splits.ts
@@ -1,0 +1,101 @@
+/**
+ * Helpers to recompute splits when only the expense amount (or category)
+ * changes during inline edit (Issue #230).
+ *
+ * Equal splits are rebuilt from participants + new amount using the same
+ * rounding rule as buildEqualSplits (remainder goes to LAST participant).
+ *
+ * Non-equal (percentage / custom / weight) splits are scaled proportionally
+ * by (new / old) and the rounding remainder is similarly absorbed by the
+ * last participant so the sum always equals the new amount exactly.
+ *
+ * Non-shared expenses return splits as-is (no-op).
+ */
+import type { SplitDetail, SplitMethod } from '@/lib/types'
+
+interface ExpenseSliceForSplit {
+  isShared: boolean
+  splitMethod: SplitMethod
+  amount: number
+  payerId: string
+  splits: SplitDetail[]
+}
+
+export function recomputeSplitsForAmount(
+  expense: ExpenseSliceForSplit,
+  newAmount: number,
+): SplitDetail[] {
+  if (!expense.isShared) return expense.splits
+  if (newAmount <= 0) return expense.splits
+
+  if (expense.splitMethod === 'equal') {
+    return rebuildEqualSplits(expense.splits, newAmount, expense.payerId)
+  }
+
+  return scaleSplitsProportionally(expense.splits, expense.amount, newAmount, expense.payerId)
+}
+
+function rebuildEqualSplits(
+  existing: SplitDetail[],
+  newAmount: number,
+  payerId: string,
+): SplitDetail[] {
+  const participants = existing.filter((s) => s.isParticipant)
+  if (participants.length === 0) return existing
+
+  const per = Math.round(newAmount / participants.length)
+  const remainder = newAmount - per * participants.length
+  let participantIdx = 0
+  return existing.map((s) => {
+    if (!s.isParticipant) {
+      return { ...s, shareAmount: 0, paidAmount: s.memberId === payerId ? newAmount : 0 }
+    }
+    const isLastParticipant = participantIdx === participants.length - 1
+    const share = isLastParticipant ? per + remainder : per
+    participantIdx++
+    return {
+      ...s,
+      shareAmount: share,
+      paidAmount: s.memberId === payerId ? newAmount : 0,
+    }
+  })
+}
+
+function scaleSplitsProportionally(
+  existing: SplitDetail[],
+  oldAmount: number,
+  newAmount: number,
+  payerId: string,
+): SplitDetail[] {
+  // Degenerate source: fall back to equal rebuild so we don't produce zeros.
+  if (oldAmount <= 0) {
+    return rebuildEqualSplits(existing, newAmount, payerId)
+  }
+
+  const ratio = newAmount / oldAmount
+  const scaled = existing.map((s) => ({
+    ...s,
+    shareAmount: s.isParticipant ? Math.round(s.shareAmount * ratio) : 0,
+    paidAmount: s.memberId === payerId ? newAmount : 0,
+  }))
+
+  // Make the sum exact — put the remainder on the last participant.
+  const currentSum = scaled.reduce((acc, s) => acc + (s.isParticipant ? s.shareAmount : 0), 0)
+  const remainder = newAmount - currentSum
+  if (remainder !== 0) {
+    let lastParticipantIdx = -1
+    for (let i = scaled.length - 1; i >= 0; i--) {
+      if (scaled[i].isParticipant) {
+        lastParticipantIdx = i
+        break
+      }
+    }
+    if (lastParticipantIdx >= 0) {
+      scaled[lastParticipantIdx] = {
+        ...scaled[lastParticipantIdx],
+        shareAmount: scaled[lastParticipantIdx].shareAmount + remainder,
+      }
+    }
+  }
+  return scaled
+}


### PR DESCRIPTION
## Summary
- Records 卡片右上加 ⚡ 按鈕（原 ✏️ 改文字為「完整編輯」）
- 點擊後整張卡片切換為 inline edit：金額（支援 \`700+150\` 四則運算）+ 類別 dropdown
- ✓ 儲存 / ✗ 取消 / ESC 取消 / onMount autofocus+select
- 儲存時自動 recompute splits 保持 sum 一致

## Why
記錄頁發現打錯金額（100 誤為 1000、類別選錯）要進 \`/expense/[id]\` full form 3-4 個 tap 才能改。最常見錯誤加 1 個按鈕 + 1 個輸入，3 秒內修完。

## Key correctness guarantee
\`recomputeSplitsForAmount\` 確保 \`sum(splits.shareAmount) === newAmount\` 永遠成立，不論：
- equal / percentage / custom / weight
- 7 → 13 的奇怪比例
- 999 → 1 的縮小
- 1 → 100000 的放大
(13 sum-invariant 單元測試覆蓋)

## Changes
- **New**: \`src/lib/scale-splits.ts\` — \`recomputeSplitsForAmount(expense, newAmount)\` pure function
- **New**: \`src/components/inline-expense-edit-row.tsx\` — inline form
- **New**: \`__tests__/scale-splits.test.ts\` — 13 cases
- **Modified**: \`src/app/(auth)/records/page.tsx\` — editingId state + handleInlineSave + ⚡ button

## Test plan
- [x] 891 tests pass（+13 new scale-splits）
- [x] \`tsc --noEmit\` 乾淨
- [x] eslint 乾淨（pre-existing unrelated warning 仍在）
- [ ] 部署後手動驗證：
  - equal split：2 人分攤，50/50 改成 60/60 → 之後 /expense/[id] 看到 splits 正確
  - custom split：30/70 改總額 100→200 → splits 變 60/140
  - 類別改成已 deactivate 的 → dropdown 顯示「（已停用）」
  - ESC 取消、✗ 取消、✓ 儲存三條路徑
  - 四則運算：\`amount+100\` 格式被正確解析

## Non-goals
- 不做 inline 編輯 description / date / payer / paymentMethod — 這些要 full form

Closes #230