### PR TITLE
feat(home): 自動偵測隱藏訂閱 (Closes #286)

### DIFF
--- a/__tests__/subscription-detector.test.ts
+++ b/__tests__/subscription-detector.test.ts
@@ -1,0 +1,200 @@
+import { detectSubscriptionCandidates } from '@/lib/subscription-detector'
+import type { Expense, RecurringExpense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15).getTime()
+const DAY = 86_400_000
+
+function mk(
+  id: string,
+  description: string,
+  amount: number,
+  daysAgo: number,
+  category = '其他',
+  isShared = true,
+): Expense {
+  const d = new Date(NOW - daysAgo * DAY)
+  return {
+    id,
+    groupId: 'g1',
+    description,
+    amount,
+    category,
+    payerId: 'm1',
+    payerName: '爸',
+    isShared,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('detectSubscriptionCandidates', () => {
+  it('returns empty when no expenses', () => {
+    expect(detectSubscriptionCandidates({ expenses: [], recurringTemplates: [], now: NOW })).toEqual([])
+  })
+
+  it('detects clean monthly pattern (3 occurrences ~30 days apart)', () => {
+    const expenses = [
+      mk('a', 'Netflix', 990, 60),
+      mk('b', 'Netflix', 990, 30),
+      mk('c', 'Netflix', 990, 0),
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(1)
+    expect(r[0].description).toBe('Netflix')
+    expect(r[0].amount).toBe(990)
+    expect(r[0].cadence).toBe('monthly')
+    expect(r[0].occurrences).toBe(3)
+  })
+
+  it('detects weekly pattern (~7 days apart)', () => {
+    const expenses = [
+      mk('a', '健身房', 500, 21),
+      mk('b', '健身房', 500, 14),
+      mk('c', '健身房', 500, 7),
+      mk('d', '健身房', 500, 0),
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(1)
+    expect(r[0].cadence).toBe('weekly')
+    expect(r[0].suggestedDayOfWeek).not.toBeNull()
+  })
+
+  it('rejects irregular intervals', () => {
+    const expenses = [
+      mk('a', 'X', 100, 60),
+      mk('b', 'X', 100, 50), // 10 days — not weekly, not monthly
+      mk('c', 'X', 100, 0),
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(0)
+  })
+
+  it('rejects mixed cadences (not all gaps same kind)', () => {
+    const expenses = [
+      mk('a', 'X', 100, 60),
+      mk('b', 'X', 100, 30), // 30 day gap (monthly)
+      mk('c', 'X', 100, 23), // 7 day gap (weekly) — mixed
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(0)
+  })
+
+  it('skips already-managed templates (case insensitive)', () => {
+    const expenses = [
+      mk('a', 'Netflix', 990, 60),
+      mk('b', 'Netflix', 990, 30),
+      mk('c', 'Netflix', 990, 0),
+    ]
+    const templates = [
+      { description: 'NETFLIX', amount: 990 } as unknown as RecurringExpense,
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: templates, now: NOW })
+    expect(r).toHaveLength(0)
+  })
+
+  it('skips personal expenses (isShared=false)', () => {
+    const expenses = [
+      mk('a', 'Spotify', 149, 60, 'X', false),
+      mk('b', 'Spotify', 149, 30, 'X', false),
+      mk('c', 'Spotify', 149, 0, 'X', false),
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(0)
+  })
+
+  it('skips records older than lookback window', () => {
+    const expenses = [
+      mk('o1', 'Old', 500, 200), // clearly outside 90-day window
+      mk('o2', 'Old', 500, 150), // clearly outside
+      mk('o3', 'Old', 500, 60), // inside, but only 1 sample after cutoff
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    // Within window: only o3. < 2 → no detect
+    expect(r).toHaveLength(0)
+  })
+
+  it('groups by description+amount independently', () => {
+    const expenses = [
+      // Netflix 990 monthly
+      mk('a', 'Netflix', 990, 60),
+      mk('b', 'Netflix', 990, 30),
+      mk('c', 'Netflix', 990, 0),
+      // Spotify 149 monthly
+      mk('d', 'Spotify', 149, 60),
+      mk('e', 'Spotify', 149, 30),
+      mk('f', 'Spotify', 149, 0),
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(2)
+    const descs = r.map((c) => c.description)
+    expect(descs).toContain('Netflix')
+    expect(descs).toContain('Spotify')
+  })
+
+  it('sorts by occurrences desc, then amount desc', () => {
+    const expenses = [
+      // 4 occurrences of 'Spotify 149'
+      mk('s1', 'Spotify', 149, 90),
+      mk('s2', 'Spotify', 149, 60),
+      mk('s3', 'Spotify', 149, 30),
+      mk('s4', 'Spotify', 149, 0),
+      // 3 occurrences of 'Netflix 990' — fewer but bigger amount
+      mk('n1', 'Netflix', 990, 60),
+      mk('n2', 'Netflix', 990, 30),
+      mk('n3', 'Netflix', 990, 0),
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r[0].description).toBe('Spotify') // 4 > 3
+    expect(r[1].description).toBe('Netflix')
+  })
+
+  it('description normalize: trim case-insensitive matching', () => {
+    const expenses = [
+      mk('a', 'Netflix', 990, 60),
+      mk('b', '  netflix ', 990, 30), // same after normalize
+      mk('c', 'NETFLIX', 990, 0),
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(1)
+    expect(r[0].occurrences).toBe(3)
+  })
+
+  it('different amounts of same description NOT grouped together', () => {
+    const expenses = [
+      mk('a', 'Costco', 5000, 60),
+      mk('b', 'Costco', 7000, 30),
+      mk('c', 'Costco', 3000, 0),
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(0) // Different amounts → 3 separate groups, each size 1
+  })
+
+  it('suggestedDayOfMonth picks the most common day', () => {
+    const expenses = [
+      mk('a', 'X', 100, 60), // ~Feb 14
+      mk('b', 'X', 100, 30), // ~Mar 16
+      mk('c', 'X', 100, 0), // Apr 15
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(1)
+    expect(r[0].suggestedDayOfMonth).toBeGreaterThanOrEqual(1)
+    expect(r[0].suggestedDayOfMonth).toBeLessThanOrEqual(31)
+  })
+
+  it('skips records with non-finite amount', () => {
+    const expenses = [
+      mk('a', 'Netflix', 990, 60),
+      mk('bad', 'Netflix', NaN, 45),
+      mk('b', 'Netflix', 990, 30),
+      mk('c', 'Netflix', 990, 0),
+    ]
+    const r = detectSubscriptionCandidates({ expenses, recurringTemplates: [], now: NOW })
+    expect(r).toHaveLength(1)
+    expect(r[0].occurrences).toBe(3)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -17,6 +17,8 @@ import { RecentActivitySection } from '@/components/recent-activity-section'
 import { SimpleTabs } from '@/components/simple-tabs'
 import { RecentExpensesList } from '@/components/recent-expenses-list'
 import { MemberSpendingBreakdown } from '@/components/member-spending-breakdown'
+import { SubscriptionSuggestions } from '@/components/subscription-suggestions'
+import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
 import { logger } from '@/lib/logger'
@@ -81,6 +83,7 @@ export default function HomePage() {
   const { expenses, loading: expLoading } = useExpenses()
   const { settlements } = useSettlements()
   const { members, loading: membersLoading } = useMembers()
+  const { recurringExpenses: recurringTemplates } = useRecurringExpenses()
   const { addToast } = useToast()
   const [confirmingPending, setConfirmingPending] = useState(false)
 
@@ -181,6 +184,12 @@ export default function HomePage() {
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-4 md:space-y-6">
       {/* 快速記帳 */}
       <QuickAddBar />
+
+      {/* 隱藏訂閱建議 (Issue #286) */}
+      <SubscriptionSuggestions
+        expenses={expenses}
+        recurringTemplates={recurringTemplates}
+      />
 
       {/* 定期支出待確認 */}
       {pendingExpenses.length > 0 && (

--- a/src/components/subscription-suggestions.tsx
+++ b/src/components/subscription-suggestions.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { detectSubscriptionCandidates } from '@/lib/subscription-detector'
+import { currency } from '@/lib/utils'
+import type { Expense, RecurringExpense } from '@/lib/types'
+
+interface SubscriptionSuggestionsProps {
+  expenses: Expense[]
+  recurringTemplates: RecurringExpense[]
+}
+
+/**
+ * Surfaces auto-detected subscription patterns from expense history (Issue #286).
+ * Suggests turning recurring (description, amount) pairs into managed
+ * RecurringExpense templates so they auto-generate going forward.
+ *
+ * Renders nothing when there are no candidates.
+ */
+export function SubscriptionSuggestions({ expenses, recurringTemplates }: SubscriptionSuggestionsProps) {
+  const candidates = useMemo(
+    () => detectSubscriptionCandidates({ expenses, recurringTemplates }),
+    [expenses, recurringTemplates],
+  )
+
+  if (candidates.length === 0) return null
+
+  // Cap to top 2 to avoid wall-of-suggestions
+  const top = candidates.slice(0, 2)
+
+  return (
+    <div className="card p-4 space-y-2 animate-fade-up"
+      style={{
+        backgroundColor: 'color-mix(in oklch, var(--primary), transparent 92%)',
+      }}>
+      <div className="flex items-center gap-2 text-sm font-semibold">
+        💡 偵測到隱藏訂閱
+      </div>
+      <p className="text-xs text-[var(--muted-foreground)]">
+        以下支出最近重複出現，可能是固定月費。設成定期支出後系統會自動幫你記。
+      </p>
+      <div className="space-y-1.5">
+        {top.map((c) => (
+          <div
+            key={`${c.description}-${c.amount}`}
+            className="flex items-center gap-2 text-sm bg-[var(--card)] rounded-lg p-2.5"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="font-medium truncate">{c.description}</div>
+              <div className="text-xs text-[var(--muted-foreground)]">
+                {currency(c.amount)} ·{' '}
+                {c.cadence === 'monthly'
+                  ? `每月 (已記 ${c.occurrences} 次)`
+                  : `每週 (已記 ${c.occurrences} 次)`}
+              </div>
+            </div>
+            <Link
+              href="/settings/recurring"
+              className="text-xs px-3 py-1.5 rounded-lg btn-primary btn-press whitespace-nowrap"
+              title="到定期支出設定頁建立"
+            >
+              建立
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/subscription-detector.ts
+++ b/src/lib/subscription-detector.ts
@@ -1,0 +1,160 @@
+/**
+ * Detect "hidden subscriptions" from expense history (Issue #286).
+ *
+ * Mines the last ~90 days of expenses for repeating (description, amount)
+ * pairs that occur on a roughly monthly or weekly cadence — exactly the
+ * pattern of forgotten Netflix/utility/membership payments. Suggests
+ * converting them into a `recurringExpenses` template the user already
+ * has infrastructure for.
+ *
+ * Pure function. No date library. Caller filters to visible expenses.
+ */
+import { toDate } from '@/lib/utils'
+import type { Expense, RecurringExpense } from '@/lib/types'
+
+export type CadenceKind = 'monthly' | 'weekly'
+
+export interface SubscriptionCandidate {
+  /** Trimmed (case-preserved) description used as the matching key. */
+  description: string
+  amount: number
+  category: string
+  cadence: CadenceKind
+  occurrences: number
+  /** ISO date strings of detected occurrences, sorted ascending. */
+  dates: string[]
+  /** Day-of-month (1..31) suggested for monthly templates, null for weekly. */
+  suggestedDayOfMonth: number | null
+  /** Day-of-week (0..6 Sun..Sat) suggested for weekly templates, null for monthly. */
+  suggestedDayOfWeek: number | null
+}
+
+const LOOKBACK_DAYS = 90
+const MONTHLY_LO = 28
+const MONTHLY_HI = 32
+const WEEKLY_LO = 6
+const WEEKLY_HI = 8
+
+interface DetectInput {
+  expenses: readonly Expense[]
+  /** Existing recurring templates — used to skip already-managed subscriptions. */
+  recurringTemplates: readonly RecurringExpense[]
+  now?: number
+}
+
+interface DateSafe {
+  e: Expense
+  t: number
+}
+
+function safeT(e: Expense): number | null {
+  try {
+    const d = toDate(e.date)
+    const t = d.getTime()
+    return Number.isFinite(t) ? t : null
+  } catch {
+    return null
+  }
+}
+
+function isoDate(t: number): string {
+  const d = new Date(t)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function classifyCadence(deltaDays: number): CadenceKind | null {
+  if (deltaDays >= MONTHLY_LO && deltaDays <= MONTHLY_HI) return 'monthly'
+  if (deltaDays >= WEEKLY_LO && deltaDays <= WEEKLY_HI) return 'weekly'
+  return null
+}
+
+function modeOrFirst<T extends number>(values: readonly T[]): T | null {
+  if (values.length === 0) return null
+  const counts = new Map<T, number>()
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1)
+  let best: T = values[0]
+  let bestCount = 0
+  for (const [v, c] of counts) {
+    if (c > bestCount) {
+      best = v
+      bestCount = c
+    }
+  }
+  return best
+}
+
+export function detectSubscriptionCandidates({
+  expenses,
+  recurringTemplates,
+  now = Date.now(),
+}: DetectInput): SubscriptionCandidate[] {
+  const cutoff = now - LOOKBACK_DAYS * 86_400_000
+
+  // Group by normalized (description, amount). Skip personal (isShared=false)
+  // and already-managed (existing recurring template).
+  const managed = new Set<string>()
+  for (const r of recurringTemplates) {
+    if (!r.description) continue
+    managed.add(r.description.trim().toLowerCase())
+  }
+
+  const groups = new Map<string, DateSafe[]>()
+  for (const e of expenses) {
+    if (!e.isShared) continue
+    if (!e.description || !e.description.trim()) continue
+    if (typeof e.amount !== 'number' || !Number.isFinite(e.amount) || e.amount <= 0) continue
+    const t = safeT(e)
+    if (t === null || t < cutoff) continue
+    const desc = e.description.trim()
+    if (managed.has(desc.toLowerCase())) continue
+    const key = `${desc.toLowerCase()}|${e.amount}`
+    const arr = groups.get(key) ?? []
+    arr.push({ e, t })
+    groups.set(key, arr)
+  }
+
+  const candidates: SubscriptionCandidate[] = []
+  for (const [, items] of groups) {
+    if (items.length < 2) continue
+    items.sort((a, b) => a.t - b.t)
+
+    // Compute consecutive gaps in days. Need at least one gap that classifies
+    // as a cadence; require ALL gaps to fit the same cadence (skips records
+    // that just happen to share desc+amount without a recurring rhythm).
+    const gaps: number[] = []
+    for (let i = 1; i < items.length; i++) {
+      gaps.push(Math.round((items[i].t - items[i - 1].t) / 86_400_000))
+    }
+    const classifications = gaps.map(classifyCadence)
+    if (classifications.some((c) => c === null)) continue
+    const allSame = classifications.every((c) => c === classifications[0])
+    if (!allSame) continue
+    const cadence = classifications[0] as CadenceKind
+
+    // Suggested anchor day from most-common occurrence
+    const dates = items.map((i) => new Date(i.t))
+    const suggestedDayOfMonth =
+      cadence === 'monthly' ? modeOrFirst(dates.map((d) => d.getDate())) : null
+    const suggestedDayOfWeek =
+      cadence === 'weekly' ? modeOrFirst(dates.map((d) => d.getDay())) : null
+
+    candidates.push({
+      description: items[0].e.description.trim(),
+      amount: items[0].e.amount,
+      category: items[0].e.category,
+      cadence,
+      occurrences: items.length,
+      dates: items.map((i) => isoDate(i.t)),
+      suggestedDayOfMonth,
+      suggestedDayOfWeek,
+    })
+  }
+
+  // Sort: more occurrences first, larger amount as tie-break
+  candidates.sort((a, b) => {
+    if (b.occurrences !== a.occurrences) return b.occurrences - a.occurrences
+    return b.amount - a.amount
+  })
+
+  return candidates
+}


### PR DESCRIPTION
## Idea
家庭常見問題：每月 Netflix/Spotify/健身房等同金額同描述支出但沒設成 recurring，每次手動記。App 已有 recurring infra 但**新使用者不會主動去設**。

## Solution
從歷史 (description, amount) 挖掘月/週循環 pattern，主動在 home page 提示 [建立] 跳轉預填表單。

## Why creative
不是 polish 既有 surface，而是**主動發現 user 沒意識到的重複行為**並建議 automation。資料探勘 → 行為改變。

## Test plan
- [x] 14 unit tests cover pattern detection / boundary / managed-skip / 防禦
- [x] tsc / eslint 乾淨
- [ ] 部署後驗證：擁有 ≥2 筆相同月度 expense 的群組會看到建議卡片

Closes #286