### PR TITLE
feat(settings/recurring): 顯示下次/上次生成日 (Closes #250)

### DIFF
--- a/__tests__/recurring-next.test.ts
+++ b/__tests__/recurring-next.test.ts
@@ -1,0 +1,116 @@
+import {
+  nextOccurrenceAfter,
+  relativeDaysLabel,
+  formatShortDate,
+} from '@/lib/recurring-next'
+import type { RecurringExpense } from '@/lib/types'
+
+function mkTemplate(partial: Partial<RecurringExpense>): RecurringExpense {
+  return {
+    id: 't1',
+    groupId: 'g1',
+    description: '租金',
+    amount: 20000,
+    category: '房租',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'transfer',
+    frequency: 'monthly',
+    dayOfMonth: 5,
+    startDate: new Date(2026, 0, 5),
+    endDate: null,
+    lastGeneratedAt: null,
+    isPaused: false,
+    createdBy: 'u1',
+    createdAt: new Date(2026, 0, 1),
+    updatedAt: new Date(2026, 0, 1),
+    ...partial,
+  } as RecurringExpense
+}
+
+describe('nextOccurrenceAfter', () => {
+  it('monthly: finds next month-day-5 after 2026-04-10', () => {
+    const now = new Date(2026, 3, 10)
+    const next = nextOccurrenceAfter(mkTemplate({ frequency: 'monthly', dayOfMonth: 5 }), now)
+    expect(next?.getFullYear()).toBe(2026)
+    expect(next?.getMonth()).toBe(4) // May
+    expect(next?.getDate()).toBe(5)
+  })
+
+  it('monthly: finds this month day-15 when we ask on day-10', () => {
+    const now = new Date(2026, 3, 10)
+    const next = nextOccurrenceAfter(mkTemplate({ frequency: 'monthly', dayOfMonth: 15 }), now)
+    expect(next?.getMonth()).toBe(3)
+    expect(next?.getDate()).toBe(15)
+  })
+
+  it('weekly: finds next target day-of-week', () => {
+    // 2026-04-18 is a Saturday (day 6). Ask on Friday 2026-04-17 for Sunday (0)
+    const now = new Date(2026, 3, 17) // Friday
+    const next = nextOccurrenceAfter(mkTemplate({ frequency: 'weekly', dayOfWeek: 0 }), now)
+    expect(next?.getDay()).toBe(0)
+    // Next Sunday from Friday 4/17 is 4/19
+    expect(next?.getDate()).toBe(19)
+  })
+
+  it('yearly: finds next Jan 1 occurrence', () => {
+    const now = new Date(2026, 3, 10)
+    const next = nextOccurrenceAfter(
+      mkTemplate({ frequency: 'yearly', monthOfYear: 1, dayOfMonth: 1 }),
+      now,
+    )
+    expect(next?.getFullYear()).toBe(2027)
+    expect(next?.getMonth()).toBe(0)
+    expect(next?.getDate()).toBe(1)
+  })
+
+  it('returns null when endDate is past', () => {
+    const now = new Date(2026, 5, 10)
+    const next = nextOccurrenceAfter(
+      mkTemplate({ frequency: 'monthly', dayOfMonth: 5, endDate: new Date(2026, 3, 5) }),
+      now,
+    )
+    expect(next).toBeNull()
+  })
+
+  it('respects endDate when it falls within lookahead', () => {
+    const now = new Date(2026, 3, 1)
+    const endDate = new Date(2026, 3, 10) // 4/10
+    const next = nextOccurrenceAfter(
+      mkTemplate({ frequency: 'monthly', dayOfMonth: 5, endDate }),
+      now,
+    )
+    expect(next?.getDate()).toBe(5) // 4/5 still reachable before end
+  })
+})
+
+describe('relativeDaysLabel', () => {
+  const NOW = new Date(2026, 3, 10) // April 10
+
+  it.each([
+    [new Date(2026, 3, 10), '今天'],
+    [new Date(2026, 3, 11), '明天'],
+    [new Date(2026, 3, 9), '昨天'],
+    [new Date(2026, 3, 17), '7 天後'],
+    [new Date(2026, 3, 3), '7 天前'],
+    [new Date(2026, 4, 10), '30 天後'],
+  ])('%s → %s', (target, expected) => {
+    expect(relativeDaysLabel(target, NOW)).toBe(expected)
+  })
+
+  it('zero-times-out: intra-day times still count as 今天', () => {
+    const now = new Date(2026, 3, 10, 8, 0)
+    const target = new Date(2026, 3, 10, 22, 30)
+    expect(relativeDaysLabel(target, now)).toBe('今天')
+  })
+})
+
+describe('formatShortDate', () => {
+  it('formats as YYYY/M/D (non-padded)', () => {
+    expect(formatShortDate(new Date(2026, 0, 5))).toBe('2026/1/5')
+    expect(formatShortDate(new Date(2026, 11, 25))).toBe('2026/12/25')
+  })
+})

--- a/src/app/(auth)/settings/recurring/page.tsx
+++ b/src/app/(auth)/settings/recurring/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/services/recurring-expense-service'
 import { buildEqualSplits } from '@/lib/services/split-calculator'
 import { currency } from '@/lib/utils'
+import { nextOccurrenceAfter, relativeDaysLabel, formatShortDate } from '@/lib/recurring-next'
 import type { RecurringExpense, RecurringFrequency } from '@/lib/types'
 import { logger } from '@/lib/logger'
 import { useToast } from '@/components/toast'
@@ -258,6 +259,49 @@ export default function RecurringPage() {
                   付款人：{item.payerName}
                 </span>
               </div>
+
+              {/* Next / last generation (Issue #250) */}
+              {(() => {
+                if (item.isPaused) {
+                  return (
+                    <div className="text-xs text-[var(--muted-foreground)] italic">
+                      📅 已暫停，不會自動生成
+                    </div>
+                  )
+                }
+                const now = new Date()
+                const next = nextOccurrenceAfter(item, now)
+                const last = item.lastGeneratedAt
+                  ? (item.lastGeneratedAt instanceof Date
+                      ? item.lastGeneratedAt
+                      : 'toDate' in item.lastGeneratedAt
+                        ? (item.lastGeneratedAt as { toDate: () => Date }).toDate()
+                        : null)
+                  : null
+                return (
+                  <div className="text-xs text-[var(--muted-foreground)] space-y-0.5">
+                    {next && (
+                      <div>
+                        📅 下次：<span className="font-medium text-[var(--foreground)]">{formatShortDate(next)}</span>
+                        <span className="ml-1">（{relativeDaysLabel(next, now)}）</span>
+                      </div>
+                    )}
+                    {!next && (
+                      <div>📅 下次：<span className="italic">無（endDate 已過或設定）</span></div>
+                    )}
+                    <div>
+                      🕓 上次：{last ? (
+                        <>
+                          <span className="font-medium text-[var(--foreground)]">{formatShortDate(last)}</span>
+                          <span className="ml-1">（{relativeDaysLabel(last, now)}）</span>
+                        </>
+                      ) : (
+                        <span className="italic">尚未生成</span>
+                      )}
+                    </div>
+                  </div>
+                )
+              })()}
 
               {/* Actions */}
               <div className="flex items-center gap-2 pt-1">

--- a/src/lib/recurring-next.ts
+++ b/src/lib/recurring-next.ts
@@ -1,0 +1,51 @@
+/**
+ * Next-occurrence helpers for the recurring-expense settings UI (Issue #250).
+ *
+ * Thin wrapper over getNextOccurrences — returns a single upcoming date or
+ * null, and provides a relative-day label ("今天" / "明天" / "N 天後").
+ * Used to surface the next scheduled auto-generation on each card without
+ * waiting for the generator sweep to fire.
+ */
+import { getNextOccurrences } from '@/lib/recurring-occurrences'
+import type { RecurringExpense } from '@/lib/types'
+
+/** How far ahead to search for the next occurrence. 1 year covers all freqs. */
+const LOOKAHEAD_MS = 366 * 24 * 60 * 60 * 1000
+
+export function nextOccurrenceAfter(template: RecurringExpense, now: Date): Date | null {
+  const end = template.endDate instanceof Date
+    ? template.endDate
+    : template.endDate && 'toDate' in template.endDate
+      ? template.endDate.toDate()
+      : null
+  const searchUntil = new Date(now.getTime() + LOOKAHEAD_MS)
+  const before = end && end < searchUntil ? end : searchUntil
+  if (before <= now) return null
+  const dates = getNextOccurrences(template, now, before)
+  return dates[0] ?? null
+}
+
+/**
+ * Short relative-day label for a future date relative to `now`.
+ * - 0 days → "今天"
+ * - 1 day → "明天"
+ * - >1 → "N 天後"
+ * - <0 → "N 天前" (used for lastGeneratedAt)
+ */
+export function relativeDaysLabel(target: Date, now: Date): string {
+  const msPerDay = 86_400_000
+  // Zero out time portion for day-level comparison
+  const a = Date.UTC(target.getFullYear(), target.getMonth(), target.getDate())
+  const b = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())
+  const diffDays = Math.round((a - b) / msPerDay)
+  if (diffDays === 0) return '今天'
+  if (diffDays === 1) return '明天'
+  if (diffDays === -1) return '昨天'
+  if (diffDays > 0) return `${diffDays} 天後`
+  return `${Math.abs(diffDays)} 天前`
+}
+
+/** Format a Date as YYYY/M/D for compact display. */
+export function formatShortDate(d: Date): string {
+  return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`
+}

--- a/src/lib/recurring-occurrences.ts
+++ b/src/lib/recurring-occurrences.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure occurrence-date math for recurring templates.
+ *
+ * Extracted from `recurring-generator.ts` so tests can import without
+ * pulling in Firebase initialization (Issue #250). The generator still
+ * re-exports from here for back-compat with existing call sites.
+ */
+import type { RecurringExpense } from '@/lib/types'
+
+/**
+ * Returns all occurrence dates for a recurring template that fall in the range (after, before].
+ * Both boundaries are exclusive on the left and inclusive on the right.
+ */
+export function getNextOccurrences(template: RecurringExpense, after: Date, before: Date): Date[] {
+  const dates: Date[] = []
+
+  if (template.frequency === 'weekly') {
+    const targetDay = template.dayOfWeek ?? 1 // default Monday
+    const cursor = new Date(after)
+    cursor.setHours(0, 0, 0, 0)
+    cursor.setDate(cursor.getDate() + 1)
+
+    while (cursor <= before) {
+      if (cursor.getDay() === targetDay) {
+        dates.push(new Date(cursor))
+        if (dates.length >= 12) break
+      }
+      cursor.setDate(cursor.getDate() + 1)
+    }
+  } else if (template.frequency === 'monthly') {
+    const targetDay = template.dayOfMonth ?? 1
+    const cursor = new Date(after)
+    cursor.setHours(0, 0, 0, 0)
+    cursor.setDate(1)
+
+    while (cursor <= before) {
+      const year = cursor.getFullYear()
+      const month = cursor.getMonth()
+      const lastDay = new Date(year, month + 1, 0).getDate()
+      const day = Math.min(targetDay, lastDay)
+      const candidate = new Date(year, month, day, 0, 0, 0, 0)
+      if (candidate > after && candidate <= before) {
+        dates.push(candidate)
+        if (dates.length >= 12) break
+      }
+      cursor.setMonth(cursor.getMonth() + 1)
+    }
+  } else if (template.frequency === 'yearly') {
+    const targetMonth = (template.monthOfYear ?? 1) - 1
+    const targetDay = template.dayOfMonth ?? 1
+
+    for (let year = after.getFullYear(); year <= before.getFullYear(); year++) {
+      const lastDay = new Date(year, targetMonth + 1, 0).getDate()
+      const day = Math.min(targetDay, lastDay)
+      const candidate = new Date(year, targetMonth, day, 0, 0, 0, 0)
+      if (candidate > after && candidate <= before) {
+        dates.push(candidate)
+        if (dates.length >= 12) break
+      }
+    }
+  }
+
+  return dates
+}

--- a/src/lib/services/recurring-generator.ts
+++ b/src/lib/services/recurring-generator.ts
@@ -5,63 +5,10 @@ import type { RecurringExpense } from '@/lib/types'
 
 const SWEEP_THROTTLE_MS = 6 * 60 * 60 * 1000 // 6 hours
 
-/**
- * Returns all occurrence dates for a recurring template that fall in the range (after, before].
- * Both boundaries are exclusive on the left and inclusive on the right.
- */
-export function getNextOccurrences(template: RecurringExpense, after: Date, before: Date): Date[] {
-  const dates: Date[] = []
-
-  if (template.frequency === 'weekly') {
-    const targetDay = template.dayOfWeek ?? 1 // default Monday
-    // Start from the day after `after`, scan forward
-    const cursor = new Date(after)
-    cursor.setHours(0, 0, 0, 0)
-    cursor.setDate(cursor.getDate() + 1)
-
-    while (cursor <= before) {
-      if (cursor.getDay() === targetDay) {
-        dates.push(new Date(cursor))
-        if (dates.length >= 12) break
-      }
-      cursor.setDate(cursor.getDate() + 1)
-    }
-  } else if (template.frequency === 'monthly') {
-    const targetDay = template.dayOfMonth ?? 1
-    // Iterate month-by-month starting from the month containing `after`
-    const cursor = new Date(after)
-    cursor.setHours(0, 0, 0, 0)
-    cursor.setDate(1) // go to first of the month to avoid skipping months
-
-    while (cursor <= before) {
-      const year = cursor.getFullYear()
-      const month = cursor.getMonth()
-      const lastDay = new Date(year, month + 1, 0).getDate()
-      const day = Math.min(targetDay, lastDay)
-      const candidate = new Date(year, month, day, 0, 0, 0, 0)
-      if (candidate > after && candidate <= before) {
-        dates.push(candidate)
-        if (dates.length >= 12) break
-      }
-      cursor.setMonth(cursor.getMonth() + 1)
-    }
-  } else if (template.frequency === 'yearly') {
-    const targetMonth = (template.monthOfYear ?? 1) - 1 // 0-indexed
-    const targetDay = template.dayOfMonth ?? 1
-
-    for (let year = after.getFullYear(); year <= before.getFullYear(); year++) {
-      const lastDay = new Date(year, targetMonth + 1, 0).getDate()
-      const day = Math.min(targetDay, lastDay)
-      const candidate = new Date(year, targetMonth, day, 0, 0, 0, 0)
-      if (candidate > after && candidate <= before) {
-        dates.push(candidate)
-        if (dates.length >= 12) break
-      }
-    }
-  }
-
-  return dates
-}
+// Re-export for back-compat — pure occurrence math lives in its own file so
+// tests can import it without pulling in Firebase init. Issue #250.
+export { getNextOccurrences } from '@/lib/recurring-occurrences'
+import { getNextOccurrences } from '@/lib/recurring-occurrences'
 
 /**
  * Generates pending expense documents for all non-paused recurring templates in a group.


### PR DESCRIPTION
## Summary
- 每張定期支出卡片加 📅「下次 X/Y」+ 🕓「上次 X/Y」兩行 metadata
- 暫停時顯示「已暫停不會自動生成」
- 支援 weekly / monthly / yearly 三種 frequency + endDate lookahead cutoff

## Architecture refactor
\`getNextOccurrences\` 原本住在 \`recurring-generator.ts\`（該檔 import Firebase），測試無法單測。抽到新 \`recurring-occurrences.ts\` 純檔；generator re-export 保持 API 穩定，0 caller 需要改動。

## Changes
- **New**: \`recurring-occurrences.ts\` (pure)、\`recurring-next.ts\` (helpers)、\`__tests__/recurring-next.test.ts\` (14 cases)
- **Refactor**: \`recurring-generator.ts\` re-export
- **UI**: \`settings/recurring/page.tsx\` 顯示 next/last

## Test plan
- [x] 14 unit tests pass
- [x] typecheck + lint 乾淨
- [ ] 部署後驗證：
  - 月中打開 → 本月已過 day-5 租金顯示「下次：下月 5 號」
  - 週一收入 → 今天是週日 → 顯示「明天」
  - 暫停的定期 → 顯示「已暫停不會自動生成」
  - 尚未生成的 → 顯示「尚未生成」

Closes #250