### PR TITLE
feat(expense-form): 異常金額偵測 (Closes #284)

### DIFF
--- a/__tests__/amount-outlier.test.ts
+++ b/__tests__/amount-outlier.test.ts
@@ -1,0 +1,257 @@
+import { detectAmountOutlier } from '@/lib/amount-outlier'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15).getTime()
+
+function mk(id: string, amount: number, category: string, daysAgo: number): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description: `e-${id}`,
+    amount,
+    category,
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('detectAmountOutlier', () => {
+  describe('skip conditions', () => {
+    it('returns non-outlier when amount is invalid', () => {
+      const r = detectAmountOutlier({
+        amount: 0,
+        category: '餐飲',
+        expenses: [mk('a', 100, '餐飲', 1)],
+        now: NOW,
+      })
+      expect(r.isOutlier).toBe(false)
+    })
+
+    it('returns non-outlier when category is empty', () => {
+      const r = detectAmountOutlier({
+        amount: 100,
+        category: '',
+        expenses: [mk('a', 100, '餐飲', 1)],
+        now: NOW,
+      })
+      expect(r.isOutlier).toBe(false)
+    })
+
+    it('returns non-outlier with < 3 historical samples', () => {
+      const r = detectAmountOutlier({
+        amount: 99999,
+        category: '餐飲',
+        expenses: [mk('a', 100, '餐飲', 1), mk('b', 200, '餐飲', 2)],
+        now: NOW,
+      })
+      expect(r.isOutlier).toBe(false)
+      expect(r.sampleSize).toBe(2)
+    })
+
+    it('skips records older than the lookback window', () => {
+      // 95 days ago is outside the 90-day window
+      const old = [
+        mk('o1', 100, '餐飲', 95),
+        mk('o2', 100, '餐飲', 96),
+        mk('o3', 100, '餐飲', 97),
+      ]
+      const r = detectAmountOutlier({
+        amount: 99999,
+        category: '餐飲',
+        expenses: old,
+        now: NOW,
+      })
+      expect(r.isOutlier).toBe(false)
+      expect(r.sampleSize).toBe(0)
+    })
+  })
+
+  describe('digit_jump signal', () => {
+    it('triggers when amount has 2+ more digits than max historical', () => {
+      const history = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 200, '餐飲', 2),
+        mk('c', 300, '餐飲', 3),
+      ]
+      // 100/200/300 = max 3 digits. 50000 = 5 digits → 5-3 = 2 → trigger
+      const r = detectAmountOutlier({
+        amount: 50000,
+        category: '餐飲',
+        expenses: history,
+        now: NOW,
+      })
+      expect(r.isOutlier).toBe(true)
+      expect(r.kind).toBe('digit_jump')
+    })
+
+    it('does NOT trigger digit-jump for +1 digit only', () => {
+      const history = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 200, '餐飲', 2),
+        mk('c', 300, '餐飲', 3),
+      ]
+      // max 3 digits, 1500 = 4 digits → +1, NOT trigger digit_jump.
+      // (May still trigger magnitude — see next test)
+      const r = detectAmountOutlier({
+        amount: 1500,
+        category: '餐飲',
+        expenses: history,
+        now: NOW,
+      })
+      expect(r.kind).not.toBe('digit_jump')
+    })
+  })
+
+  describe('magnitude_jump signal', () => {
+    it('triggers when amount is > 5x median', () => {
+      const history = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 200, '餐飲', 2),
+        mk('c', 300, '餐飲', 3),
+      ]
+      // median = 200, 5x = 1000, current 1500 > 1000 → trigger
+      const r = detectAmountOutlier({
+        amount: 1500,
+        category: '餐飲',
+        expenses: history,
+        now: NOW,
+      })
+      expect(r.isOutlier).toBe(true)
+      expect(r.kind).toBe('magnitude_jump')
+    })
+
+    it('does NOT trigger when amount is < 5x median', () => {
+      const history = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 200, '餐飲', 2),
+        mk('c', 300, '餐飲', 3),
+      ]
+      // median 200, 4x = 800. current 700 < 1000 → no trigger
+      const r = detectAmountOutlier({
+        amount: 700,
+        category: '餐飲',
+        expenses: history,
+        now: NOW,
+      })
+      expect(r.isOutlier).toBe(false)
+    })
+  })
+
+  describe('signal precedence', () => {
+    it('prefers digit_jump over magnitude_jump when both apply', () => {
+      const history = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 200, '餐飲', 2),
+        mk('c', 300, '餐飲', 3),
+      ]
+      // 99999 — both signals fire, expect digit_jump (more specific)
+      const r = detectAmountOutlier({
+        amount: 99999,
+        category: '餐飲',
+        expenses: history,
+        now: NOW,
+      })
+      expect(r.kind).toBe('digit_jump')
+    })
+  })
+
+  describe('history scoping', () => {
+    it('only considers expenses with matching category (case-insensitive trim)', () => {
+      const mixed = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 100, '餐飲 ', 2),
+        mk('c', 100, 'CANTINA', 3),
+        mk('other1', 5000, '購物', 1),
+        mk('other2', 5000, '購物', 2),
+        mk('other3', 5000, '購物', 3),
+      ]
+      const r = detectAmountOutlier({
+        amount: 1500,
+        category: ' 餐飲',
+        expenses: mixed,
+        now: NOW,
+      })
+      // Only 餐飲 (a + b) — sample = 2, below MIN_SAMPLE_SIZE → no outlier
+      expect(r.sampleSize).toBe(2)
+      expect(r.isOutlier).toBe(false)
+    })
+
+    it('excludes the expense being edited via excludeId', () => {
+      const history = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 200, '餐飲', 2),
+        mk('c', 300, '餐飲', 3),
+        mk('editing', 50000, '餐飲', 0),
+      ]
+      const r = detectAmountOutlier({
+        amount: 50000,
+        category: '餐飲',
+        expenses: history,
+        now: NOW,
+        excludeId: 'editing',
+      })
+      // Should fire because excluded record doesn't bias maxDigits upward
+      expect(r.kind).toBe('digit_jump')
+    })
+
+    it('skips records with non-finite amounts', () => {
+      const history = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 200, '餐飲', 2),
+        mk('bad', NaN, '餐飲', 3),
+        mk('c', 300, '餐飲', 4),
+      ]
+      const r = detectAmountOutlier({
+        amount: 99999,
+        category: '餐飲',
+        expenses: history,
+        now: NOW,
+      })
+      expect(r.kind).toBe('digit_jump')
+      expect(r.sampleSize).toBe(3)
+    })
+
+    it('skips records with bad date gracefully', () => {
+      const bad = { ...mk('bad', 100, '餐飲', 1), date: 'oops' } as unknown as Expense
+      const ok = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 200, '餐飲', 2),
+        mk('c', 300, '餐飲', 3),
+      ]
+      const r = detectAmountOutlier({
+        amount: 99999,
+        category: '餐飲',
+        expenses: [bad, ...ok],
+        now: NOW,
+      })
+      expect(r.kind).toBe('digit_jump')
+      expect(r.sampleSize).toBe(3)
+    })
+  })
+
+  describe('historicalMedian accuracy', () => {
+    it('returns the median of historical amounts', () => {
+      const history = [
+        mk('a', 100, '餐飲', 1),
+        mk('b', 200, '餐飲', 2),
+        mk('c', 300, '餐飲', 3),
+      ]
+      const r = detectAmountOutlier({
+        amount: 250,
+        category: '餐飲',
+        expenses: history,
+        now: NOW,
+      })
+      expect(r.historicalMedian).toBe(200)
+    })
+  })
+})

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -20,6 +20,7 @@ import { useAuth, getActor } from '@/lib/auth'
 import { toDate } from '@/lib/utils'
 import { saveButtonLabel, type UploadProgress } from '@/lib/save-button-label'
 import { findPossibleDuplicate } from '@/lib/duplicate-expense-detector'
