### PR TITLE
feat(records): 下拉刷新 (Closes #237)

### DIFF
--- a/__tests__/use-pull-to-refresh.test.ts
+++ b/__tests__/use-pull-to-refresh.test.ts
@@ -1,0 +1,43 @@
+import { computeOffset } from '@/hooks/use-pull-to-refresh'
+
+describe('computeOffset', () => {
+  it('returns 0 for non-positive drag', () => {
+    expect(computeOffset(0, 80)).toBe(0)
+    expect(computeOffset(-10, 80)).toBe(0)
+    expect(computeOffset(-100, 80)).toBe(0)
+  })
+
+  it('returns dy directly when below threshold', () => {
+    expect(computeOffset(20, 80)).toBe(20)
+    expect(computeOffset(50, 80)).toBe(50)
+    expect(computeOffset(80, 80)).toBe(80)
+  })
+
+  it('applies diminishing resistance past threshold', () => {
+    // dy = 81, threshold = 80 → over = 1 → 80 + sqrt(1)*3 = 83
+    expect(computeOffset(81, 80)).toBe(83)
+    // dy = 84, over = 4 → 80 + sqrt(4)*3 = 86
+    expect(computeOffset(84, 80)).toBe(86)
+    // dy = 180, over = 100 → 80 + sqrt(100)*3 = 110
+    expect(computeOffset(180, 80)).toBe(110)
+  })
+
+  it('is monotonically non-decreasing', () => {
+    let prev = 0
+    for (let dy = 0; dy < 500; dy += 5) {
+      const next = computeOffset(dy, 80)
+      expect(next).toBeGreaterThanOrEqual(prev)
+      prev = next
+    }
+  })
+
+  it('respects custom threshold', () => {
+    expect(computeOffset(100, 100)).toBe(100)
+    expect(computeOffset(100, 50)).toBe(50 + Math.sqrt(50) * 3)
+  })
+
+  it('handles very small threshold gracefully', () => {
+    // threshold=1, dy=10 → over=9 → 1 + 9 = not 10; sqrt(9)*3 = 9 → total 10
+    expect(computeOffset(10, 1)).toBe(10)
+  })
+})

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/amount-range-filter'
 import { AmountRangeChips } from '@/components/amount-range-chips'
 import { useSwipe } from '@/hooks/use-swipe'
+import { usePullToRefresh } from '@/hooks/use-pull-to-refresh'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useExpenses } from '@/lib/hooks/use-expenses'
 import { useMembers } from '@/lib/hooks/use-members'
@@ -299,8 +300,34 @@ export default function RecordsPage() {
     },
   })
 
