### PR TITLE
feat(statistics): 月度記事 Money Diary — 敘事體月度回顧 (Closes #282)

### DIFF
--- a/__tests__/money-diary.test.ts
+++ b/__tests__/money-diary.test.ts
@@ -1,0 +1,232 @@
+import { extractDiaryFacts, composeDiarySentences } from '@/lib/money-diary'
+import type { Expense } from '@/lib/types'
+
+function mk(
+  id: string,
+  amount: number,
+  category: string,
+  date: Date,
+  payerName = '爸',
+  description?: string,
+): Expense {
+  return {
+    id,
+    groupId: 'g1',
+    description: description ?? `desc-${id}`,
+    amount,
+    category,
+    payerId: 'm1',
+    payerName,
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date,
+    createdAt: date,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('extractDiaryFacts', () => {
+  it('returns zero-state for empty month', () => {
+    const f = extractDiaryFacts({ monthExpenses: [], earlierExpenses: [], previousMonthTotal: null })
+    expect(f.totals.current).toBe(0)
+    expect(f.totals.deltaPct).toBeNull()
+    expect(f.largest).toBeNull()
+    expect(f.topByCount).toBeNull()
+    expect(f.newCategories).toEqual([])
+    expect(f.busiestDay).toBeNull()
+    expect(f.expenseCount).toBe(0)
+  })
+
+  it('computes total and delta vs previous month', () => {
+    const expenses = [mk('a', 100, '餐飲', new Date(2026, 3, 5))]
+    const f = extractDiaryFacts({
+      monthExpenses: expenses,
+      earlierExpenses: [],
+      previousMonthTotal: 200,
+    })
+    expect(f.totals.current).toBe(100)
+    expect(f.totals.previous).toBe(200)
+    expect(f.totals.deltaPct).toBe(-50)
+  })
+
+  it('delta null when previous month is 0 (no useful comparison)', () => {
+    const expenses = [mk('a', 100, '餐飲', new Date(2026, 3, 5))]
+    const f = extractDiaryFacts({
+      monthExpenses: expenses,
+      earlierExpenses: [],
+      previousMonthTotal: 0,
+    })
+    expect(f.totals.deltaPct).toBeNull()
+  })
+
+  it('finds the single largest expense', () => {
+    const expenses = [
+      mk('a', 100, '餐飲', new Date(2026, 3, 1)),
+      mk('big', 5000, '購物', new Date(2026, 3, 15)),
+      mk('b', 200, '交通', new Date(2026, 3, 10)),
+    ]
+    const f = extractDiaryFacts({ monthExpenses: expenses, earlierExpenses: [], previousMonthTotal: null })
+    expect(f.largest?.id).toBe('big')
+  })
+
+  it('detects top-by-count category', () => {
+    const expenses = [
+      mk('a', 100, '餐飲', new Date(2026, 3, 1)),
+      mk('b', 100, '餐飲', new Date(2026, 3, 2)),
+      mk('c', 100, '餐飲', new Date(2026, 3, 3)),
+      mk('d', 500, '購物', new Date(2026, 3, 4)),
+    ]
+    const f = extractDiaryFacts({ monthExpenses: expenses, earlierExpenses: [], previousMonthTotal: null })
+    expect(f.topByCount?.category).toBe('餐飲')
+    expect(f.topByCount?.count).toBe(3)
+    expect(f.topByCount?.total).toBe(300)
+  })
+
+  it('detects new categories that appeared this month but not before', () => {
+    const earlier = [mk('e1', 100, '餐飲', new Date(2026, 2, 1))]
+    const monthExpenses = [
+      mk('a', 100, '餐飲', new Date(2026, 3, 1)), // existing
+      mk('b', 12000, '子女教育', new Date(2026, 3, 5)), // new
+      mk('c', 300, '其他', new Date(2026, 3, 10)), // new
+    ]
+    const f = extractDiaryFacts({ monthExpenses, earlierExpenses: earlier, previousMonthTotal: null })
+    const newNames = f.newCategories.map((c) => c.category)
+    expect(newNames).toContain('子女教育')
+    expect(newNames).toContain('其他')
+    expect(newNames).not.toContain('餐飲')
+    // Sorted desc by total
+    expect(f.newCategories[0].category).toBe('子女教育')
+  })
+
+  it('finds busiest day by total', () => {
+    const expenses = [
+      mk('a', 100, 'X', new Date(2026, 3, 1)),
+      mk('b', 200, 'X', new Date(2026, 3, 5)),
+      mk('c', 300, 'X', new Date(2026, 3, 5)), // same day → total 500
+      mk('d', 400, 'X', new Date(2026, 3, 10)),
+    ]
+    const f = extractDiaryFacts({ monthExpenses: expenses, earlierExpenses: [], previousMonthTotal: null })
+    expect(f.busiestDay?.dateKey).toBe('2026/4/5')
+    expect(f.busiestDay?.total).toBe(500)
+    expect(f.busiestDay?.count).toBe(2)
+  })
+
+  it('skips records with non-finite amount in all calculations', () => {
+    const expenses = [
+      mk('a', 100, 'X', new Date(2026, 3, 1)),
+      mk('bad', NaN, 'X', new Date(2026, 3, 2)),
+    ]
+    const f = extractDiaryFacts({ monthExpenses: expenses, earlierExpenses: [], previousMonthTotal: null })
+    expect(f.totals.current).toBe(100)
+    expect(f.expenseCount).toBe(1)
+  })
+
+  it('expenseCount only counts finite-amount records', () => {
+    const expenses = [
+      mk('a', 100, 'X', new Date(2026, 3, 1)),
+      mk('b', 200, 'X', new Date(2026, 3, 2)),
+      mk('bad', Infinity, 'X', new Date(2026, 3, 3)),
+    ]
+    const f = extractDiaryFacts({ monthExpenses: expenses, earlierExpenses: [], previousMonthTotal: null })
+    expect(f.expenseCount).toBe(2)
+  })
+})
+
+describe('composeDiarySentences', () => {
+  const month = { year: 2026, month: 3 } // April
+
+  it('returns empty array when no expenses', () => {
+    const facts = extractDiaryFacts({ monthExpenses: [], earlierExpenses: [], previousMonthTotal: null })
+    expect(composeDiarySentences(facts, month)).toEqual([])
+  })
+
+  it('omits delta sentence when previous month null', () => {
+    const facts = extractDiaryFacts({
+      monthExpenses: [mk('a', 100, 'X', new Date(2026, 3, 1))],
+      earlierExpenses: [],
+      previousMonthTotal: null,
+    })
+    const lines = composeDiarySentences(facts, month)
+    // First sentence should mention total but not "vs 上月"
+    expect(lines[0]).toContain('100')
+    expect(lines[0]).not.toContain('比上月')
+  })
+
+  it('reports persistent total when delta is 0%', () => {
+    const facts = extractDiaryFacts({
+      monthExpenses: [mk('a', 100, 'X', new Date(2026, 3, 1))],
+      earlierExpenses: [],
+      previousMonthTotal: 100,
+    })
+    const lines = composeDiarySentences(facts, month)
+    expect(lines[0]).toContain('持平')
+  })
+
+  it('mentions delta direction when non-zero', () => {
+    const facts = extractDiaryFacts({
+      monthExpenses: [mk('a', 200, 'X', new Date(2026, 3, 1))],
+      earlierExpenses: [],
+      previousMonthTotal: 100,
+    })
+    const lines = composeDiarySentences(facts, month)
+    expect(lines[0]).toContain('多花 100%')
+  })
+
+  it('skips top-by-count sentence when count < 2', () => {
+    const facts = extractDiaryFacts({
+      monthExpenses: [mk('a', 100, '餐飲', new Date(2026, 3, 1))],
+      earlierExpenses: [],
+      previousMonthTotal: null,
+    })
+    const lines = composeDiarySentences(facts, month)
+    expect(lines.find((l) => l.includes('最頻繁'))).toBeUndefined()
+  })
+
+  it('produces multi-paragraph diary for rich month', () => {
+    const expenses = [
+      mk('a', 100, '餐飲', new Date(2026, 3, 1), '爸', '早餐'),
+      mk('b', 100, '餐飲', new Date(2026, 3, 2), '媽', '午餐'),
+      mk('c', 100, '餐飲', new Date(2026, 3, 3), '爸', '晚餐'),
+      mk('big', 5000, '購物', new Date(2026, 3, 15), '媽', '家樂福'),
+      mk('new', 12000, '子女教育', new Date(2026, 3, 5), '爸', '學費'),
+    ]
+    const facts = extractDiaryFacts({
+      monthExpenses: expenses,
+      earlierExpenses: [],
+      previousMonthTotal: 10000,
+    })
+    const lines = composeDiarySentences(facts, month)
+    expect(lines.length).toBeGreaterThanOrEqual(3)
+    // 12000 學費 is largest — should appear in 最大一筆 sentence
+    expect(lines.join('\n')).toContain('學費')
+    // 餐飲 has 3 entries — top-by-count sentence
+    expect(lines.join('\n')).toContain('餐飲')
+    // 子女教育 is one of the new categories
+    expect(lines.join('\n')).toContain('子女教育')
+    // Delta sentence
+    expect(lines.join('\n')).toContain('比上月')
+  })
+
+  it('mentions only top 2 new categories when there are many', () => {
+    const monthExpenses = [
+      mk('a', 100, 'A', new Date(2026, 3, 1)),
+      mk('b', 200, 'B', new Date(2026, 3, 2)),
+      mk('c', 300, 'C', new Date(2026, 3, 3)),
+    ]
+    const facts = extractDiaryFacts({
+      monthExpenses,
+      earlierExpenses: [],
+      previousMonthTotal: null,
+    })
+    const lines = composeDiarySentences(facts, month)
+    const newCatLine = lines.find((l) => l.includes('第一次出現'))
+    expect(newCatLine).toBeTruthy()
+    // Should pick C and B (top 2 by total) — not A
+    expect(newCatLine).toContain('C')
+    expect(newCatLine).toContain('B')
+    expect(newCatLine).not.toContain('「A」') // 排除 A 出現在引號內
+  })
+})

--- a/src/app/(auth)/statistics/page.tsx
+++ b/src/app/(auth)/statistics/page.tsx
@@ -8,6 +8,7 @@ import { useExpenses } from '@/lib/hooks/use-expenses'
 import { toDate, fmtDateFull, currency } from '@/lib/utils'
 import { aggregateYearStats } from '@/lib/year-stats'
 import { TopExpensesCard } from '@/components/top-expenses-card'
+import { MoneyDiary } from '@/components/money-diary'
 import type { Expense } from '@/lib/types'
 import type { StatisticsChartsProps } from '@/components/statistics-charts'
 
@@ -180,6 +181,24 @@ export default function StatisticsPage() {
     return filterByMonth(expenses, prev.getFullYear(), prev.getMonth())
   }, [expenses, selectedMonth])
 
+  // For Money Diary (Issue #282) — needs all expenses BEFORE the selected
+  // month to detect "first-time" categories.
+  const earlierExpenses = useMemo(() => {
+    const monthStart = new Date(selectedMonth.year, selectedMonth.month, 1).getTime()
+    return expenses.filter((e) => {
+      try {
+        const d = toDate(e.date)
+        return Number.isFinite(d.getTime()) && d.getTime() < monthStart
+      } catch {
+        return false
+      }
+    })
+  }, [expenses, selectedMonth])
+  const previousMonthTotal = useMemo(
+    () => prevMonthExpenses.reduce((s, e) => (typeof e.amount === 'number' && Number.isFinite(e.amount) ? s + e.amount : s), 0),
+    [prevMonthExpenses],
+  )
+
   // The shared expenses subscription is capped at EXPENSE_LIMIT. When we hit the cap,
   // the oldest record we have is a hard floor for any month that predates it.
   // expenses are ordered by date desc, so the last item is the oldest loaded.
@@ -273,6 +292,14 @@ export default function StatisticsPage() {
 
       {/* Top 3 expenses (Issue #278) */}
       <TopExpensesCard expenses={monthExpenses} groupId={group?.id} />
+
+      {/* Money Diary — narrative summary (Issue #282) */}
+      <MoneyDiary
+        monthExpenses={monthExpenses}
+        earlierExpenses={earlierExpenses}
+        previousMonthTotal={previousMonthTotal > 0 ? previousMonthTotal : null}
+        selectedMonth={selectedMonth}
+      />
 
       {/* Charts — lazily loaded to avoid including recharts in initial bundle */}
       <StatisticsCharts

--- a/src/components/money-diary.tsx
+++ b/src/components/money-diary.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useMemo } from 'react'
+import { extractDiaryFacts, composeDiarySentences } from '@/lib/money-diary'
+import type { Expense } from '@/lib/types'
+
+interface MoneyDiaryProps {
+  /** Expenses occurring within the selected month. */
+  monthExpenses: Expense[]
+  /** All expenses prior to selectedMonth — used to detect "first-time" categories. */
+  earlierExpenses: Expense[]
+  /** Total spending in the previous calendar month, or null when unavailable. */
+  previousMonthTotal: number | null
+  /** Selected month (year + 0-indexed month). */
+  selectedMonth: { year: number; month: number }
+}
+
+/**
+ * Renders a narrative diary of the month's spending (Issue #282). Designed
+ * for end-of-month family conversations: reads like a journal entry, not a
+ * dashboard. Returns null when there's nothing to say.
+ */
+export function MoneyDiary({
+  monthExpenses,
+  earlierExpenses,
+  previousMonthTotal,
+  selectedMonth,
+}: MoneyDiaryProps) {
+  const sentences = useMemo(() => {
+    const facts = extractDiaryFacts({
+      monthExpenses,
+      earlierExpenses,
+      previousMonthTotal,
+    })
+    return composeDiarySentences(facts, selectedMonth)
+  }, [monthExpenses, earlierExpenses, previousMonthTotal, selectedMonth])
+
+  if (sentences.length === 0) return null
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        📖 {selectedMonth.year}/{String(selectedMonth.month + 1).padStart(2, '0')} 月度記事
+      </div>
+      <div className="space-y-2">
+        {sentences.map((s, i) => (
+          <p
+            key={i}
+            className="text-sm leading-relaxed text-[var(--foreground)]"
+            // First sentence stands out a touch
+            style={i === 0 ? { fontWeight: 500 } : undefined}
+          >
+            {s}
+          </p>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/money-diary.ts
+++ b/src/lib/money-diary.ts
@@ -1,0 +1,210 @@
+/**
+ * Money Diary — narrative summary of a month's spending (Issue #282).
+ *
+ * Pulls human-shaped facts out of raw expenses and composes them into 5-7
+ * sentences that read like a journal entry, not a dashboard. Each fact is
+ * extracted independently and the composer skips sentences whose data is
+ * absent — so a sparse month produces a short diary instead of awkward
+ * filler. No LLM, no external services. Pure functions, deterministic.
+ */
+import { toDate } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+export interface DiaryFact {
+  /** Total spending in the month and delta vs previous month (null if no prev data). */
+  totals: { current: number; previous: number | null; deltaPct: number | null }
+  /** The single largest expense in the month, if any. */
+  largest: Expense | null
+  /** Most-used category by frequency (count). */
+  topByCount: { category: string; count: number; total: number } | null
+  /** Categories that appear this month but never in any earlier month from the dataset. */
+  newCategories: { category: string; count: number; total: number }[]
+  /** Day with the highest single-day total. */
+  busiestDay: { dateKey: string; total: number; count: number } | null
+  /** Number of expenses in the month. */
+  expenseCount: number
+}
+
+interface ExtractInput {
+  /** Expenses occurring in the selected month. */
+  monthExpenses: readonly Expense[]
+  /** All expenses prior to the selected month (used to detect "new" categories). */
+  earlierExpenses: readonly Expense[]
+  /** Total spending in the previous calendar month, or null when unavailable. */
+  previousMonthTotal: number | null
+}
+
+function safeDate(e: Expense): Date | null {
+  try {
+    const d = toDate(e.date)
+    return Number.isFinite(d.getTime()) ? d : null
+  } catch {
+    return null
+  }
+}
+
+function sumAmount(expenses: readonly Expense[]): number {
+  let total = 0
+  for (const e of expenses) {
+    if (typeof e.amount === 'number' && Number.isFinite(e.amount)) total += e.amount
+  }
+  return total
+}
+
+export function extractDiaryFacts(input: ExtractInput): DiaryFact {
+  const { monthExpenses, earlierExpenses, previousMonthTotal } = input
+
+  // ── totals ──────────────────────────────────────────────────────
+  const current = sumAmount(monthExpenses)
+  let deltaPct: number | null = null
+  if (previousMonthTotal !== null && previousMonthTotal > 0) {
+    deltaPct = Math.round(((current - previousMonthTotal) / previousMonthTotal) * 100)
+  }
+
+  // ── largest expense ─────────────────────────────────────────────
+  let largest: Expense | null = null
+  for (const e of monthExpenses) {
+    if (typeof e.amount !== 'number' || !Number.isFinite(e.amount)) continue
+    if (!largest || e.amount > largest.amount) largest = e
+  }
+
+  // ── top by count + new categories ──────────────────────────────
+  const monthCatCount = new Map<string, { count: number; total: number }>()
+  for (const e of monthExpenses) {
+    if (!e.category) continue
+    if (typeof e.amount !== 'number' || !Number.isFinite(e.amount)) continue
+    const cur = monthCatCount.get(e.category) ?? { count: 0, total: 0 }
+    cur.count += 1
+    cur.total += e.amount
+    monthCatCount.set(e.category, cur)
+  }
+
+  const earlierCats = new Set<string>()
+  for (const e of earlierExpenses) {
+    if (e.category) earlierCats.add(e.category)
+  }
+
+  let topByCount: DiaryFact['topByCount'] = null
+  for (const [category, info] of monthCatCount) {
+    if (!topByCount || info.count > topByCount.count) {
+      topByCount = { category, ...info }
+    }
+  }
+
+  const newCategories: DiaryFact['newCategories'] = []
+  for (const [category, info] of monthCatCount) {
+    if (!earlierCats.has(category)) {
+      newCategories.push({ category, ...info })
+    }
+  }
+  newCategories.sort((a, b) => b.total - a.total)
+
+  // ── busiest day ─────────────────────────────────────────────────
+  const byDay = new Map<string, { total: number; count: number }>()
+  for (const e of monthExpenses) {
+    if (typeof e.amount !== 'number' || !Number.isFinite(e.amount)) continue
+    const d = safeDate(e)
+    if (!d) continue
+    const key = `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`
+    const cur = byDay.get(key) ?? { total: 0, count: 0 }
+    cur.total += e.amount
+    cur.count += 1
+    byDay.set(key, cur)
+  }
+  let busiestDay: DiaryFact['busiestDay'] = null
+  for (const [dateKey, info] of byDay) {
+    if (!busiestDay || info.total > busiestDay.total) {
+      busiestDay = { dateKey, ...info }
+    }
+  }
+
+  return {
+    totals: { current, previous: previousMonthTotal, deltaPct },
+    largest,
+    topByCount,
+    newCategories,
+    busiestDay,
+    expenseCount: monthExpenses.filter(
+      (e) => typeof e.amount === 'number' && Number.isFinite(e.amount),
+    ).length,
+  }
+}
+
+function formatCurrency(n: number): string {
+  return `NT$ ${Math.round(n).toLocaleString('zh-TW')}`
+}
+
+/**
+ * Compose facts into ordered paragraphs. Each entry is one sentence; caller
+ * renders them as separate <p> elements. Sentences whose underlying fact is
+ * missing are dropped so a sparse month yields a short diary.
+ */
+export function composeDiarySentences(
+  facts: DiaryFact,
+  selectedMonth: { year: number; month: number },
+): string[] {
+  if (facts.expenseCount === 0) return []
+
+  const lines: string[] = []
+  const monthLabel = `${selectedMonth.year} 年 ${selectedMonth.month + 1} 月`
+
+  // 1. totals + delta
+  if (facts.totals.deltaPct === null) {
+    lines.push(`${monthLabel}你們花了 ${formatCurrency(facts.totals.current)}，共 ${facts.expenseCount} 筆記錄。`)
+  } else {
+    const direction = facts.totals.deltaPct > 0 ? '多花' : '少花'
+    const abs = Math.abs(facts.totals.deltaPct)
+    if (abs === 0) {
+      lines.push(`${monthLabel}花了 ${formatCurrency(facts.totals.current)}，與上月持平。`)
+    } else {
+      const diff = facts.totals.previous !== null
+        ? Math.abs(facts.totals.current - facts.totals.previous)
+        : null
+      const diffText = diff !== null ? ` — ${direction === '多花' ? '多了' : '省了'} ${formatCurrency(diff)}` : ''
+      lines.push(
+        `${monthLabel}你們花了 ${formatCurrency(facts.totals.current)}，比上月${direction} ${abs}%${diffText}。`,
+      )
+    }
+  }
+
+  // 2. largest expense
+  if (facts.largest) {
+    let dateText = ''
+    const d = safeDate(facts.largest)
+    if (d) dateText = `${d.getMonth() + 1}/${d.getDate()} `
+    const cat = facts.largest.category ? `（${facts.largest.category}）` : ''
+    lines.push(
+      `最大一筆：${facts.largest.payerName} ${dateText}記了「${facts.largest.description}」${formatCurrency(facts.largest.amount)}${cat}。`,
+    )
+  }
+
+  // 3. top by count
+  if (facts.topByCount && facts.topByCount.count >= 2) {
+    lines.push(
+      `${facts.topByCount.category}記了 ${facts.topByCount.count} 次（共 ${formatCurrency(facts.topByCount.total)}），是本月最頻繁的類別。`,
+    )
+  }
+
+  // 4. new categories (cap at 2 to avoid wall of text)
+  if (facts.newCategories.length > 0) {
+    const top = facts.newCategories.slice(0, 2)
+    if (top.length === 1) {
+      lines.push(
+        `本月第一次出現「${top[0].category}」（${formatCurrency(top[0].total)}，${top[0].count} 筆）。`,
+      )
+    } else {
+      lines.push(
+        `本月第一次出現的類別：「${top[0].category}」與「${top[1].category}」。`,
+      )
+    }
+  }
+
+  // 5. busiest day
+  if (facts.busiestDay && facts.busiestDay.count >= 2) {
+    lines.push(
+      `${facts.busiestDay.dateKey} 是花最多的一天：${formatCurrency(facts.busiestDay.total)}（${facts.busiestDay.count} 筆）。`,
+    )
+  }
+
+  return lines
+}


### PR DESCRIPTION
## Idea
Statistics 頁不只 chart，加 narrative。家庭月底回顧時敘事比數字更引發對話。

## Sample output
```
2026 年 4 月你們花了 NT\$ 28,400，比上月少花 12% — 省了 NT\$ 3,800。
最大一筆：媽 4/15 記了「家樂福」NT\$ 5,000（日用品）。
餐飲記了 17 次（共 NT\$ 8,420），是本月最頻繁的類別。
本月第一次出現的類別：「子女教育」與「孝親」。
2026/4/15 是花最多的一天：NT\$ 5,200（3 筆）。
```

## Implementation
- 5 facts extractor + sentence composer，**無 LLM**，純 deterministic
- 缺資料自動跳對應句（單筆月份只顯示 1-2 句）
- 16 unit tests 覆蓋空/邊界/conditional rendering

## Files
- \`src/lib/money-diary.ts\` (pure)
- \`src/components/money-diary.tsx\` (UI)
- \`src/app/(auth)/statistics/page.tsx\` (整合 + earlierExpenses memo)
- \`__tests__/money-diary.test.ts\` (16 cases)

## Why this is new
不是 polish 既有 features，是新類型的「資料說故事」表達方式。可後續延伸更多句型 / 季度版本 / email digest。

Closes #282