### PR TITLE
feat(budget): 預算超標 80%/100% email 警示 (Closes #236)

### DIFF
--- a/__tests__/budget-alert.test.ts
+++ b/__tests__/budget-alert.test.ts
@@ -1,0 +1,201 @@
+import {
+  shouldTriggerAlert,
+  buildAlertHistoryKey,
+  buildAlertMessage,
+} from '@/lib/budget-alert'
+
+describe('buildAlertHistoryKey', () => {
+  it('zero-pads month', () => {
+    expect(buildAlertHistoryKey(2026, 3, 80)).toBe('2026-03-80')
+    expect(buildAlertHistoryKey(2026, 12, 100)).toBe('2026-12-100')
+  })
+})
+
+describe('shouldTriggerAlert', () => {
+  const YEAR = 2026
+  const MONTH = 4
+
+  describe('skip conditions', () => {
+    it('returns null when budget is 0', () => {
+      expect(
+        shouldTriggerAlert({ currentTotal: 100, budget: 0, history: {}, year: YEAR, month: MONTH }),
+      ).toBeNull()
+    })
+
+    it('returns null when budget is negative', () => {
+      expect(
+        shouldTriggerAlert({ currentTotal: 100, budget: -10, history: {}, year: YEAR, month: MONTH }),
+      ).toBeNull()
+    })
+
+    it('returns null when budget is NaN', () => {
+      expect(
+        shouldTriggerAlert({ currentTotal: 100, budget: NaN, history: {}, year: YEAR, month: MONTH }),
+      ).toBeNull()
+    })
+
+    it('returns null when currentTotal is negative (defensive)', () => {
+      expect(
+        shouldTriggerAlert({ currentTotal: -10, budget: 100, history: {}, year: YEAR, month: MONTH }),
+      ).toBeNull()
+    })
+
+    it('returns null when under 80% and no history', () => {
+      expect(
+        shouldTriggerAlert({ currentTotal: 79, budget: 100, history: {}, year: YEAR, month: MONTH }),
+      ).toBeNull()
+    })
+  })
+
+  describe('80% threshold', () => {
+    it('fires at exactly 80%', () => {
+      const result = shouldTriggerAlert({ currentTotal: 80, budget: 100, history: {}, year: YEAR, month: MONTH })
+      expect(result).toEqual({
+        threshold: 80,
+        historyKey: '2026-04-80',
+        alsoMark: [],
+      })
+    })
+
+    it('fires at 85% when no history', () => {
+      const result = shouldTriggerAlert({ currentTotal: 85, budget: 100, history: {}, year: YEAR, month: MONTH })
+      expect(result?.threshold).toBe(80)
+    })
+
+    it('does NOT re-fire 80% when already in history', () => {
+      const result = shouldTriggerAlert({
+        currentTotal: 85,
+        budget: 100,
+        history: { '2026-04-80': true },
+        year: YEAR,
+        month: MONTH,
+      })
+      expect(result).toBeNull()
+    })
+
+    it('history for OTHER month does not prevent firing', () => {
+      const result = shouldTriggerAlert({
+        currentTotal: 80,
+        budget: 100,
+        history: { '2026-03-80': true }, // previous month
+        year: YEAR,
+        month: MONTH,
+      })
+      expect(result?.threshold).toBe(80)
+    })
+  })
+
+  describe('100% threshold', () => {
+    it('fires at exactly 100%', () => {
+      const result = shouldTriggerAlert({ currentTotal: 100, budget: 100, history: {}, year: YEAR, month: MONTH })
+      expect(result).toEqual({
+        threshold: 100,
+        historyKey: '2026-04-100',
+        alsoMark: ['2026-04-80'],
+      })
+    })
+
+    it('fires at 150% when no 100% history', () => {
+      const result = shouldTriggerAlert({
+        currentTotal: 150,
+        budget: 100,
+        history: { '2026-04-80': true },
+        year: YEAR,
+        month: MONTH,
+      })
+      expect(result?.threshold).toBe(100)
+    })
+
+    it('does NOT re-fire 100% when already in history', () => {
+      const result = shouldTriggerAlert({
+        currentTotal: 120,
+        budget: 100,
+        history: { '2026-04-100': true, '2026-04-80': true },
+        year: YEAR,
+        month: MONTH,
+      })
+      expect(result).toBeNull()
+    })
+
+    it('100% jumps over 80% and marks both', () => {
+      const result = shouldTriggerAlert({
+        currentTotal: 110,
+        budget: 100,
+        history: {},
+        year: YEAR,
+        month: MONTH,
+      })
+      expect(result?.threshold).toBe(100)
+      expect(result?.alsoMark).toContain('2026-04-80')
+    })
+  })
+
+  describe('precedence', () => {
+    it('100% wins over 80% in same tick', () => {
+      const result = shouldTriggerAlert({
+        currentTotal: 100,
+        budget: 100,
+        history: {},
+        year: YEAR,
+        month: MONTH,
+      })
+      expect(result?.threshold).toBe(100)
+    })
+
+    it('at 99.9% fires 80% (not 100%)', () => {
+      const result = shouldTriggerAlert({
+        currentTotal: 99.9,
+        budget: 100,
+        history: {},
+        year: YEAR,
+        month: MONTH,
+      })
+      expect(result?.threshold).toBe(80)
+    })
+
+    it('at 79.9% fires nothing', () => {
+      const result = shouldTriggerAlert({
+        currentTotal: 79.9,
+        budget: 100,
+        history: {},
+        year: YEAR,
+        month: MONTH,
+      })
+      expect(result).toBeNull()
+    })
+  })
+
+  it('accepts undefined history as empty', () => {
+    const result = shouldTriggerAlert({
+      currentTotal: 80,
+      budget: 100,
+      history: undefined,
+      year: YEAR,
+      month: MONTH,
+    })
+    expect(result?.threshold).toBe(80)
+  })
+})
+
+describe('buildAlertMessage', () => {
+  it('formats 100% body with overspend wording', () => {
+    const msg = buildAlertMessage(
+      { threshold: 100, historyKey: '2026-04-100', alsoMark: [] },
+      { currentTotal: 12000, budget: 10000 },
+    )
+    expect(msg.title).toContain('超過預算')
+    expect(msg.body).toContain('12,000')
+    expect(msg.body).toContain('10,000')
+  })
+
+  it('formats 80% body with remaining amount', () => {
+    const msg = buildAlertMessage(
+      { threshold: 80, historyKey: '2026-04-80', alsoMark: [] },
+      { currentTotal: 8000, budget: 10000 },
+    )
+    expect(msg.title).toContain('80%')
+    expect(msg.body).toContain('8,000')
+    expect(msg.body).toContain('10,000')
+    expect(msg.body).toContain('2,000') // remaining
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -17,6 +17,7 @@ import { RecentActivitySection } from '@/components/recent-activity-section'
 import { SimpleTabs } from '@/components/simple-tabs'
 import { RecentExpensesList } from '@/components/recent-expenses-list'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
+import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
 import { logger } from '@/lib/logger'
 import { useToast } from '@/components/toast'
 import {
@@ -140,6 +141,19 @@ export default function HomePage() {
   const monthLabel = `${now.getFullYear()}年 ${now.getMonth() + 1}月`
   const total = useMemo(() => monthly.reduce((s, e) => s + e.amount, 0), [monthly])
   const sharedTotal = useMemo(() => monthly.filter((e) => e.isShared).reduce((s, e) => s + e.amount, 0), [monthly])
+
+  // Budget-alert check (Issue #236). Fires fire-and-forget whenever the
+  // monthly total changes; transaction handles dedup across tabs.
+  useEffect(() => {
+    if (!group?.id || !group.monthlyBudget || total <= 0) return
+    const d = new Date()
+    maybeSendBudgetAlert({
+      groupId: group.id,
+      currentTotal: total,
+      year: d.getFullYear(),
+      month: d.getMonth() + 1,
+    })
+  }, [group?.id, group?.monthlyBudget, total])
 
   if (groupLoading) {
     return (

--- a/src/lib/budget-alert.ts
+++ b/src/lib/budget-alert.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure decision logic for monthly budget alerts (Issue #236).
+ *
+ * A group's monthly budget can cross two thresholds: 80% (warning) and 100%
+ * (over). We fire **one** email per threshold per month per group and record
+ * it in `group.budgetAlertHistory` so later writes don't re-alert.
+ *
+ * 100% alerts take precedence over 80% — if somehow both fire in the same
+ * tick (e.g. a big single expense jumping from 50% to 110%), the 100% one
+ * is emitted and 80% is considered "subsumed". We still record 80% in
+ * history so that in the unlikely event the group budget is raised later
+ * back above 80% but below 100%, we don't re-alert the 80% threshold.
+ */
+export type BudgetAlertThreshold = 80 | 100
+export type BudgetAlertHistory = Record<string, boolean>
+
+export interface AlertDecision {
+  threshold: BudgetAlertThreshold
+  /** History map key that should be set to true atomically with the send. */
+  historyKey: string
+  /** Any other keys that should also be set (e.g. 80 gets set when 100 fires). */
+  alsoMark: readonly string[]
+}
+
+/**
+ * Build the canonical history key for a (year, month, threshold) combo.
+ * Exported for unit tests and service-side writes.
+ */
+export function buildAlertHistoryKey(year: number, month: number, threshold: BudgetAlertThreshold): string {
+  const mm = String(month).padStart(2, '0')
+  return `${year}-${mm}-${threshold}`
+}
+
+export interface AlertInput {
+  currentTotal: number
+  budget: number
+  history: BudgetAlertHistory | undefined
+  /** Four-digit year. */
+  year: number
+  /** 1..12. */
+  month: number
+}
+
+export function shouldTriggerAlert({
+  currentTotal,
+  budget,
+  history,
+  year,
+  month,
+}: AlertInput): AlertDecision | null {
+  if (!Number.isFinite(budget) || budget <= 0) return null
+  if (!Number.isFinite(currentTotal) || currentTotal < 0) return null
+
+  const h = history ?? {}
+  const pct = (currentTotal / budget) * 100
+  const key80 = buildAlertHistoryKey(year, month, 80)
+  const key100 = buildAlertHistoryKey(year, month, 100)
+
+  if (pct >= 100 && !h[key100]) {
+    // Subsume the 80 threshold by also marking it (avoids replay if budget
+    // is raised later and we land back between 80 and 100 in the same month).
+    return { threshold: 100, historyKey: key100, alsoMark: [key80] }
+  }
+
+  if (pct >= 80 && !h[key80]) {
+    return { threshold: 80, historyKey: key80, alsoMark: [] }
+  }
+
+  return null
+}
+
+/**
+ * Human-friendly email subject + body based on the decision.
+ * Exported for both server-side rendering and tests.
+ */
+export function buildAlertMessage(
+  decision: AlertDecision,
+  data: { currentTotal: number; budget: number; groupName?: string },
+): { title: string; body: string } {
+  const fmt = (n: number) => `NT$ ${n.toLocaleString('zh-TW')}`
+  if (decision.threshold === 100) {
+    return {
+      title: '🚨 本月支出超過預算',
+      body: `本月支出 ${fmt(data.currentTotal)} 已超過 ${fmt(data.budget)} 預算。下半個月請特別留意開銷。`,
+    }
+  }
+  return {
+    title: '⚠️ 本月已達 80% 預算',
+    body: `本月支出 ${fmt(data.currentTotal)} 已達 ${fmt(data.budget)} 預算的 80%。剩餘額度還有 ${fmt(data.budget - data.currentTotal)}。`,
+  }
+}

--- a/src/lib/services/budget-alert-service.ts
+++ b/src/lib/services/budget-alert-service.ts
@@ -1,0 +1,101 @@
+/**
+ * Budget-alert orchestrator (Issue #236). Decides + sends + records.
+ *
+ * Called from the home page when the monthly total changes. Uses a
+ * Firestore transaction on the group doc so the read-decide-write cycle
+ * is atomic — prevents two tabs from sending duplicate emails when a new
+ * expense crosses a threshold at the same moment.
+ */
+import { doc, runTransaction } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import {
+  shouldTriggerAlert,
+  buildAlertMessage,
+  type BudgetAlertHistory,
+} from '@/lib/budget-alert'
+import { notifyByEmailFanOut } from '@/lib/services/email-notification'
+import { logger } from '@/lib/logger'
+
+interface GroupDocSubset {
+  monthlyBudget?: number | null
+  budgetAlertHistory?: BudgetAlertHistory
+  memberUids?: string[]
+  name?: string
+}
+
+export interface BudgetAlertTriggerArgs {
+  groupId: string
+  currentTotal: number
+  /** 1..12 — caller supplies so we can stub in tests and avoid Date() inside. */
+  year: number
+  month: number
+  /** Uids to notify; typically `memberUids` excluding the acting user is fine. */
+  recipientOverride?: readonly string[]
+}
+
+/**
+ * Check the group's monthly budget vs current total; if a threshold has just
+ * been crossed, atomically record in `budgetAlertHistory` and fan out email.
+ *
+ * Best-effort: on any failure logs and returns. Caller should treat this as
+ * fire-and-forget (do NOT await in the critical path). The transaction
+ * provides single-flight safety across tabs / clients.
+ */
+export async function maybeSendBudgetAlert(args: BudgetAlertTriggerArgs): Promise<void> {
+  const { groupId, currentTotal, year, month, recipientOverride } = args
+  try {
+    const groupRef = doc(db, 'groups', groupId)
+    const outcome = await runTransaction(db, async (tx) => {
+      const snap = await tx.get(groupRef)
+      if (!snap.exists()) return null
+      const data = snap.data() as GroupDocSubset
+      const budget = data.monthlyBudget ?? 0
+      const history = data.budgetAlertHistory ?? {}
+      const decision = shouldTriggerAlert({
+        currentTotal,
+        budget: budget ?? 0,
+        history,
+        year,
+        month,
+      })
+      if (!decision) return null
+
+      // Optimistically mark all the keys (main + alsoMark) so a concurrent
+      // transaction reading right after us won't re-decide. This is the
+      // reason we use a transaction rather than just Firestore `update`.
+      const newHistory: BudgetAlertHistory = { ...history, [decision.historyKey]: true }
+      for (const k of decision.alsoMark) newHistory[k] = true
+      tx.update(groupRef, { budgetAlertHistory: newHistory })
+
+      return {
+        decision,
+        data: {
+          currentTotal,
+          budget: budget ?? 0,
+          groupName: data.name,
+          memberUids: data.memberUids ?? [],
+        },
+      }
+    })
+
+    if (!outcome) return
+
+    const { decision, data } = outcome
+    const msg = buildAlertMessage(decision, {
+      currentTotal: data.currentTotal,
+      budget: data.budget,
+      groupName: data.groupName,
+    })
+    const recipients = recipientOverride ?? data.memberUids
+    if (!recipients || recipients.length === 0) return
+    await notifyByEmailFanOut({
+      groupId,
+      recipientUids: recipients,
+      title: msg.title,
+      body: msg.body,
+      groupName: data.groupName,
+    })
+  } catch (e) {
+    logger.error('[BudgetAlert] Failed to check/send alert', e)
+  }
+}


### PR DESCRIPTION
## Summary
- 本月支出首次跨越 80% 預算 → email 警示 ⚠️
- 首次跨越 100% 預算 → email 警示 🚨
- 同月內不重複發送；月份自動重置
- Firestore transaction 保證多 tab/多裝置 only-once

## Architecture
- \`src/lib/budget-alert.ts\` — pure function: \`shouldTriggerAlert\` + \`buildAlertHistoryKey\` + \`buildAlertMessage\`
- \`src/lib/services/budget-alert-service.ts\` — \`maybeSendBudgetAlert\`: Firestore transaction 讀 group + 決策 + 原子更新 \`budgetAlertHistory\` + fan-out email（best-effort）
- \`src/app/(auth)/page.tsx\` — useEffect 在 \`total\` 或 \`group.monthlyBudget\` 改變時觸發
- 100% 觸發時也 mark 該月 80%，避免後續預算調升回到 80–100% 區間重觸

## Why
家人不會天天盯 App 看預算進度。超標到發現可能已經月底。Email 警示是低成本的 early warning，且一次性設計避免騷擾。

## Test plan
- [x] 20 unit tests pass（skip / 80% / 100% / precedence / history 重置 / NaN / 負值）
- [x] \`tsc --noEmit\` 乾淨
- [x] eslint 乾淨
- [ ] 部署後手動驗證：
  - 設預算 NT\$ 10000，本月支出達 8000 → 收到 80% 警示
  - 繼續記到 9000 → 不再發（已 mark）
  - 繼續記到 10000 → 收到 100% 警示
  - 記到 12000 → 不再發
- [ ] 需要 Firebase Extension 已裝（見 CLAUDE.md 的 email setup 章節）

## No-rules-change
groups update 既有規則允許 member 修改任意欄位；\`budgetAlertHistory\` map 無需 schema 宣告。

Closes #236