### PR TITLE
feat(home): 成員花費分布條 (Closes #264)

### DIFF
--- a/__tests__/member-spending.test.ts
+++ b/__tests__/member-spending.test.ts
@@ -1,0 +1,103 @@
+import { aggregateMemberSpending } from '@/lib/member-spending'
+import type { Expense, FamilyMember } from '@/lib/types'
+
+function mkMember(id: string, name: string): FamilyMember {
+  return { id, name, role: 'member', addedAt: new Date(), addedBy: 'u1' } as unknown as FamilyMember
+}
+
+function mkExpense(id: string, payerId: string, amount: number, payerName?: string): Expense {
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId,
+    payerName: payerName ?? payerId,
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: new Date(),
+    createdAt: new Date(),
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('aggregateMemberSpending', () => {
+  const members: FamilyMember[] = [mkMember('m1', '爸'), mkMember('m2', '媽')]
+
+  it('returns rows for every member when no expenses', () => {
+    const rows = aggregateMemberSpending([], members)
+    expect(rows).toHaveLength(2)
+    expect(rows.every((r) => r.paid === 0)).toBe(true)
+    expect(rows.every((r) => r.share === 0)).toBe(true)
+  })
+
+  it('aggregates paid amounts per payerId', () => {
+    const expenses = [
+      mkExpense('e1', 'm1', 100),
+      mkExpense('e2', 'm1', 200),
+      mkExpense('e3', 'm2', 50),
+    ]
+    const rows = aggregateMemberSpending(expenses, members)
+    expect(rows[0]).toMatchObject({ memberId: 'm1', paid: 300 })
+    expect(rows[1]).toMatchObject({ memberId: 'm2', paid: 50 })
+  })
+
+  it('sorts rows desc by paid amount', () => {
+    const expenses = [mkExpense('e1', 'm1', 50), mkExpense('e2', 'm2', 100)]
+    const rows = aggregateMemberSpending(expenses, members)
+    expect(rows[0].memberId).toBe('m2')
+    expect(rows[1].memberId).toBe('m1')
+  })
+
+  it('computes share as fraction of total', () => {
+    const expenses = [mkExpense('e1', 'm1', 60), mkExpense('e2', 'm2', 40)]
+    const rows = aggregateMemberSpending(expenses, members)
+    const m1 = rows.find((r) => r.memberId === 'm1')!
+    const m2 = rows.find((r) => r.memberId === 'm2')!
+    expect(m1.share).toBeCloseTo(0.6)
+    expect(m2.share).toBeCloseTo(0.4)
+  })
+
+  it('includes payerIds NOT in members list (historical removed members)', () => {
+    const expenses = [
+      mkExpense('e1', 'm1', 100),
+      mkExpense('e2', 'ghost', 50, '已移除成員'),
+    ]
+    const rows = aggregateMemberSpending(expenses, members)
+    const ghost = rows.find((r) => r.memberId === 'ghost')
+    expect(ghost).toBeDefined()
+    expect(ghost?.memberName).toBe('已移除成員')
+    expect(ghost?.paid).toBe(50)
+  })
+
+  it('skips expenses with no payerId', () => {
+    const expenses = [
+      mkExpense('e1', 'm1', 100),
+      // @ts-expect-error testing defensive guard
+      mkExpense('e2', '', 50),
+    ]
+    const rows = aggregateMemberSpending(expenses, members)
+    const total = rows.reduce((s, r) => s + r.paid, 0)
+    expect(total).toBe(100)
+  })
+
+  it('skips expenses with non-finite amount', () => {
+    const expenses = [
+      mkExpense('e1', 'm1', 100),
+      mkExpense('e2', 'm1', NaN),
+      mkExpense('e3', 'm1', Infinity),
+    ]
+    const rows = aggregateMemberSpending(expenses, members)
+    expect(rows.find((r) => r.memberId === 'm1')?.paid).toBe(100)
+  })
+
+  it('share is 0 when total is 0 even with zero-amount expenses', () => {
+    const expenses = [mkExpense('e1', 'm1', 0)]
+    const rows = aggregateMemberSpending(expenses, members)
+    expect(rows.every((r) => r.share === 0)).toBe(true)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -16,6 +16,7 @@ import { BudgetProgress } from '@/components/budget-progress'
 import { RecentActivitySection } from '@/components/recent-activity-section'
 import { SimpleTabs } from '@/components/simple-tabs'
 import { RecentExpensesList } from '@/components/recent-expenses-list'
+import { MemberSpendingBreakdown } from '@/components/member-spending-breakdown'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
 import { logger } from '@/lib/logger'
@@ -261,6 +262,22 @@ export default function HomePage() {
               <div className="text-lg font-bold mt-1">{debts.length} 筆</div>
             </div>
           </div>
+
+          {/* 成員花費分布 (Issue #264) */}
+          {(() => {
+            const monthStart = new Date(now.getFullYear(), now.getMonth(), 1)
+            const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+            const fmt = (d: Date) =>
+              `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+            return (
+              <MemberSpendingBreakdown
+                expenses={monthly}
+                members={members}
+                monthStart={fmt(monthStart)}
+                monthEnd={fmt(monthEnd)}
+              />
+            )
+          })()}
         </div>
 
         {/* 誰欠誰 — 左欄；空狀態折疊為單行避免浪費垂直空間 (Issue #222) */}

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -118,7 +118,8 @@ export default function RecordsPage() {
   // "all time"). Issue #185.
   const [dateStart, setDateStart] = useState(() => searchParams.get('start') || currentMonthRange().start)
   const [dateEnd, setDateEnd] = useState(() => searchParams.get('end') || currentMonthRange().end)
-  const [payerFilter, setPayerFilter] = useState('')
+  // Init from URL ?payer=<id> for home-page drill-downs (Issue #264).
+  const [payerFilter, setPayerFilter] = useState(() => searchParams.get('payer') ?? '')
   const [categoryFilter, setCategoryFilter] = useState(() => searchParams.get('category') ?? '')
   // Amount-range quick filter (Issue #221). Initial value from URL; sync back
   // to URL on change so the chip selection persists across reloads and can be

--- a/src/components/member-spending-breakdown.tsx
+++ b/src/components/member-spending-breakdown.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { aggregateMemberSpending } from '@/lib/member-spending'
+import { categoryColor } from '@/lib/category-color'
+import { currency } from '@/lib/utils'
+import type { Expense, FamilyMember } from '@/lib/types'
+
+interface MemberSpendingBreakdownProps {
+  expenses: Expense[]
+  members: FamilyMember[]
+  /** ISO YYYY-MM-DD inclusive — used to build the drill-down URL. */
+  monthStart: string
+  monthEnd: string
+}
+
+/**
+ * Per-member "paid as payer" breakdown bar chart on home (Issue #264).
+ * Click a row → /records?payer=<id>&start=<>&end=<>.
+ */
+export function MemberSpendingBreakdown({
+  expenses,
+  members,
+  monthStart,
+  monthEnd,
+}: MemberSpendingBreakdownProps) {
+  const rows = useMemo(
+    () => aggregateMemberSpending(expenses, members),
+    [expenses, members],
+  )
+
+  // Hide entirely when no spending recorded — avoids blank zeros.
+  const total = rows.reduce((s, r) => s + r.paid, 0)
+  if (total === 0) return null
+
+  return (
+    <div className="space-y-1.5 pt-2 border-t border-[var(--border)]">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        💸 本月成員花費分布
+      </div>
+      <div className="space-y-1">
+        {rows.map((row) => {
+          if (row.paid === 0) return null
+          const color = categoryColor(row.memberName) // reuse stable hash palette
+          const pct = Math.round(row.share * 100)
+          const href = `/records?payer=${encodeURIComponent(row.memberId)}&start=${monthStart}&end=${monthEnd}`
+          return (
+            <Link
+              key={row.memberId}
+              href={href}
+              title={`查看 ${row.memberName} 本月支出`}
+              className="flex items-center gap-2 text-sm py-1.5 px-2 -mx-2 rounded-lg hover:bg-[var(--muted)] transition-colors"
+            >
+              <span
+                className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold flex-shrink-0"
+                style={{ backgroundColor: color.bg, color: color.fg }}
+                aria-hidden
+              >
+                {row.memberName.charAt(0)}
+              </span>
+              <span className="w-16 font-medium truncate">{row.memberName}</span>
+              <div className="flex-1 h-2 rounded-full bg-[var(--muted)] overflow-hidden">
+                <div
+                  className="h-full rounded-full"
+                  style={{ width: `${pct}%`, backgroundColor: color.fg, opacity: 0.6 }}
+                />
+              </div>
+              <span className="w-12 text-right text-xs text-[var(--muted-foreground)]">
+                {pct}%
+              </span>
+              <span className="w-24 text-right font-semibold tabular-nums">
+                {currency(row.paid)}
+              </span>
+            </Link>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/member-spending.ts
+++ b/src/lib/member-spending.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-member spending aggregation for the home page breakdown widget
+ * (Issue #264). "Spending" here means amount the member fronted as payer
+ * (matches the "X 付" UX semantic), not their share of split.
+ *
+ * Pure function — caller passes already-filtered expenses (typically the
+ * current month). Returns rows sorted desc by amount, including 0-amount
+ * members so the UI can choose to hide or grey them.
+ */
+import type { Expense, FamilyMember } from '@/lib/types'
+
+export interface MemberSpendingRow {
+  memberId: string
+  memberName: string
+  paid: number
+  /** Share of the total spending (0..1). 0 when total is 0. */
+  share: number
+}
+
+export function aggregateMemberSpending(
+  expenses: readonly Expense[],
+  members: readonly FamilyMember[],
+): MemberSpendingRow[] {
+  const totals = new Map<string, number>()
+  for (const e of expenses) {
+    if (!e.payerId) continue
+    if (typeof e.amount !== 'number' || !Number.isFinite(e.amount)) continue
+    totals.set(e.payerId, (totals.get(e.payerId) ?? 0) + e.amount)
+  }
+
+  const grandTotal = [...totals.values()].reduce((s, v) => s + v, 0)
+
+  // Build rows for every member so we get stable ordering even with zero spend
+  const rows: MemberSpendingRow[] = members.map((m) => {
+    const paid = totals.get(m.id) ?? 0
+    const share = grandTotal > 0 ? paid / grandTotal : 0
+    return { memberId: m.id, memberName: m.name, paid, share }
+  })
+
+  // Append rows for payerIds that aren't in the members list (e.g. removed
+  // members who still appear as historical payerName). Use payerName from any
+  // expense that has it for display.
+  const knownIds = new Set(members.map((m) => m.id))
+  for (const e of expenses) {
+    if (!e.payerId || knownIds.has(e.payerId)) continue
+    knownIds.add(e.payerId)
+    const paid = totals.get(e.payerId) ?? 0
+    rows.push({
+      memberId: e.payerId,
+      memberName: e.payerName ?? e.payerId,
+      paid,
+      share: grandTotal > 0 ? paid / grandTotal : 0,
+    })
+  }
+
+  rows.sort((a, b) => b.paid - a.paid)
+  return rows
+}


### PR DESCRIPTION
## Summary
首頁月支出摘要加「💸 本月成員花費分布」進度條，依 paid 金額 desc 列出每位成員，click → 該成員月份明細。

## Changes
- \`src/lib/member-spending.ts\` — pure aggregator
- \`src/components/member-spending-breakdown.tsx\` — UI
- \`src/app/(auth)/page.tsx\` — 整合
- \`src/app/(auth)/records/page.tsx\` — 支援 \`?payer=\` URL param
- \`__tests__/member-spending.test.ts\` — 8 cases

## Test plan
- [x] 8 unit tests pass
- [x] tsc / eslint 乾淨
- [ ] 部署後驗證：
  - 多 payer 月份顯示分布條
  - 點擊跳對 records 篩選
  - 全 0 筆月份不顯示 widget

Closes #264