### PR TITLE
feat(mobile): 存支出 haptic 震動回饋 (Closes #248)

### DIFF
--- a/__tests__/haptic.test.ts
+++ b/__tests__/haptic.test.ts
@@ -1,0 +1,77 @@
+import { hapticFeedback, isHapticSupported } from '@/lib/haptic'
+
+describe('isHapticSupported', () => {
+  const originalNavigator = globalThis.navigator
+
+  afterEach(() => {
+    // @ts-expect-error restore original navigator after test
+    globalThis.navigator = originalNavigator
+  })
+
+  it('returns false when navigator is undefined (SSR)', () => {
+    // @ts-expect-error simulate SSR
+    delete globalThis.navigator
+    expect(isHapticSupported()).toBe(false)
+  })
+
+  it('returns false when navigator has no vibrate', () => {
+    // @ts-expect-error minimal navigator without vibrate
+    globalThis.navigator = {}
+    expect(isHapticSupported()).toBe(false)
+  })
+
+  it('returns true when navigator.vibrate is a function', () => {
+    // @ts-expect-error navigator.vibrate function provided for support check
+    globalThis.navigator = { vibrate: () => true }
+    expect(isHapticSupported()).toBe(true)
+  })
+})
+
+describe('hapticFeedback', () => {
+  const originalNavigator = globalThis.navigator
+
+  afterEach(() => {
+    // @ts-expect-error restore original navigator after test
+    globalThis.navigator = originalNavigator
+  })
+
+  it('no-ops on unsupported browser (does not throw)', () => {
+    // @ts-expect-error assign empty navigator for unsupported check
+    globalThis.navigator = {}
+    expect(() => hapticFeedback('success')).not.toThrow()
+  })
+
+  it('invokes navigator.vibrate with a number pattern for success', () => {
+    const spy = jest.fn().mockReturnValue(true)
+    // @ts-expect-error mock navigator with vibrate spy
+    globalThis.navigator = { vibrate: spy }
+    hapticFeedback('success')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(40)
+  })
+
+  it('invokes navigator.vibrate with an array pattern for error', () => {
+    const spy = jest.fn().mockReturnValue(true)
+    // @ts-expect-error mock navigator with vibrate spy
+    globalThis.navigator = { vibrate: spy }
+    hapticFeedback('error')
+    expect(spy).toHaveBeenCalledWith([60, 40, 60])
+  })
+
+  it('invokes navigator.vibrate with a short pattern for light', () => {
+    const spy = jest.fn().mockReturnValue(true)
+    // @ts-expect-error mock navigator
+    globalThis.navigator = { vibrate: spy }
+    hapticFeedback('light')
+    expect(spy).toHaveBeenCalledWith(15)
+  })
+
+  it('swallows exceptions from vibrate and does not propagate', () => {
+    const spy = jest.fn().mockImplementation(() => {
+      throw new Error('security denied')
+    })
+    // @ts-expect-error mock navigator with throwing vibrate
+    globalThis.navigator = { vibrate: spy }
+    expect(() => hapticFeedback('warning')).not.toThrow()
+  })
+})

--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -12,6 +12,7 @@ import { findLastSettlementBetween, formatSettlementAge } from '@/lib/settlement
 import { useToast } from '@/components/toast'
 import { currency, signedCurrency, toDate, fmtDateFull } from '@/lib/utils'
 import { Skeleton } from '@/components/ui/skeleton'
+import { hapticFeedback } from '@/lib/haptic'
 import { useAuth, getActor } from '@/lib/auth'
 import { useCurrentMember } from '@/lib/hooks/use-current-member'
 
@@ -158,9 +159,11 @@ export default function SplitPage() {
         amount: d.amount,
       })), actor)
       addToast(`已結清 ${debts.length} 筆債務`, 'success')
+      hapticFeedback('success')
     } catch (e) {
       logger.error('[SplitPage] Failed to settle all:', e)
       addToast('批次結清失敗', 'error')
+      hapticFeedback('error')
     } finally {
       setSettlingAll(false)
     }
@@ -226,6 +229,7 @@ export default function SplitPage() {
     }, getActor(user))
     setSettling(null)
     addToast('已記錄轉帳', 'success')
