### PR TITLE
feat(home): Catch-up 提醒 banner (Closes #288)

### DIFF
--- a/__tests__/catchup-detector.test.ts
+++ b/__tests__/catchup-detector.test.ts
@@ -1,0 +1,97 @@
+import { detectCatchupNudge } from '@/lib/catchup-detector'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, noon
+
+function mk(id: string, daysAgo: number): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount: 100,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('detectCatchupNudge', () => {
+  it('returns null with empty expenses', () => {
+    expect(detectCatchupNudge({ expenses: [], now: NOW })).toBeNull()
+  })
+
+  it('returns null when most recent is today', () => {
+    expect(detectCatchupNudge({ expenses: [mk('a', 0)], now: NOW })).toBeNull()
+  })
+
+  it('returns null when gap is 1 day (below default threshold of 4)', () => {
+    expect(detectCatchupNudge({ expenses: [mk('a', 1)], now: NOW })).toBeNull()
+  })
+
+  it('returns null when gap is exactly 3 days (still below 4)', () => {
+    expect(detectCatchupNudge({ expenses: [mk('a', 3)], now: NOW })).toBeNull()
+  })
+
+  it('triggers at exactly 4 days', () => {
+    const r = detectCatchupNudge({ expenses: [mk('a', 4)], now: NOW })
+    expect(r).not.toBeNull()
+    expect(r?.daysGap).toBe(4)
+  })
+
+  it('triggers at 7 days with correct lastRecordedDate', () => {
+    const r = detectCatchupNudge({ expenses: [mk('a', 7)], now: NOW })
+    expect(r?.daysGap).toBe(7)
+    expect(r?.lastRecordedDate).toBe('2026-04-08')
+  })
+
+  it('uses the most recent expense, ignoring older records', () => {
+    const expenses = [mk('old', 30), mk('newer', 5), mk('newest', 2)]
+    const r = detectCatchupNudge({ expenses, now: NOW })
+    // Most recent = 2 days ago → below threshold
+    expect(r).toBeNull()
+  })
+
+  it('triggers on most recent gap even with very old records also present', () => {
+    const expenses = [mk('old', 60), mk('mid', 30), mk('lastRecorded', 6)]
+    const r = detectCatchupNudge({ expenses, now: NOW })
+    expect(r?.daysGap).toBe(6)
+  })
+
+  it('respects custom threshold', () => {
+    const expenses = [mk('a', 2)]
+    expect(detectCatchupNudge({ expenses, now: NOW, thresholdDays: 2 })?.daysGap).toBe(2)
+    expect(detectCatchupNudge({ expenses, now: NOW, thresholdDays: 3 })).toBeNull()
+  })
+
+  it('skips records with bad dates', () => {
+    const bad = { ...mk('bad', 1), date: 'oops' } as unknown as Expense
+    const ok = mk('good', 7)
+    const r = detectCatchupNudge({ expenses: [bad, ok], now: NOW })
+    expect(r?.daysGap).toBe(7)
+  })
+
+  it('skips records with non-finite timestamp', () => {
+    const bad = { ...mk('bad', 1), date: new Date(NaN) } as unknown as Expense
+    const ok = mk('good', 5)
+    const r = detectCatchupNudge({ expenses: [bad, ok], now: NOW })
+    expect(r?.daysGap).toBe(5)
+  })
+
+  it('day-level granularity ignores time-of-day', () => {
+    // Expense at 23:59 yesterday, now is 00:01 today — 1 day diff regardless
+    const expense = mk('a', 0)
+    expense.date = new Date(NOW - 86_400_000 + 60_000) as unknown as Expense['date']
+    const r = detectCatchupNudge({ expenses: [expense], now: NOW })
+    // 1 day gap only — below threshold
+    expect(r).toBeNull()
+  })
+})

--- a/src/app/(auth)/expense/new/page.tsx
+++ b/src/app/(auth)/expense/new/page.tsx
@@ -17,6 +17,8 @@ export default function NewExpensePage() {
 
   const duplicateId = searchParams.get('duplicate')
   const duplicateSource = duplicateId ? expenses.find((e) => e.id === duplicateId) : undefined
+  // Initial date from ?date=YYYY-MM-DD param (catch-up nudge, Issue #288).
+  const initialDate = searchParams.get('date') ?? undefined
 
   // Expose a setter that ExpenseForm can call back to us via ref
   const onVoiceParsedRef = useRef<((_result: ParsedExpense) => void) | null>(null)
@@ -36,6 +38,7 @@ export default function NewExpensePage() {
       </div>
       <ExpenseForm
         duplicateFrom={duplicateSource}
+        initialDate={initialDate}
         onSaved={() => router.push('/records')}
         onVoiceParsedRef={onVoiceParsedRef}
       />

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -18,6 +18,7 @@ import { SimpleTabs } from '@/components/simple-tabs'
 import { RecentExpensesList } from '@/components/recent-expenses-list'
 import { MemberSpendingBreakdown } from '@/components/member-spending-breakdown'
 import { SubscriptionSuggestions } from '@/components/subscription-suggestions'
+import { CatchupNudge } from '@/components/catchup-nudge'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -184,6 +185,9 @@ export default function HomePage() {
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-4 md:space-y-6">
       {/* 快速記帳 */}
       <QuickAddBar />
+
+      {/* Catch-up 提醒 (Issue #288) — 超過 3 天沒記時溫和提示 */}
+      <CatchupNudge expenses={expenses} />
 
       {/* 隱藏訂閱建議 (Issue #286) */}
       <SubscriptionSuggestions

--- a/src/components/catchup-nudge.tsx
+++ b/src/components/catchup-nudge.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { detectCatchupNudge } from '@/lib/catchup-detector'
+import type { Expense } from '@/lib/types'
+
+interface CatchupNudgeProps {
+  expenses: Expense[]
+}
+
+function formatDate(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Friendly nudge banner when the user hasn't recorded in a while
+ * (Issue #288). Surfaces *while memory is fresh* — the moment they open
+ * the app — and links to /expense/new with a pre-filled date so the user
+ * can backfill in two taps.
+ *
+ * Dismiss is session-only (useState) — reload reveals it again. Persistent
+ * dismiss would risk silencing real gaps.
+ */
+export function CatchupNudge({ expenses }: CatchupNudgeProps) {
+  const [dismissed, setDismissed] = useState(false)
+  const nudge = useMemo(() => detectCatchupNudge({ expenses }), [expenses])
+
+  if (!nudge || dismissed) return null
+
+  const today = new Date()
+  const yesterday = new Date(today.getTime() - 86_400_000)
+
+  return (
+    <div
+      className="rounded-2xl border p-4 space-y-2 animate-fade-up"
+      style={{
+        borderColor: 'color-mix(in oklch, var(--primary), transparent 70%)',
+        backgroundColor: 'color-mix(in oklch, var(--primary), transparent 92%)',
+      }}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 text-sm font-semibold">
+        <span aria-hidden>📅</span>
+        <span>已 {nudge.daysGap} 天沒記帳了</span>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          aria-label="關閉提醒"
+          className="ml-auto text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition px-1"
+        >
+          ✕
+        </button>
+      </div>
+      <p className="text-xs text-[var(--muted-foreground)]">
+        想起這幾天有什麼支出嗎？最後一次記錄是 {nudge.lastRecordedDate}。
+      </p>
+      <div className="flex gap-2 flex-wrap">
+        <Link
+          href={`/expense/new?date=${formatDate(yesterday)}`}
+          className="text-xs px-3 py-1.5 rounded-lg btn-primary btn-press whitespace-nowrap"
+        >
+          記補昨天
+        </Link>
+        <Link
+          href={`/expense/new?date=${formatDate(today)}`}
+          className="text-xs px-3 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)] whitespace-nowrap"
+        >
+          記補今天
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -39,13 +39,15 @@ const FALLBACK_CATEGORIES = ['餐飲', '交通', '購物', '房租', '水電', '
 interface Props {
   existingExpense?: Expense
   duplicateFrom?: Expense
+  /** Pre-fill date in YYYY-MM-DD format (catch-up nudge backfill, Issue #288). Only used when there's no source. */
+  initialDate?: string
   onSaved: () => void
   /** Ref to register a setter for voice-parsed results. Parent passes ref, form fills it on mount. */
   onVoiceParsedRef?: RefObject<((_result: ParsedExpense) => void) | null>
 }
 
 
-export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoiceParsedRef }: Props) {
+export function ExpenseForm({ existingExpense, duplicateFrom, initialDate, onSaved, onVoiceParsedRef }: Props) {
   const { group } = useGroup()
   const { members } = useMembers()
   const { expenses } = useExpenses()
@@ -81,6 +83,9 @@ export function ExpenseForm({ existingExpense, duplicateFrom, onSaved, onVoicePa
 
   const [date, setDate] = useState(() => {
     if (source && !duplicateFrom) return toDate(source.date).toISOString().split('T')[0]
+    // Initial date from prop (e.g. catchup-nudge backfill, Issue #288).
+    // Format YYYY-MM-DD; only used when there's no source to copy from.
+    if (initialDate && /^\d{4}-\d{2}-\d{2}$/.test(initialDate)) return initialDate
     return new Date().toISOString().split('T')[0]
   })
   const [description, setDescription] = useState(source?.description ?? '')

--- a/src/lib/catchup-detector.ts
+++ b/src/lib/catchup-detector.ts
@@ -1,0 +1,77 @@
+/**
+ * Detect "user has been quiet for too long" gaps that warrant a catch-up
+ * nudge on the home page (Issue #288).
+ *
+ * The biggest data-quality failure mode for any expense tracker is "I forgot
+ * to record". Surfacing the gap right after the user opens the app gives
+ * them a chance to backfill while memory is fresh. The function returns
+ * null when there's no gap worth nudging about (no expenses yet, or
+ * recorded recently); otherwise it returns the gap size in days.
+ *
+ * Pure function. Caller owns dismiss state (we recommend session-only —
+ * see component).
+ */
+import { toDate } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+const DEFAULT_THRESHOLD_DAYS = 4
+
+export interface CatchupNudge {
+  /** Whole days since the most recent recorded expense. */
+  daysGap: number
+  /** ISO YYYY-MM-DD of the most recent recorded date — for context display. */
+  lastRecordedDate: string
+}
+
+interface DetectInput {
+  expenses: readonly Expense[]
+  /** Current time (injectable for tests). */
+  now?: number
+  /** Threshold in days; default 4. */
+  thresholdDays?: number
+}
+
+function safeT(e: Expense): number | null {
+  try {
+    const d = toDate(e.date)
+    const t = d.getTime()
+    return Number.isFinite(t) ? t : null
+  } catch {
+    return null
+  }
+}
+
+function isoDay(t: number): string {
+  const d = new Date(t)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+export function detectCatchupNudge({
+  expenses,
+  now = Date.now(),
+  thresholdDays = DEFAULT_THRESHOLD_DAYS,
+}: DetectInput): CatchupNudge | null {
+  if (expenses.length === 0) return null
+
+  // Find the most recent valid expense date
+  let mostRecent: number | null = null
+  for (const e of expenses) {
+    const t = safeT(e)
+    if (t === null) continue
+    if (mostRecent === null || t > mostRecent) mostRecent = t
+  }
+
+  if (mostRecent === null) return null
+
+  // Day-level gap: zero out time portion of both dates so a record yesterday
+  // at any time counts as "1 day gap" not partial.
+  const today = new Date(now)
+  const todayUtc = Date.UTC(today.getFullYear(), today.getMonth(), today.getDate())
+  const last = new Date(mostRecent)
+  const lastUtc = Date.UTC(last.getFullYear(), last.getMonth(), last.getDate())
+  const daysGap = Math.floor((todayUtc - lastUtc) / 86_400_000)
+
+  if (daysGap < thresholdDays) return null
+
+  return { daysGap, lastRecordedDate: isoDay(mostRecent) }
+}


### PR DESCRIPTION
## Idea
記帳最大失敗：忘記記。surface gap + 一鍵記補昨/今日。

## Why creative
不是更多 chart，是**減少需要使用者主動記得**的設計。Banner 出現的時機是 user 打開 app 那一刻 — 記憶最 fresh。

## Files
- \`src/lib/catchup-detector.ts\` (pure)
- \`src/components/catchup-nudge.tsx\` (UI)
- \`src/app/(auth)/page.tsx\` (整合)
- \`src/app/(auth)/expense/new/page.tsx\` + \`src/components/expense-form.tsx\` (initialDate URL param)
- \`__tests__/catchup-detector.test.ts\` (12 cases)

Closes #288