### PR TITLE
feat(statistics): Top 3 最大支出 card (Closes #278)

### DIFF
--- a/__tests__/top-expenses.test.ts
+++ b/__tests__/top-expenses.test.ts
@@ -1,0 +1,89 @@
+import { topNExpenses } from '@/lib/top-expenses'
+import type { Expense } from '@/lib/types'
+
+function mk(id: string, amount: number, date: Date): Expense {
+  return {
+    id,
+    groupId: 'g1',
+    description: `e-${id}`,
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date,
+    createdAt: date,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('topNExpenses', () => {
+  it('returns empty for n=0', () => {
+    expect(topNExpenses([mk('a', 100, new Date(2026, 0, 1))], 0)).toEqual([])
+  })
+
+  it('returns empty for negative n', () => {
+    expect(topNExpenses([mk('a', 100, new Date())], -1)).toEqual([])
+  })
+
+  it('returns empty for empty input', () => {
+    expect(topNExpenses([], 3)).toEqual([])
+  })
+
+  it('returns all when n exceeds list size', () => {
+    const list = [mk('a', 100, new Date(2026, 0, 1))]
+    expect(topNExpenses(list, 5)).toHaveLength(1)
+  })
+
+  it('sorts by amount desc', () => {
+    const list = [
+      mk('a', 50, new Date(2026, 0, 1)),
+      mk('b', 200, new Date(2026, 0, 2)),
+      mk('c', 100, new Date(2026, 0, 3)),
+    ]
+    const top = topNExpenses(list, 3)
+    expect(top.map((e) => e.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('tie-breaks by newer date first when amounts equal', () => {
+    const list = [
+      mk('older', 100, new Date(2026, 0, 1)),
+      mk('newer', 100, new Date(2026, 0, 5)),
+      mk('mid', 100, new Date(2026, 0, 3)),
+    ]
+    const top = topNExpenses(list, 3)
+    expect(top.map((e) => e.id)).toEqual(['newer', 'mid', 'older'])
+  })
+
+  it('skips non-finite amounts', () => {
+    const list = [
+      mk('a', 100, new Date(2026, 0, 1)),
+      mk('nan', NaN, new Date(2026, 0, 2)),
+      mk('inf', Infinity, new Date(2026, 0, 3)),
+      mk('b', 50, new Date(2026, 0, 4)),
+    ]
+    const top = topNExpenses(list, 5)
+    expect(top.map((e) => e.id)).toEqual(['a', 'b'])
+  })
+
+  it('returns exactly n when list has more', () => {
+    const list = Array.from({ length: 10 }, (_, i) =>
+      mk(String(i), i * 10, new Date(2026, 0, i + 1)),
+    )
+    expect(topNExpenses(list, 3)).toHaveLength(3)
+  })
+
+  it('handles records with bad date gracefully (sorts to bottom on tie)', () => {
+    const bad = { ...mk('bad', 100, new Date()), date: 'oops' } as unknown as Expense
+    const good = mk('good', 100, new Date(2026, 0, 1))
+    const top = topNExpenses([bad, good], 2)
+    // Both with amount=100; good has valid date (2026-01-01 = positive ts),
+    // bad has t=0 → good ranks first (newer).
+    expect(top[0]?.id).toBe('good')
+    expect(top[1]?.id).toBe('bad')
+  })
+})

--- a/src/app/(auth)/statistics/page.tsx
+++ b/src/app/(auth)/statistics/page.tsx
@@ -7,6 +7,7 @@ import { useMembers } from '@/lib/hooks/use-members'
 import { useExpenses } from '@/lib/hooks/use-expenses'
 import { toDate, fmtDateFull, currency } from '@/lib/utils'
 import { aggregateYearStats } from '@/lib/year-stats'
+import { TopExpensesCard } from '@/components/top-expenses-card'
 import type { Expense } from '@/lib/types'
 import type { StatisticsChartsProps } from '@/components/statistics-charts'
 
@@ -155,7 +156,7 @@ function SummaryCards({ expenses, prevExpenses }: { expenses: Expense[]; prevExp
 // ── Page ───────────────────────────────────────────────────────
 
 export default function StatisticsPage() {
-  const { loading: groupLoading } = useGroup()
+  const { group, loading: groupLoading } = useGroup()
   const { expenses, loading: expLoading } = useExpenses()
   const { members, loading: membersLoading } = useMembers()
 
@@ -269,6 +270,9 @@ export default function StatisticsPage() {
 
       {/* Summary */}
       <SummaryCards expenses={monthExpenses} prevExpenses={prevMonthExpenses} />
+
+      {/* Top 3 expenses (Issue #278) */}
+      <TopExpensesCard expenses={monthExpenses} groupId={group?.id} />
 
       {/* Charts — lazily loaded to avoid including recharts in initial bundle */}
       <StatisticsCharts

--- a/src/components/top-expenses-card.tsx
+++ b/src/components/top-expenses-card.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { topNExpenses } from '@/lib/top-expenses'
+import { categoryColor } from '@/lib/category-color'
+import { currency, fmtDate, toDate } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface TopExpensesCardProps {
+  expenses: Expense[]
+  /** Optional groupId for deep-link query suffix; matches existing /expense/[id] href shape. */
+  groupId?: string
+  /** How many to show. Default 3. */
+  count?: number
+  /** Optional title override. */
+  title?: string
+}
+
+/**
+ * "Top N largest expenses" card for the /statistics page (Issue #278).
+ * Hidden entirely when there are no expenses to show.
+ */
+export function TopExpensesCard({ expenses, groupId, count = 3, title }: TopExpensesCardProps) {
+  const top = useMemo(() => topNExpenses(expenses, count), [expenses, count])
+
+  if (top.length === 0) return null
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        {title ?? `💰 本月最大支出 (Top ${top.length})`}
+      </div>
+      <div className="space-y-1.5">
+        {top.map((e, i) => {
+          const color = categoryColor(e.category)
+          const href = groupId
+            ? `/expense/${e.id}?groupId=${groupId}`
+            : `/expense/${e.id}`
+          return (
+            <Link
+              key={e.id}
+              href={href}
+              className="flex items-center gap-3 py-2 px-2 -mx-2 rounded-lg hover:bg-[var(--muted)] transition-colors"
+              title={`查看詳情：${e.description}`}
+            >
+              <span
+                className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0"
+                style={{ backgroundColor: color.bg, color: color.fg }}
+                aria-hidden
+              >
+                {i + 1}
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="font-medium text-sm truncate">{e.description}</div>
+                <div className="text-xs text-[var(--muted-foreground)]">
+                  {e.category} · {fmtDate(toDate(e.date))} · {e.payerName}付
+                </div>
+              </div>
+              <div className="font-semibold tabular-nums">{currency(e.amount)}</div>
+            </Link>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/top-expenses.ts
+++ b/src/lib/top-expenses.ts
@@ -1,0 +1,30 @@
+/**
+ * Pick the N largest expenses for a "top spends" widget (Issue #278).
+ *
+ * Pure function. Sort key: amount desc; tie-break: newer date first
+ * (so today's NT$1000 outranks yesterday's same-amount). Skips
+ * non-finite amounts defensively.
+ */
+import { toDate } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+export function topNExpenses(expenses: readonly Expense[], n: number): Expense[] {
+  if (n <= 0) return []
+  const valid: Array<{ e: Expense; t: number }> = []
+  for (const e of expenses) {
+    if (typeof e.amount !== 'number' || !Number.isFinite(e.amount)) continue
+    let t: number
+    try {
+      const d = toDate(e.date)
+      t = d.getTime()
+    } catch {
+      t = 0
+    }
+    valid.push({ e, t })
+  }
+  valid.sort((a, b) => {
+    if (b.e.amount !== a.e.amount) return b.e.amount - a.e.amount
+    return b.t - a.t
+  })
+  return valid.slice(0, n).map((v) => v.e)
+}


### PR DESCRIPTION
/statistics 加 Top N 大支出 card，desc by amount + tie-break by newer date。9 tests cover edges。Closes #278