### PR TITLE
feat(records/home): 自己付款顯示「我付」(Closes #262)

### DIFF
--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -13,6 +13,7 @@ import { useSwipe } from '@/hooks/use-swipe'
 import { usePullToRefresh } from '@/hooks/use-pull-to-refresh'
 import { useGroup } from '@/lib/hooks/use-group'
 import { useExpenses } from '@/lib/hooks/use-expenses'
+import { useCurrentMember } from '@/lib/hooks/use-current-member'
 import { useMembers } from '@/lib/hooks/use-members'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { deleteExpense, updateExpense, loadMoreExpenses } from '@/lib/services/expense-service'
@@ -48,6 +49,7 @@ export default function RecordsPage() {
   const { members } = useMembers()
   const { categories } = useCategories()
   const { user } = useAuth()
+  const { currentMemberId } = useCurrentMember(group?.id)
   const { addToast } = useToast()
   const searchParams = useSearchParams()
 
@@ -632,7 +634,12 @@ export default function RecordsPage() {
                         <div className="flex-1 min-w-0">
                           <div className="font-medium truncate">{e.description}</div>
                           <div className="text-xs text-[var(--muted-foreground)] mt-0.5">
-                            {e.category} · {e.payerName}付
+                            {e.category} ·{' '}
+                            {currentMemberId && e.payerId === currentMemberId ? (
+                              <span className="font-semibold text-[var(--foreground)]">我付</span>
+                            ) : (
+                              <>{e.payerName}付</>
+                            )}
                           </div>
                         </div>
                       </div>

--- a/src/components/recent-expenses-list.tsx
+++ b/src/components/recent-expenses-list.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from 'next/navigation'
 import { currency, toDate, fmtDate } from '@/lib/utils'
 import { categoryColor } from '@/lib/category-color'
+import { useGroup } from '@/lib/hooks/use-group'
+import { useCurrentMember } from '@/lib/hooks/use-current-member'
 import type { Expense } from '@/lib/types'
 
 interface RecentExpensesListProps {
@@ -16,6 +18,8 @@ interface RecentExpensesListProps {
  */
 export function RecentExpensesList({ expenses }: RecentExpensesListProps) {
   const router = useRouter()
+  const { group } = useGroup()
+  const { currentMemberId } = useCurrentMember(group?.id)
 
   if (expenses.length === 0) {
     return (
@@ -45,7 +49,12 @@ export function RecentExpensesList({ expenses }: RecentExpensesListProps) {
           <div className="flex-1 min-w-0">
             <div className="font-medium text-sm truncate">{e.description}</div>
             <div className="text-xs text-[var(--muted-foreground)]">
-              {fmtDate(toDate(e.date))} · {e.category} · {e.payerName}付
+              {fmtDate(toDate(e.date))} · {e.category} ·{' '}
+              {currentMemberId && e.payerId === currentMemberId ? (
+                <span className="font-semibold text-[var(--foreground)]">我付</span>
+              ) : (
+                <>{e.payerName}付</>
+              )}
             </div>
           </div>
           <div className="font-semibold text-sm">{currency(e.amount)}</div>


### PR DESCRIPTION
expense.payerId === currentMemberId 時顯示粗體「我付」，否則「{payerName} 付」。Closes #262