### PR TITLE
feat(ui): 統一 loading skeleton 取代 spinner (Closes #234)

### DIFF
--- a/src/app/(auth)/expense/[id]/page.tsx
+++ b/src/app/(auth)/expense/[id]/page.tsx
@@ -47,8 +47,11 @@ export default function EditExpensePage({ params }: { params: Promise<{ id: stri
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin h-8 w-8 border-4 border-[var(--primary)] border-t-transparent rounded-full" />
+      <div className="p-4 md:p-8 max-w-2xl mx-auto space-y-3">
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-8 w-32" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-24" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-16" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-16" />
       </div>
     )
   }

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -143,8 +143,14 @@ export default function HomePage() {
 
   if (groupLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin h-8 w-8 border-4 border-[var(--primary)] border-t-transparent rounded-full" />
+      <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-4">
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-16" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-28" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-24" />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="animate-pulse bg-[var(--muted)] rounded-md h-48" />
+          <div className="animate-pulse bg-[var(--muted)] rounded-md h-48" />
+        </div>
       </div>
     )
   }

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -547,8 +547,13 @@ export default function RecordsPage() {
 
       {/* Content */}
       {loading ? (
-        <div className="flex justify-center py-12">
-          <div className="animate-spin h-8 w-8 border-4 border-[var(--primary)] border-t-transparent rounded-full" />
+        <div className="space-y-3 py-4">
+          <div className="animate-pulse bg-[var(--muted)] rounded-md h-5 w-24" />
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            <div className="animate-pulse bg-[var(--muted)] rounded-md h-24" />
+            <div className="animate-pulse bg-[var(--muted)] rounded-md h-24" />
+            <div className="animate-pulse bg-[var(--muted)] rounded-md h-24" />
+          </div>
         </div>
       ) : filtered.length === 0 ? (
         <div className="text-center py-12 space-y-3">

--- a/src/app/(auth)/settings/activity-log/page.tsx
+++ b/src/app/(auth)/settings/activity-log/page.tsx
@@ -11,8 +11,11 @@ export default function ActivityLogPage() {
 
   if (groupLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin h-8 w-8 border-4 border-[var(--primary)] border-t-transparent rounded-full" />
+      <div className="p-4 md:p-8 max-w-4xl mx-auto space-y-3">
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-8 w-32" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-16" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-16" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-16" />
       </div>
     )
   }

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -650,8 +650,11 @@ export default function SettingsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin h-8 w-8 border-4 border-[var(--primary)] border-t-transparent rounded-full" />
+      <div className="p-4 md:p-8 max-w-3xl mx-auto space-y-3">
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-10 w-32" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-32" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-24" />
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-16" />
       </div>
     )
   }

--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -11,6 +11,7 @@ import { addSettlement, addSettlements, deleteSettlement } from '@/lib/services/
 import { findLastSettlementBetween, formatSettlementAge } from '@/lib/settlement-history'
 import { useToast } from '@/components/toast'
 import { currency, signedCurrency, toDate, fmtDateFull } from '@/lib/utils'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useAuth, getActor } from '@/lib/auth'
 import { useCurrentMember } from '@/lib/hooks/use-current-member'
 
@@ -274,8 +275,12 @@ export default function SplitPage() {
 
   if (groupLoading || expLoading || membersLoading || settlementsLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin h-8 w-8 border-4 border-[var(--primary)] border-t-transparent rounded-full" />
+      <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-3">
+        <Skeleton className="h-12" />
+        <Skeleton className="h-24" />
+        <Skeleton className="h-16" />
+        <Skeleton className="h-16" />
+        <Skeleton className="h-16" />
       </div>
     )
   }

--- a/src/app/(auth)/statistics/page.tsx
+++ b/src/app/(auth)/statistics/page.tsx
@@ -195,8 +195,10 @@ export default function StatisticsPage() {
 
   if (groupLoading || expLoading || membersLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin h-8 w-8 border-4 border-[var(--primary)] border-t-transparent rounded-full" />
+      <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-3">
+        <div className="animate-pulse bg-[var(--muted)] rounded-md h-10 w-40" />
+        <ChartSkeleton />
+        <ChartSkeleton />
       </div>
     )
   }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+interface SkeletonProps {
+  className?: string
+  /** ARIA label for screen readers; defaults to "載入中". */
+  label?: string
+}
+
+/**
+ * Minimal skeleton placeholder — animated gray block using existing CSS
+ * tokens so it respects light/dark themes. Used to replace spinner-only
+ * loading states across the app (Issue #234) and improve perceived speed.
+ */
+export function Skeleton({ className, label = '載入中' }: SkeletonProps) {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={label}
+      className={`animate-pulse bg-[var(--muted)] rounded-md ${className ?? ''}`}
+    />
+  )
+}
+
+/**
+ * Common page-level skeleton: a stack of blocks approximating a card grid.
+ * Use when the page has a uniform list/grid layout.
+ */
+export function SkeletonPageGrid({ rows = 3, className }: { rows?: number; className?: string }) {
+  return (
+    <div className={`space-y-3 ${className ?? ''}`}>
+      <Skeleton className="h-24" />
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-16" />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 6 個頁面 loading 從全螢幕 spinner 改為 skeleton 佔位塊
- 新 \`src/components/ui/skeleton.tsx\` primitive（可重用）
- 保留 inline action spinner（例：「載入更多」按鈕內）

## Why
原本全螢幕中央轉圈的 UX：
- 感知速度慢（沒有內容輪廓）
- CLS 高（載入完 layout 跳動）
- 與 TodaySummary 已有的 skeleton 風格不一致

## Changes
- **New**: \`src/components/ui/skeleton.tsx\` — \`Skeleton\` + \`SkeletonPageGrid\`
- **Modified**: home / split / statistics / settings / settings/activity-log / expense/[id] / records page

## Test plan
- [x] \`tsc --noEmit\` 乾淨
- [x] eslint 乾淨（兩個 pre-existing warnings unchanged）
- [ ] 部署後手動驗證：
  - 第一次 login → home 顯示 skeleton 非 spinner
  - 切到 split/statistics 看到 skeleton
  - Refresh records → skeleton 的 3-col grid 過渡到實際資料
  - Layout loading 與 load-more 的 inline spinner 保持不動

Closes #234