### PR TITLE
feat(expense-form): 上次此類別金額提示 (Closes #252)

### DIFF
--- a/__tests__/last-category-expense.test.ts
+++ b/__tests__/last-category-expense.test.ts
@@ -1,0 +1,87 @@
+import { findLastExpenseByCategory, relativeDays } from '@/lib/last-category-expense'
+import type { Expense } from '@/lib/types'
+
+function mk(id: string, category: string, daysAgo: number, amount = 100): Expense {
+  const now = new Date(2026, 3, 10) // 2026-04-10
+  const d = new Date(now)
+  d.setDate(d.getDate() - daysAgo)
+  return {
+    id,
+    groupId: 'g1',
+    description: `e-${id}`,
+    amount,
+    category,
+    isShared: true,
+    payerId: 'm1',
+    payerName: '爸',
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('findLastExpenseByCategory', () => {
+  it('returns null for empty category', () => {
+    expect(findLastExpenseByCategory([mk('a', '餐飲', 1)], '')).toBeNull()
+    expect(findLastExpenseByCategory([mk('a', '餐飲', 1)], null)).toBeNull()
+    expect(findLastExpenseByCategory([mk('a', '餐飲', 1)], undefined)).toBeNull()
+    expect(findLastExpenseByCategory([mk('a', '餐飲', 1)], '   ')).toBeNull()
+  })
+
+  it('returns null when no match', () => {
+    expect(findLastExpenseByCategory([mk('a', '餐飲', 1)], '交通')).toBeNull()
+  })
+
+  it('returns the newest matching category', () => {
+    const list = [
+      mk('old', '餐飲', 5, 100),
+      mk('newest', '餐飲', 1, 200),
+      mk('mid', '餐飲', 3, 150),
+    ]
+    const m = findLastExpenseByCategory(list, '餐飲')
+    expect(m?.expense.id).toBe('newest')
+    expect(m?.expense.amount).toBe(200)
+  })
+
+  it('ignores records without a category', () => {
+    const list = [mk('no-cat', '', 1), mk('match', '餐飲', 5)]
+    const m = findLastExpenseByCategory(list, '餐飲')
+    expect(m?.expense.id).toBe('match')
+  })
+
+  it('trims and lowercases both sides', () => {
+    const m = findLastExpenseByCategory([mk('a', '餐飲 ', 1)], ' 餐飲')
+    expect(m?.expense.id).toBe('a')
+    // English case
+    const m2 = findLastExpenseByCategory([mk('b', 'Food', 1)], 'FOOD')
+    expect(m2?.expense.id).toBe('b')
+  })
+
+  it('excludes by id when editing', () => {
+    const list = [mk('being-edited', '餐飲', 1, 200), mk('other', '餐飲', 3, 100)]
+    const m = findLastExpenseByCategory(list, '餐飲', 'being-edited')
+    expect(m?.expense.id).toBe('other')
+  })
+
+  it('returns null when only match is excluded', () => {
+    const list = [mk('only', '餐飲', 1)]
+    expect(findLastExpenseByCategory(list, '餐飲', 'only')).toBeNull()
+  })
+})
+
+describe('relativeDays', () => {
+  const NOW = new Date(2026, 3, 10)
+  it.each([
+    [new Date(2026, 3, 10), '今天'],
+    [new Date(2026, 3, 9), '昨天'],
+    [new Date(2026, 3, 3), '7 天前'],
+    [new Date(2026, 3, 11), '明天'],
+    [new Date(2026, 3, 15), '5 天後'],
+  ])('%s → %s', (target, expected) => {
+    expect(relativeDays(target, NOW)).toBe(expected)
+  })
+})

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -23,6 +23,8 @@ import { findPossibleDuplicate } from '@/lib/duplicate-expense-detector'
 import { evaluateAmountExpression } from '@/lib/amount-expression'
 import { AmountChips } from '@/components/amount-chips'
 import { hapticFeedback } from '@/lib/haptic'
+import { findLastExpenseByCategory, relativeDays } from '@/lib/last-category-expense'
+import { currency as fmtCurrency } from '@/lib/utils'
 import { useSubmitGuard } from '@/lib/hooks/use-submit-guard'
 import { ref as storageRef, getDownloadURL } from 'firebase/storage'
 import { storage } from '@/lib/firebase'
@@ -749,6 +751,20 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
               : group.children.map((c) => <option key={c} value={c}>{c}</option>)
           })}
         </select>