+    hapticFeedback('success')
   }
 
   function buildShareText() {

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -22,6 +22,7 @@ import { saveButtonLabel, type UploadProgress } from '@/lib/save-button-label'
 import { findPossibleDuplicate } from '@/lib/duplicate-expense-detector'
 import { evaluateAmountExpression } from '@/lib/amount-expression'
 import { AmountChips } from '@/components/amount-chips'
+import { hapticFeedback } from '@/lib/haptic'
 import { useSubmitGuard } from '@/lib/hooks/use-submit-guard'
 import { ref as storageRef, getDownloadURL } from 'firebase/storage'
 import { storage } from '@/lib/firebase'
@@ -576,10 +577,12 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
         if (draftKey && typeof window !== 'undefined') {
           sessionStorage.removeItem(draftKey)
         }
+        hapticFeedback('success')
         onSaved()
       } catch (e: unknown) {
         if (e instanceof ReceiptUploadError) setError(`圖片上傳失敗：${e.message}`)
         else setError(e instanceof Error ? e.message : '儲存失敗')
+        hapticFeedback('error')
       } finally {
         setUploadProgress({ current: 0, total: 0 })
       }

--- a/src/components/quick-add-bar.tsx
+++ b/src/components/quick-add-bar.tsx
@@ -18,6 +18,7 @@ import { buildDuplicateHref } from '@/lib/quick-add-duplicate'
 import { evaluateAmountExpression } from '@/lib/amount-expression'
 import { AmountChips } from '@/components/amount-chips'
 import { useSpeechRecognition, type SpeechErrorCode } from '@/hooks/use-speech-recognition'
+import { hapticFeedback } from '@/lib/haptic'
 import { logger } from '@/lib/logger'
 
 function speechErrorMessage(code: SpeechErrorCode): string {
@@ -250,6 +251,7 @@ export function QuickAddBar() {
           }
         })
         addToast(`已記錄 ${description.trim()} $${amt}`, 'success')
+        hapticFeedback('success')
         clearDraft()
         setDescription('')
         setAmount('')
@@ -259,6 +261,7 @@ export function QuickAddBar() {
       } catch (e) {
         logger.error('[QuickAdd] Failed:', e)
         addToast('記帳失敗，請重試', 'error')
+        hapticFeedback('error')
       }
     })
   }

--- a/src/lib/haptic.ts
+++ b/src/lib/haptic.ts
@@ -1,0 +1,42 @@
+/**
+ * Haptic feedback wrapper (Issue #248).
+ *
+ * Uses the Web Vibration API (`navigator.vibrate`) where supported —
+ * Android Chrome, Firefox, Edge. iOS Safari silently no-ops (not a bug,
+ * Apple has deliberately not implemented the API). Wrapped in try/catch
+ * so any browser quirk degrades gracefully.
+ *
+ * Keep patterns short (< 100ms total). Longer vibrations are jarring and
+ * drain battery for no perceivable benefit.
+ */
+
+export type HapticKind = 'success' | 'light' | 'warning' | 'error'
+
+const PATTERNS: Record<HapticKind, number | readonly number[]> = {
+  light: 15,
+  success: 40,
+  warning: [30, 30] as const,
+  error: [60, 40, 60] as const,
+}
+
+/**
+ * Feature-detect — callable from tests and components.
+ */
+export function isHapticSupported(): boolean {
+  if (typeof navigator === 'undefined') return false
+  return typeof navigator.vibrate === 'function'
+}
+
+/**
+ * Fire a haptic cue. Safe to call from any browser; unsupported browsers
+ * silently skip. Never throws.
+ */
+export function hapticFeedback(kind: HapticKind): void {
+  try {
+    if (!isHapticSupported()) return
+    const pattern = PATTERNS[kind]
+    navigator.vibrate(pattern as number | number[])
+  } catch {
+    // Safari iOS or locked-down env: swallow. No-op is the contract.
+  }
+}


### PR DESCRIPTION
## Summary
- Android Chrome / Firefox 存支出、結算、批次清帳時手機震一下
- iOS Safari 不支援 API → silently no-op
- 錯誤 pattern 更長提醒（60-40-60）

## Changes
- \`src/lib/haptic.ts\` — 安全 wrapper + \`isHapticSupported\`
- \`src/components/quick-add-bar.tsx\` / \`src/components/expense-form.tsx\` / \`src/app/(auth)/split/page.tsx\` — 成功/失敗路徑注入

## Test plan
- [x] 8 tests pass
- [x] typecheck / lint 乾淨（pre-existing warning 不變）
- [ ] 部署後 Android 手動驗證：
  - QuickAdd 存 → 短震
  - 失敗 → 長震
  - iOS Safari 存支出 → 無震動、也無錯誤

Closes #248