+  // Pull-to-refresh: reset pagination so the Firestore subscription re-emits
+  // the first page, and confirm with a toast (Issue #237). Firestore realtime
+  // listener reconnects automatically — no explicit refetch needed.
+  const pullState = usePullToRefresh(swipeRef, {
+    onRefresh: async () => {
+      setExtraExpenses([])
+      setHasMore(contextHasMore)
+      setLastDoc(contextLastDoc)
+      await new Promise((r) => setTimeout(r, 300))
+      addToast('已更新', 'success')
+    },
+  })
+
   return (
-    <div ref={swipeRef} className="p-4 md:p-8 max-w-5xl mx-auto">
+    <div ref={swipeRef} className="p-4 md:p-8 max-w-5xl mx-auto" style={{ transform: pullState.offset > 0 ? `translateY(${pullState.offset}px)` : undefined, transition: pullState.offset === 0 ? 'transform 200ms ease-out' : undefined }}>
+      {(pullState.offset > 0 || pullState.refreshing) && (
+        <div
+          className="flex items-center justify-center text-xs text-[var(--muted-foreground)] -mt-2 mb-2"
+          style={{ height: Math.min(pullState.offset, 64) }}
+          aria-live="polite"
+        >
+          {pullState.refreshing
+            ? '🔄 重新整理中…'
+            : pullState.armed
+              ? '放開以重新整理'
+              : '⬇ 下拉可重新整理'}
+        </div>
+      )}
       {/* Header row */}
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-bold">所有記錄</h1>

--- a/src/hooks/use-pull-to-refresh.ts
+++ b/src/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useRef, useState, type RefObject } from 'react'
+
+export interface PullToRefreshOptions {
+  onRefresh: () => void | Promise<void>
+  threshold?: number
+  /** When false, touch listeners are not attached. */
+  enabled?: boolean
+}
+
+export interface PullToRefreshState {
+  /** Current visual offset in px (0..threshold+overshoot). */
+  offset: number
+  /** Whether an onRefresh callback is currently in flight. */
+  refreshing: boolean
+  /** True once offset ≥ threshold — used to switch the label to "放開更新". */
+  armed: boolean
+}
+
+/**
+ * Pure decision helper — returns the visual offset to render given the
+ * raw vertical drag distance. Extracted so the math is unit-testable
+ * without a DOM. Resistance curve ramps slowly past threshold so the UI
+ * feels elastic but not runaway.
+ */
+export function computeOffset(dy: number, threshold: number): number {
+  if (dy <= 0) return 0
+  if (dy <= threshold) return dy
+  // Past threshold: diminishing returns (square root curve)
+  const over = dy - threshold
+  return threshold + Math.sqrt(over) * 3
+}
+
+/**
+ * Pull-to-refresh detector for mobile touch scrolling (Issue #237).
+ * Only activates when the scroll container is already at the top so it
+ * doesn't fight native overscroll. Uses passive touchstart + touchmove
+ * to avoid blocking the scroll path.
+ */
+export function usePullToRefresh(
+  ref: RefObject<HTMLElement | null>,
+  { onRefresh, threshold = 80, enabled = true }: PullToRefreshOptions,
+): PullToRefreshState {
+  const [offset, setOffset] = useState(0)
+  const [refreshing, setRefreshing] = useState(false)
+  const startY = useRef<number | null>(null)
+  const tracking = useRef(false)
+  const refreshingRef = useRef(false)
+
+  useEffect(() => {
+    refreshingRef.current = refreshing
+  }, [refreshing])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || !enabled) return
+
+    const onStart = (e: TouchEvent) => {
+      if (refreshingRef.current) return
+      if ((window.scrollY || document.documentElement.scrollTop) > 0) return
+      if (e.touches.length !== 1) return
+      startY.current = e.touches[0].clientY
+      tracking.current = true
+    }
+
+    const onMove = (e: TouchEvent) => {
+      if (!tracking.current || startY.current === null) return
+      const dy = e.touches[0].clientY - startY.current
+      if (dy <= 0) {
+        setOffset(0)
+        return
+      }
+      setOffset(computeOffset(dy, threshold))
+    }
+
+    const onEnd = () => {
+      if (!tracking.current) return
+      tracking.current = false
+      startY.current = null
+      setOffset((current) => {
+        if (current >= threshold && !refreshingRef.current) {
+          setRefreshing(true)
+          // Run in microtask so React can paint the "refreshing" state first
+          Promise.resolve()
+            .then(() => onRefresh())
+            .catch(() => {})
+            .finally(() => {
+              setRefreshing(false)
+              setOffset(0)
+            })
+        }
+        return 0
+      })
+    }
+
+    el.addEventListener('touchstart', onStart, { passive: true })
+    el.addEventListener('touchmove', onMove, { passive: true })
+    el.addEventListener('touchend', onEnd, { passive: true })
+    el.addEventListener('touchcancel', onEnd, { passive: true })
+    return () => {
+      el.removeEventListener('touchstart', onStart)
+      el.removeEventListener('touchmove', onMove)
+      el.removeEventListener('touchend', onEnd)
+      el.removeEventListener('touchcancel', onEnd)
+    }
+  }, [ref, onRefresh, threshold, enabled])
+
+  return { offset, refreshing, armed: offset >= threshold }
+}


### PR DESCRIPTION
## Summary
- Records 頁手機下拉 > 80px 觸發 refresh
- 重置分頁、toast「已更新」
- 桌機不影響（touch-only）

## Changes
- \`src/hooks/use-pull-to-refresh.ts\` — hook + \`computeOffset\` 純函式
- \`src/app/(auth)/records/page.tsx\` — 接入 + 視覺反饋
- \`__tests__/use-pull-to-refresh.test.ts\` — 6 cases 涵蓋阻尼曲線

## Test plan
- [x] 6 unit tests pass
- [x] typecheck + lint 乾淨
- [ ] 部署後手機驗證：
  - Records 頂部下拉顯示「下拉可重新整理」→ 超過 threshold 「放開以重新整理」→ 放開後 refresh toast
  - 頁面中間下拉（非頂部）不觸發
  - 桌機滑鼠 drag 不觸發

Closes #237