+        {(() => {
+          // Hint: "上次此類別金額" (Issue #252). Only show when there's a
+          // distinct previous record — exclude the expense currently being
+          // edited so it doesn't cite itself.
+          if (!category) return null
+          const match = findLastExpenseByCategory(expenses, category, existingExpense?.id)
+          if (!match) return null
+          return (
+            <p className="text-xs text-[var(--muted-foreground)] mt-1.5">
+              💡 上次「{category}」：<span className="font-medium text-[var(--foreground)]">{fmtCurrency(match.expense.amount)}</span>
+              <span className="ml-1">（{relativeDays(match.date, new Date())}）</span>
+            </p>
+          )
+        })()}
       </div>
 
       {/* 付款方式 */}

--- a/src/components/quick-add-bar.tsx
+++ b/src/components/quick-add-bar.tsx
@@ -17,6 +17,8 @@ import { buildDraftKey, parseDraft, serializeDraft } from '@/lib/quick-add-draft
 import { buildDuplicateHref } from '@/lib/quick-add-duplicate'
 import { evaluateAmountExpression } from '@/lib/amount-expression'
 import { AmountChips } from '@/components/amount-chips'
+import { findLastExpenseByCategory, relativeDays } from '@/lib/last-category-expense'
+import { currency } from '@/lib/utils'
 import { useSpeechRecognition, type SpeechErrorCode } from '@/hooks/use-speech-recognition'
 import { hapticFeedback } from '@/lib/haptic'
 import { logger } from '@/lib/logger'
@@ -367,6 +369,19 @@ export function QuickAddBar() {
 
       {/* 金額快捷 chips — 允許 700+150 直接輸入也支援 */}
       <AmountChips value={amount} onChange={setAmount} />
+
+      {/* 上次此類別金額提示 (Issue #252) */}
+      {(() => {
+        if (!category) return null
+        const match = findLastExpenseByCategory(expenses, category)
+        if (!match) return null
+        return (
+          <p className="text-xs text-[var(--muted-foreground)]">
+            💡 上次「{category}」：<span className="font-medium text-[var(--foreground)]">{currency(match.expense.amount)}</span>
+            <span className="ml-1">（{relativeDays(match.date, new Date())}）</span>
+          </p>
+        )
+      })()}
 
       {/* 類別 chips */}
       <div className="flex flex-wrap items-center gap-1.5">

--- a/src/lib/last-category-expense.ts
+++ b/src/lib/last-category-expense.ts
@@ -1,0 +1,53 @@
+/**
+ * Find the most recent expense matching a category for the "上次此類別金額"
+ * hint on expense forms (Issue #252). Pure function — the caller holds the
+ * expenses array (already sorted desc by date via useExpenses).
+ *
+ * Matches case-insensitive, trimmed category — so "餐飲" and " 餐飲 " collide.
+ * Returns null when the category is empty or no match exists.
+ */
+import { toDate } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+export interface LastCategoryMatch {
+  expense: Expense
+  date: Date
+}
+
+export function findLastExpenseByCategory(
+  expenses: readonly Expense[],
+  category: string | undefined | null,
+  /** Optional exclude id — used when editing an expense so we don't cite itself. */
+  excludeId?: string,
+): LastCategoryMatch | null {
+  if (!category) return null
+  const normalized = category.trim().toLowerCase()
+  if (!normalized) return null
+
+  let best: LastCategoryMatch | null = null
+  for (const e of expenses) {
+    if (excludeId && e.id === excludeId) continue
+    if (!e.category) continue
+    if (e.category.trim().toLowerCase() !== normalized) continue
+    const d = toDate(e.date)
+    if (!best || d > best.date) best = { expense: e, date: d }
+  }
+  return best
+}
+
+/**
+ * Short relative-day label. Reused logic pattern identical to
+ * recurring-next.ts — kept inline here to avoid a cross-module import
+ * for a 5-line helper.
+ */
+export function relativeDays(target: Date, now: Date): string {
+  const msPerDay = 86_400_000
+  const a = Date.UTC(target.getFullYear(), target.getMonth(), target.getDate())
+  const b = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())
+  const diff = Math.round((a - b) / msPerDay)
+  if (diff === 0) return '今天'
+  if (diff === -1) return '昨天'
+  if (diff < 0) return `${Math.abs(diff)} 天前`
+  if (diff === 1) return '明天'
+  return `${diff} 天後`
+}


### PR DESCRIPTION
## Summary
選完類別後，表單顯示 💡「上次『餐飲』：NT\$ 150（3 天前）」muted 提示。

## Why
常見消費（便利商店、飲料、加油）類別固定但金額變動小。提示幫助快速 recall，不用到 records 頁翻找。

## Test plan
- [x] 12 unit tests pass
- [x] typecheck 乾淨
- [ ] 部署後驗證：
  - 選餐飲 → 顯示最近一筆餐飲金額
  - 切到沒用過的類別 → 不顯示
  - 編輯一筆支出 → 不顯示自己（excludeId 生效）

Closes #252