+import { detectAmountOutlier } from '@/lib/amount-outlier'
 import { evaluateAmountExpression } from '@/lib/amount-expression'
 import { AmountChips } from '@/components/amount-chips'
 import { hapticFeedback } from '@/lib/haptic'
@@ -364,6 +365,8 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
   // last 5 minutes. Skip when user explicitly dismissed this candidate.
   // Issue #211.
   const [dismissedDuplicateKey, setDismissedDuplicateKey] = useState<string | null>(null)
+  // Amount outlier dismiss key (Issue #284). Same per-candidate dismiss pattern.
+  const [dismissedOutlierKey, setDismissedOutlierKey] = useState<string | null>(null)
   // 1-min tick so the banner self-clears once the 5-min window expires
   // without requiring any field change (reviewer flagged that Date.now()
   // inside useMemo was a hidden dep).
@@ -405,6 +408,25 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
     ? `${possibleDuplicate.id}-${possibleDuplicate.amount}-${description.trim().toLowerCase()}`
     : null
   const showDuplicateWarning = !!possibleDuplicate && duplicateKey !== dismissedDuplicateKey
+
+  // Amount outlier check (Issue #284): uses parsed expression value + selected
+  // category against last ~90 days of same-category history.
+  const outlierResult = useMemo(() => {
+    if (!category) return null
+    const parsed = evaluateAmountExpression(amount)
+    if (!parsed.ok || parsed.value <= 0) return null
+    return detectAmountOutlier({
+      amount: parsed.value,
+      category,
+      expenses,
+      excludeId: existingExpense?.id,
+    })
+  }, [amount, category, expenses, existingExpense?.id])
+  const outlierKey = outlierResult?.isOutlier
+    ? `${category}-${outlierResult.kind}-${amount}`
+    : null
+  const showOutlierWarning =
+    !!outlierResult?.isOutlier && outlierKey !== dismissedOutlierKey
 
   const buildSplits = (): SplitDetail[] => {
     const amt = parseFloat(amount) || 0
@@ -713,6 +735,54 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
             type="button"
             onClick={() => setDismissedDuplicateKey(duplicateKey)}
             aria-label="忽略重複提醒"
+            className="shrink-0 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition px-1"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {/* Amount outlier warning (Issue #284) — heuristic typo detection
+          based on this group's history of the same category. */}
+      {showOutlierWarning && outlierResult && (
+        <div
+          className="rounded-lg border p-3 flex items-start gap-3 text-xs"
+          style={{
+            borderColor: 'color-mix(in oklch, oklch(0.80 0.15 75), var(--card) 40%)',
+            backgroundColor: 'color-mix(in oklch, oklch(0.85 0.10 75), var(--card) 80%)',
+          }}
+          role="alert"
+          aria-live="polite"
+        >
+          <span className="text-lg">⚠️</span>
+          <div className="flex-1 min-w-0">
+            <div className="font-medium">金額看起來不太一樣</div>
+            <div className="text-[var(--muted-foreground)] mt-0.5">
+              {outlierResult.kind === 'digit_jump' ? (
+                <>
+                  「{category}」過去通常在
+                  <span className="font-medium text-[var(--foreground)]">
+                    {' '}NT${' '}
+                    {outlierResult.historicalMedian?.toLocaleString() ?? ''}{' '}
+                  </span>
+                  左右，這筆是不是多打了 0？
+                </>
+              ) : (
+                <>
+                  「{category}」過去中位數是
+                  <span className="font-medium text-[var(--foreground)]">
+                    {' '}NT${' '}
+                    {outlierResult.historicalMedian?.toLocaleString() ?? ''}
+                  </span>
+                  ，這筆比平常高 5 倍以上，確定金額正確？
+                </>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setDismissedOutlierKey(outlierKey)}
+            aria-label="忽略金額提醒"
             className="shrink-0 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition px-1"
           >
             ✕

--- a/src/lib/amount-outlier.ts
+++ b/src/lib/amount-outlier.ts
@@ -1,0 +1,110 @@
+/**
+ * Detect "looks like a typo" amounts at save time (Issue #284).
+ *
+ * Two independent signals against the user's history of the same category
+ * over the last ~3 months:
+ *
+ * 1. Digit-length jump: if the current amount has 2+ more digits than the
+ *    historical maximum in that category, it's almost certainly a misplaced
+ *    zero ("you typed 1500, did you mean 150?").
+ * 2. Magnitude jump: if the current amount is more than 5× the historical
+ *    median (after the digit-length signal already cleared), it's a softer
+ *    nudge ("usually this category lands near NT$ X").
+ *
+ * Sample size guard: with fewer than 3 historical samples we don't fire —
+ * not enough signal, false positives would annoy.
+ *
+ * Pure function. No date library — caller filters expenses to the recent
+ * window before passing in.
+ */
+import { toDate } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+export type OutlierKind = 'digit_jump' | 'magnitude_jump'
+
+export interface OutlierResult {
+  isOutlier: boolean
+  kind: OutlierKind | null
+  /** Median of the historical sample, for use in the message. */
+  historicalMedian: number | null
+  /** Sample size used. */
+  sampleSize: number
+}
+
+const DEFAULT_LOOKBACK_DAYS = 90
+const MIN_SAMPLE_SIZE = 3
+const MAGNITUDE_RATIO = 5
+
+function digitCount(n: number): number {
+  if (n <= 0) return 0
+  return String(Math.floor(n)).length
+}
+
+function median(arr: readonly number[]): number {
+  if (arr.length === 0) return 0
+  const sorted = [...arr].sort((a, b) => a - b)
+  const m = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[m - 1] + sorted[m]) / 2 : sorted[m]
+}
+
+interface DetectInput {
+  amount: number
+  category: string
+  /** Caller's full visible expense list — function filters internally. */
+  expenses: readonly Expense[]
+  /** Optional now (for tests). Defaults to Date.now(). */
+  now?: number
+  /** Optional id of the expense being edited — exclude from history. */
+  excludeId?: string
+}
+
+export function detectAmountOutlier({
+  amount,
+  category,
+  expenses,
+  now = Date.now(),
+  excludeId,
+}: DetectInput): OutlierResult {
+  if (!Number.isFinite(amount) || amount <= 0 || !category) {
+    return { isOutlier: false, kind: null, historicalMedian: null, sampleSize: 0 }
+  }
+
+  const cutoff = now - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000
+  const normalized = category.trim().toLowerCase()
+
+  const historicalAmounts: number[] = []
+  for (const e of expenses) {
+    if (e.id === excludeId) continue
+    if (!e.category || e.category.trim().toLowerCase() !== normalized) continue
+    if (typeof e.amount !== 'number' || !Number.isFinite(e.amount) || e.amount <= 0) continue
+    let t: number
+    try {
+      const d = toDate(e.date)
+      t = d.getTime()
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(t) || t < cutoff) continue
+    historicalAmounts.push(e.amount)
+  }
+
+  if (historicalAmounts.length < MIN_SAMPLE_SIZE) {
+    return { isOutlier: false, kind: null, historicalMedian: null, sampleSize: historicalAmounts.length }
+  }
+
+  const med = median(historicalAmounts)
+  const maxDigits = Math.max(...historicalAmounts.map(digitCount))
+  const currentDigits = digitCount(amount)
+
+  // Signal 1: digit jump — clearer error, prefer this message
+  if (currentDigits >= maxDigits + 2) {
+    return { isOutlier: true, kind: 'digit_jump', historicalMedian: med, sampleSize: historicalAmounts.length }
+  }
+
+  // Signal 2: magnitude jump
+  if (med > 0 && amount > med * MAGNITUDE_RATIO) {
+    return { isOutlier: true, kind: 'magnitude_jump', historicalMedian: med, sampleSize: historicalAmounts.length }
+  }
+
+  return { isOutlier: false, kind: null, historicalMedian: med, sampleSize: historicalAmounts.length }
+}


### PR DESCRIPTION
## Idea
記帳最常見的資料品質問題：金額多打/少打 0。一旦存下，後續所有 stat、預算、結算全錯。

## Heuristic
- 同 category 過去 90 天歷史
- 樣本 < 3 不警示
- digit_jump（差 ≥2 位數）優先於 magnitude_jump（> 5x median）
- 用 median 不用 stddev（餐飲 50 / 房租 20000，stddev 不適用）

## Files
- \`src/lib/amount-outlier.ts\` (pure)
- \`src/components/expense-form.tsx\` (useMemo + dismissable banner)
- \`__tests__/amount-outlier.test.ts\` (14 cases)

## Why this is creative
不只是 polish，是**數據品質防護**。這類偵測在多數記帳 App 都沒有，但對家庭場景影響最大（小金額類別誤打 0 → 月度統計徹底錯誤 → 預算系統噪音）。

Closes #284