### PR TITLE
feat(shortcut): 鍵盤快捷鍵 N/R/S/H/T (Closes #235)

### DIFF
--- a/__tests__/use-keyboard-shortcut.test.ts
+++ b/__tests__/use-keyboard-shortcut.test.ts
@@ -1,0 +1,80 @@
+import { isEditableTarget, shouldIgnoreEvent } from '@/hooks/use-keyboard-shortcut'
+
+// Duck-typed HTMLElement stand-in so tests don't require jsdom.
+class FakeEl {
+  constructor(
+    public tagName: string,
+    public isContentEditable = false,
+  ) {}
+}
+// Make FakeEl satisfy `instanceof HTMLElement` by assigning to the global.
+// The hook tests only rely on the runtime check — this keeps them env-agnostic.
+beforeAll(() => {
+  // @ts-expect-error installing fake HTMLElement global for hook filter tests
+  globalThis.HTMLElement = FakeEl
+})
+
+describe('isEditableTarget', () => {
+  it('returns false for null', () => {
+    expect(isEditableTarget(null)).toBe(false)
+  })
+
+  it.each([
+    ['INPUT', true],
+    ['TEXTAREA', true],
+    ['SELECT', true],
+    ['DIV', false],
+    ['BUTTON', false],
+    ['P', false],
+    ['A', false],
+  ])('returns %s for <%s>', (tag, expected) => {
+    expect(isEditableTarget(new FakeEl(tag) as unknown as HTMLElement)).toBe(expected)
+  })
+
+  it('returns true for contenteditable div', () => {
+    expect(isEditableTarget(new FakeEl('DIV', true) as unknown as HTMLElement)).toBe(true)
+  })
+
+  it('returns false for non-Element-like value', () => {
+    // Plain object isn't instanceof HTMLElement
+    expect(isEditableTarget({ tagName: 'INPUT' } as unknown as EventTarget)).toBe(false)
+  })
+})
+
+describe('shouldIgnoreEvent', () => {
+  function makeEvent(partial: Partial<Parameters<typeof shouldIgnoreEvent>[0]> = {}) {
+    return {
+      target: null,
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      ...partial,
+    }
+  }
+
+  it('ignores when meta key held (reserve Cmd+R etc.)', () => {
+    expect(shouldIgnoreEvent(makeEvent({ metaKey: true }))).toBe(true)
+  })
+
+  it('ignores when ctrl key held', () => {
+    expect(shouldIgnoreEvent(makeEvent({ ctrlKey: true }))).toBe(true)
+  })
+
+  it('ignores when alt key held', () => {
+    expect(shouldIgnoreEvent(makeEvent({ altKey: true }))).toBe(true)
+  })
+
+  it('ignores when focus is in an input', () => {
+    const input = new FakeEl('INPUT') as unknown as HTMLElement
+    expect(shouldIgnoreEvent(makeEvent({ target: input }))).toBe(true)
+  })
+
+  it('does NOT ignore plain key with no target and no modifiers', () => {
+    expect(shouldIgnoreEvent(makeEvent({ target: null }))).toBe(false)
+  })
+
+  it('does NOT ignore plain key on button (not editable)', () => {
+    const btn = new FakeEl('BUTTON') as unknown as HTMLElement
+    expect(shouldIgnoreEvent(makeEvent({ target: btn }))).toBe(false)
+  })
+})

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { NavShell } from '@/components/nav-shell'
 import { ConnectionBanner } from '@/components/connection-banner'
+import { KeyboardShortcutsProvider } from '@/components/keyboard-shortcuts-provider'
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
@@ -30,7 +31,9 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
     <GroupProvider>
       <GroupDataProvider>
         <ConnectionBanner />
-        <NavShell>{children}</NavShell>
+        <KeyboardShortcutsProvider>
+          <NavShell>{children}</NavShell>
+        </KeyboardShortcutsProvider>
       </GroupDataProvider>
     </GroupProvider>
   )

