### PR TITLE
feat(records/home): 類別顏色 coding (Closes #242)

### DIFF
--- a/__tests__/category-color.test.ts
+++ b/__tests__/category-color.test.ts
@@ -1,0 +1,71 @@
+import {
+  categoryColor,
+  categoryPaletteIndex,
+  CATEGORY_PALETTE,
+  CATEGORY_FG_PALETTE,
+} from '@/lib/category-color'
+
+describe('categoryPaletteIndex', () => {
+  it('returns 0 for empty/null/undefined', () => {
+    expect(categoryPaletteIndex(undefined)).toBe(0)
+    expect(categoryPaletteIndex(null)).toBe(0)
+    expect(categoryPaletteIndex('')).toBe(0)
+    expect(categoryPaletteIndex('   ')).toBe(0)
+  })
+
+  it('is deterministic (same name → same index)', () => {
+    expect(categoryPaletteIndex('餐飲')).toBe(categoryPaletteIndex('餐飲'))
+    expect(categoryPaletteIndex('Groceries')).toBe(categoryPaletteIndex('Groceries'))
+  })
+
+  it('normalizes whitespace and case (equivalent keys collide)', () => {
+    expect(categoryPaletteIndex('餐飲')).toBe(categoryPaletteIndex(' 餐飲 '))
+    expect(categoryPaletteIndex('Food')).toBe(categoryPaletteIndex('FOOD'))
+    expect(categoryPaletteIndex('Food')).toBe(categoryPaletteIndex('food'))
+  })
+
+  it('returns a valid palette index', () => {
+    for (const name of ['餐飲', '交通', '購物', '房租', '水電', '醫療', '娛樂', '孝親', '子女教育', '日用品', '通訊', '其他', 'Starbucks', 'X']) {
+      const i = categoryPaletteIndex(name)
+      expect(i).toBeGreaterThanOrEqual(0)
+      expect(i).toBeLessThan(CATEGORY_PALETTE.length)
+    }
+  })
+
+  it('distributes across palette slots reasonably (not all zero)', () => {
+    const names = ['餐飲', '交通', '購物', '房租', '水電', '醫療', '娛樂', '孝親', '子女教育', '日用品', '通訊', '其他']
+    const indices = new Set(names.map(categoryPaletteIndex))
+    // With 12 inputs across 12 slots, expect at least 5 distinct hits
+    expect(indices.size).toBeGreaterThanOrEqual(5)
+  })
+})
+
+describe('categoryColor', () => {
+  it('returns both bg and fg from palette', () => {
+    const c = categoryColor('餐飲')
+    expect(CATEGORY_PALETTE).toContain(c.bg)
+    expect(CATEGORY_FG_PALETTE).toContain(c.fg)
+  })
+
+  it('bg and fg come from the same palette slot', () => {
+    const i = categoryPaletteIndex('餐飲')
+    expect(categoryColor('餐飲').bg).toBe(CATEGORY_PALETTE[i])
+    expect(categoryColor('餐飲').fg).toBe(CATEGORY_FG_PALETTE[i])
+  })
+
+  it('empty/null defaults to slot 0', () => {
+    const c = categoryColor('')
+    expect(c.bg).toBe(CATEGORY_PALETTE[0])
+    expect(c.fg).toBe(CATEGORY_FG_PALETTE[0])
+  })
+})
+
+describe('palette shape invariants', () => {
+  it('bg and fg arrays have matching length', () => {
+    expect(CATEGORY_PALETTE.length).toBe(CATEGORY_FG_PALETTE.length)
+  })
+
+  it('palette has at least 8 colours for enough variety', () => {
+    expect(CATEGORY_PALETTE.length).toBeGreaterThanOrEqual(8)
+  })
+})

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -18,6 +18,7 @@ import { useCategories } from '@/lib/hooks/use-categories'
 import { deleteExpense, updateExpense, loadMoreExpenses } from '@/lib/services/expense-service'
 import { recomputeSplitsForAmount } from '@/lib/scale-splits'
 import { InlineExpenseEditRow } from '@/components/inline-expense-edit-row'
+import { categoryColor } from '@/lib/category-color'
 import { logger } from '@/lib/logger'
 import { currency, toDate, fmtDateFull, paymentLabel } from '@/lib/utils'
 import { useAuth, getActor } from '@/lib/auth'
@@ -595,12 +596,18 @@ export default function RecordsPage() {
                   ) : (
                     <div key={e.id} className="card p-4 space-y-2 group relative">
                       <div className="flex items-start gap-3">
-                        <div
-                          className="w-10 h-10 rounded-lg flex items-center justify-center text-lg shrink-0"
-                          style={{ backgroundColor: 'color-mix(in oklch, var(--primary), transparent 85%)' }}
-                        >
-                          {e.isShared ? '👥' : '👤'}
-                        </div>
+                        {(() => {
+                          const color = categoryColor(e.category)
+                          return (
+                            <div
+                              className="w-10 h-10 rounded-lg flex items-center justify-center text-lg shrink-0"
+                              style={{ backgroundColor: color.bg, color: color.fg }}
+                              title={e.category}
+                            >
+                              {e.isShared ? '👥' : '👤'}
+                            </div>
+                          )
+                        })()}
                         <div className="flex-1 min-w-0">
                           <div className="font-medium truncate">{e.description}</div>
                           <div className="text-xs text-[var(--muted-foreground)] mt-0.5">

--- a/src/components/recent-expenses-list.tsx
+++ b/src/components/recent-expenses-list.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { currency, toDate, fmtDate } from '@/lib/utils'
+import { categoryColor } from '@/lib/category-color'
 import type { Expense } from '@/lib/types'
 
 interface RecentExpensesListProps {
@@ -27,14 +28,17 @@ export function RecentExpensesList({ expenses }: RecentExpensesListProps) {
 
   return (
     <div className="space-y-1">
-      {expenses.map((e) => (
+      {expenses.map((e) => {
+        const color = categoryColor(e.category)
+        return (
         <div
           key={e.id}
           className="group flex items-center gap-3 py-2 rounded-lg hover:bg-[var(--muted)] px-2 -mx-2 transition-colors"
         >
           <div
             className="w-9 h-9 rounded-lg flex items-center justify-center text-lg flex-shrink-0"
-            style={{ backgroundColor: 'color-mix(in oklch, var(--primary), transparent 85%)' }}
+            style={{ backgroundColor: color.bg, color: color.fg }}
+            title={e.category}
           >
             {e.isShared ? '👥' : '👤'}
           </div>
@@ -54,7 +58,8 @@ export function RecentExpensesList({ expenses }: RecentExpensesListProps) {
             📋
           </button>
         </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/src/lib/category-color.ts
+++ b/src/lib/category-color.ts
@@ -1,0 +1,75 @@
+/**
+ * Deterministic category → accent color mapping (Issue #242).
+ *
+ * Each category name maps to one of `CATEGORY_PALETTE`, a hand-picked set
+ * of 12 OKLCH colours that are visually distinct and avoid the app's
+ * destructive/alert reds. Same name → same colour across the whole app.
+ *
+ * Hash uses a simple FNV-1a variant — we don't need cryptographic strength,
+ * just stable distribution across the small palette. Pure function, safe
+ * to call in render paths.
+ */
+
+export const CATEGORY_PALETTE: readonly string[] = [
+  'oklch(92% 0.05 30)',  // peach
+  'oklch(92% 0.05 80)',  // butter
+  'oklch(92% 0.05 130)', // lime
+  'oklch(92% 0.05 160)', // mint
+  'oklch(92% 0.05 200)', // sky
+  'oklch(92% 0.05 240)', // periwinkle
+  'oklch(92% 0.05 280)', // lavender
+  'oklch(92% 0.05 310)', // pink
+  'oklch(88% 0.06 60)',  // sand
+  'oklch(88% 0.06 180)', // aqua
+  'oklch(88% 0.06 260)', // iris
+  'oklch(88% 0.06 340)', // rose (pale, not destructive)
+] as const
+
+export const CATEGORY_FG_PALETTE: readonly string[] = [
+  'oklch(35% 0.08 30)',
+  'oklch(35% 0.08 80)',
+  'oklch(35% 0.08 130)',
+  'oklch(35% 0.08 160)',
+  'oklch(35% 0.08 200)',
+  'oklch(35% 0.08 240)',
+  'oklch(35% 0.08 280)',
+  'oklch(35% 0.08 310)',
+  'oklch(32% 0.10 60)',
+  'oklch(32% 0.10 180)',
+  'oklch(32% 0.10 260)',
+  'oklch(32% 0.10 340)',
+] as const
+
+function hashString(s: string): number {
+  // FNV-1a 32-bit variant
+  let h = 0x811c9dc5
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return h >>> 0
+}
+
+/**
+ * Get the index into the palette for a given category name.
+ * Normalizes (trim + lowercase) so "餐飲" and "餐飲 " collide.
+ */
+export function categoryPaletteIndex(name: string | undefined | null): number {
+  if (!name) return 0
+  const normalized = name.trim().toLowerCase()
+  if (!normalized) return 0
+  return hashString(normalized) % CATEGORY_PALETTE.length
+}
+
+export interface CategoryColorPair {
+  bg: string
+  fg: string
+}
+
+export function categoryColor(name: string | undefined | null): CategoryColorPair {
+  const i = categoryPaletteIndex(name)
+  return {
+    bg: CATEGORY_PALETTE[i],
+    fg: CATEGORY_FG_PALETTE[i],
+  }
+}


### PR DESCRIPTION
## Summary
Records 卡片與首頁最近記錄加上穩定的 category 顏色 icon 背景。

## Changes
- \`src/lib/category-color.ts\` — \`categoryColor(name)\` + \`categoryPaletteIndex\`
- \`src/components/recent-expenses-list.tsx\` — apply
- \`src/app/(auth)/records/page.tsx\` — apply
- \`__tests__/category-color.test.ts\` — 10 cases

## Design
- 12 OKLCH palette，避開 destructive 紅
- FNV-1a hash，deterministic，同 category 永遠同色
- 不取代 👥/👤 shared/personal 標示——顏色是額外視覺軸

## Test plan
- [x] 10 tests pass
- [x] typecheck + lint 乾淨（pre-existing warning 不變）
- [ ] 部署後視覺驗證：
  - 餐飲/交通/購物 三色明顯不同
  - 同 category 跨頁一致
  - Dark mode 下仍可讀（fg/bg pair）

Closes #242