--- a/src/components/keyboard-shortcuts-provider.tsx
+++ b/src/components/keyboard-shortcuts-provider.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useKeyboardShortcuts, type ShortcutBinding } from '@/hooks/use-keyboard-shortcut'
+
+/**
+ * Wraps the auth area with global keyboard shortcuts (Issue #235).
+ * Shortcuts are desktop-friendly and ignored when the user is typing in
+ * form controls or contenteditable regions.
+ */
+const NAV_SHORTCUTS = [
+  { key: 'h', label: '首頁', path: '/' },
+  { key: 'n', label: '新增支出', path: '/expense/new' },
+  { key: 'r', label: '所有記錄', path: '/records' },
+  { key: 's', label: '結算', path: '/split' },
+  { key: 't', label: '統計', path: '/statistics' },
+] as const
+
+export function KeyboardShortcutsProvider({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const [cheatsheetOpen, setCheatsheetOpen] = useState(false)
+
+  const bindings = useMemo<ShortcutBinding[]>(
+    () => [
+      ...NAV_SHORTCUTS.map((s) => ({
+        key: s.key,
+        handler: () => router.push(s.path),
+      })),
+      {
+        key: '?',
+        shift: true,
+        handler: () => setCheatsheetOpen((v) => !v),
+      },
+      {
+        key: '/',
+        shift: true,
+        handler: () => setCheatsheetOpen((v) => !v),
+      },
+      {
+        key: 'Escape',
+        handler: () => setCheatsheetOpen(false),
+      },
+    ],
+    [router],
+  )
+
+  useKeyboardShortcuts(bindings)
+
+  return (
+    <>
+      {children}
+      {cheatsheetOpen && (
+        <div
+          className="fixed inset-0 z-[80] flex items-center justify-center bg-black/50 animate-fade-in"
+          onClick={() => setCheatsheetOpen(false)}
+          role="dialog"
+          aria-label="鍵盤快捷鍵"
+        >
+          <div
+            className="bg-[var(--card)] border border-[var(--border)] rounded-2xl p-6 w-full max-w-sm mx-4 space-y-3 animate-slide-up"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-bold">⌨️ 鍵盤快捷鍵</h2>
+              <button
+                type="button"
+                onClick={() => setCheatsheetOpen(false)}
+                aria-label="關閉"
+                className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="space-y-1.5 text-sm">
+              {NAV_SHORTCUTS.map((s) => (
+                <div key={s.key} className="flex items-center justify-between">
+                  <span className="text-[var(--muted-foreground)]">{s.label}</span>
+                  <kbd className="px-2 py-0.5 rounded border border-[var(--border)] bg-[var(--muted)] font-mono text-xs">
+                    {s.key.toUpperCase()}
+                  </kbd>
+                </div>
+              ))}
+              <div className="flex items-center justify-between pt-2 border-t border-[var(--border)] mt-2">
+                <span className="text-[var(--muted-foreground)]">開關此面板</span>
+                <kbd className="px-2 py-0.5 rounded border border-[var(--border)] bg-[var(--muted)] font-mono text-xs">
+                  ?
+                </kbd>
+              </div>
+            </div>
+            <p className="text-xs text-[var(--muted-foreground)] pt-2">
+              輸入欄位聚焦時不觸發。
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/hooks/use-keyboard-shortcut.ts
+++ b/src/hooks/use-keyboard-shortcut.ts
@@ -1,0 +1,65 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export interface ShortcutBinding {
+  /** Key to match — case-insensitive, compared against `event.key`. */
+  key: string
+  /** Require Shift. Default false. */
+  shift?: boolean
+  handler: () => void
+}
+
+/**
+ * Returns true if the current focus target is an editable element where a
+ * plain alpha key should be treated as text input, not a shortcut.
+ *
+ * Exported so tests can exercise the filter without mounting DOM.
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  if (target.isContentEditable) return true
+  return false
+}
+
+/**
+ * Should a keyboard event trigger a shortcut? Separate from the matcher so
+ * both parts can be unit-tested independently.
+ */
+export function shouldIgnoreEvent(event: {
+  target: EventTarget | null
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+}): boolean {
+  if (event.metaKey || event.ctrlKey || event.altKey) return true
+  return isEditableTarget(event.target)
+}
+
+/**
+ * Global keyboard shortcut registration for the authenticated layout
+ * (Issue #235). Ignores events when the user is typing in inputs, textareas,
+ * selects, or contenteditable regions; also ignores events with modifier
+ * keys so browser shortcuts (Cmd+R, Ctrl+T, …) keep working.
+ *
+ * Bindings are compared case-insensitively. Shift is explicit when needed
+ * (e.g. `?` requires shift=true on most US layouts).
+ */
+export function useKeyboardShortcuts(bindings: readonly ShortcutBinding[]): void {
+  useEffect(() => {
+    function onKey(event: KeyboardEvent) {
+      if (shouldIgnoreEvent(event)) return
+      for (const b of bindings) {
+        if (event.key.toLowerCase() !== b.key.toLowerCase()) continue
+        if ((b.shift ?? false) !== event.shiftKey) continue
+        event.preventDefault()
+        b.handler()
+        return
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [bindings])
+}


### PR DESCRIPTION
## Summary
- 桌機按 H/N/R/S/T 快速導航
- Shift+/ 或 ? 開關快捷鍵面板（ESC 關閉）
- input/textarea/contenteditable focus 或 Cmd/Ctrl/Alt 按下時不觸發

## Why
桌機使用者每天打開家計本要連續切換幾個頁面（記帳 → 看記錄 → 結算），滑鼠點側邊欄摩擦大。1 key 導航省幾百毫秒。

## Changes
- \`src/hooks/use-keyboard-shortcut.ts\` — hook + 純函式 \`shouldIgnoreEvent\` / \`isEditableTarget\`
- \`src/components/keyboard-shortcuts-provider.tsx\` — provider + cheatsheet
- \`src/app/(auth)/layout.tsx\` — 掛進去
- \`__tests__/use-keyboard-shortcut.test.ts\` — 16 cases（6 個 isEditableTarget 類型、10 個 ignore event 條件）

## Test plan
- [x] 16 tests pass（無需 jsdom，duck-typed HTMLElement shim）
- [x] typecheck 乾淨
- [x] lint 乾淨
- [ ] 部署後桌機驗證：
  - 按 N 跳到 /expense/new
  - 在 quick-add input 打字按 N 不跳頁（當成字元輸入）
  - Cmd+R / Ctrl+R 仍正常 reload
  - ? 打開 cheatsheet

## Non-goals
- 不做 vim-style Gg/Gd composition
- 不做自訂快捷鍵設定（後續 issue 可加）

Closes #235