### PR TITLE
feat(home): 30 天 spending heatmap (Closes #290)

### DIFF
--- a/__tests__/spending-heatmap.test.ts
+++ b/__tests__/spending-heatmap.test.ts
@@ -1,0 +1,119 @@
+import { aggregateDailyBuckets } from '@/lib/spending-heatmap'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15
+
+function mk(id: string, amount: number, daysAgo: number): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('aggregateDailyBuckets', () => {
+  it('returns empty array when days <= 0', () => {
+    expect(aggregateDailyBuckets({ expenses: [], days: 0, now: NOW })).toEqual([])
+    expect(aggregateDailyBuckets({ expenses: [], days: -1, now: NOW })).toEqual([])
+  })
+
+  it('returns N buckets for the requested window', () => {
+    const r = aggregateDailyBuckets({ expenses: [], days: 7, now: NOW })
+    expect(r).toHaveLength(7)
+    // Last bucket should be today (2026-04-15)
+    expect(r[r.length - 1].date).toBe('2026-04-15')
+    // First bucket should be 6 days earlier
+    expect(r[0].date).toBe('2026-04-09')
+  })
+
+  it('aggregates totals by day', () => {
+    const expenses = [
+      mk('a', 100, 0), // today
+      mk('b', 200, 0), // today
+      mk('c', 50, 1), // yesterday
+    ]
+    const r = aggregateDailyBuckets({ expenses, days: 7, now: NOW })
+    const today = r[r.length - 1]
+    const yesterday = r[r.length - 2]
+    expect(today.total).toBe(300)
+    expect(today.count).toBe(2)
+    expect(yesterday.total).toBe(50)
+    expect(yesterday.count).toBe(1)
+  })
+
+  it('intensity is 1 for max bucket and proportional for others', () => {
+    const expenses = [
+      mk('a', 100, 0), // today: 100
+      mk('b', 50, 1), // yesterday: 50
+      mk('c', 25, 2), // 2 days ago: 25
+    ]
+    const r = aggregateDailyBuckets({ expenses, days: 5, now: NOW })
+    const today = r[r.length - 1]
+    const yesterday = r[r.length - 2]
+    const twoAgo = r[r.length - 3]
+    expect(today.intensity).toBe(1)
+    expect(yesterday.intensity).toBe(0.5)
+    expect(twoAgo.intensity).toBe(0.25)
+    // Empty days should be 0
+    expect(r[0].intensity).toBe(0)
+  })
+
+  it('all-zero window has 0 intensity for every bucket', () => {
+    const r = aggregateDailyBuckets({ expenses: [], days: 7, now: NOW })
+    expect(r.every((b) => b.intensity === 0)).toBe(true)
+  })
+
+  it('skips expenses outside the window', () => {
+    const expenses = [
+      mk('inside', 100, 0),
+      mk('outside_old', 999, 30), // 30 days back, outside 7-day window
+    ]
+    const r = aggregateDailyBuckets({ expenses, days: 7, now: NOW })
+    const totals = r.reduce((sum, b) => sum + b.total, 0)
+    expect(totals).toBe(100)
+  })
+
+  it('skips records with non-finite amount', () => {
+    const expenses = [mk('a', 100, 0), mk('bad', NaN, 0), mk('inf', Infinity, 0)]
+    const r = aggregateDailyBuckets({ expenses, days: 1, now: NOW })
+    expect(r[0].total).toBe(100)
+    expect(r[0].count).toBe(1)
+  })
+
+  it('skips records with bad date', () => {
+    const bad = { ...mk('a', 100, 0), date: 'oops' } as unknown as Expense
+    const r = aggregateDailyBuckets({ expenses: [bad], days: 1, now: NOW })
+    expect(r[0].total).toBe(0)
+  })
+
+  it('handles 30-day window without crashing', () => {
+    const expenses = Array.from({ length: 30 }, (_, i) => mk(String(i), (i + 1) * 10, i))
+    const r = aggregateDailyBuckets({ expenses, days: 30, now: NOW })
+    expect(r).toHaveLength(30)
+    // Each bucket should have positive total
+    expect(r.every((b) => b.total > 0)).toBe(true)
+    // Intensity in [0, 1]
+    expect(r.every((b) => b.intensity >= 0 && b.intensity <= 1)).toBe(true)
+  })
+
+  it('multiple expenses on same day combine into one bucket', () => {
+    const expenses = [mk('a', 100, 5), mk('b', 200, 5), mk('c', 50, 5)]
+    const r = aggregateDailyBuckets({ expenses, days: 10, now: NOW })
+    const dayBucket = r[r.length - 6]
+    expect(dayBucket.total).toBe(350)
+    expect(dayBucket.count).toBe(3)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -19,6 +19,7 @@ import { RecentExpensesList } from '@/components/recent-expenses-list'
 import { MemberSpendingBreakdown } from '@/components/member-spending-breakdown'
 import { SubscriptionSuggestions } from '@/components/subscription-suggestions'
 import { CatchupNudge } from '@/components/catchup-nudge'
+import { SpendingHeatmap } from '@/components/spending-heatmap'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -239,6 +240,9 @@ export default function HomePage() {
 
       {/* 月度預算進度 */}
       <BudgetProgress group={group} expenses={expenses} />
+
+      {/* 30 天每日花費熱力圖 (Issue #290) */}
+      <SpendingHeatmap expenses={expenses} />
 
       {/* Dashboard grid: 桌面版 2 欄，手機版單欄 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 mt-4 md:mt-6">

--- a/src/components/spending-heatmap.tsx
+++ b/src/components/spending-heatmap.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { aggregateDailyBuckets, type DailyBucket } from '@/lib/spending-heatmap'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface SpendingHeatmapProps {
+  expenses: Expense[]
+  /** Number of days back from today, inclusive. Default 30. */
+  days?: number
+}
+
+function bucketColor(intensity: number): string {
+  // 0 → muted gray; >0 → primary tint scaling by intensity (using OKLCH
+  // alpha mix so it respects light/dark themes via CSS vars).
+  if (intensity <= 0) return 'var(--muted)'
+  // Map intensity (0..1) to alpha 15..85% of var(--primary)
+  const alpha = 15 + Math.round(intensity * 70)
+  return `color-mix(in oklch, var(--primary) ${alpha}%, transparent)`
+}
+
+function dowLabel(dateIso: string): string {
+  const [y, m, d] = dateIso.split('-').map(Number)
+  const wd = new Date(y, m - 1, d).getDay()
+  return ['日', '一', '二', '三', '四', '五', '六'][wd]
+}
+
+/**
+ * 30-day spending heatmap (Issue #290). Square grid where each cell is one
+ * day, tinted by share of the window's max daily spend. Click → drill down
+ * to /records filtered to that day.
+ */
+export function SpendingHeatmap({ expenses, days = 30 }: SpendingHeatmapProps) {
+  const buckets = useMemo(
+    () => aggregateDailyBuckets({ expenses, days }),
+    [expenses, days],
+  )
+
+  const total = useMemo(
+    () => buckets.reduce((s, b) => s + b.total, 0),
+    [buckets],
+  )
+
+  if (total === 0) return null
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+          📅 最近 {days} 天 · 每日花費熱力圖
+        </div>
+        <div className="text-xs text-[var(--muted-foreground)]">
+          總計 {currency(total)}
+        </div>
+      </div>
+      <div className="grid grid-cols-10 gap-1.5 sm:gap-2">
+        {buckets.map((b) => (
+          <DayCell key={b.date} bucket={b} />
+        ))}
+      </div>
+      <div className="flex items-center gap-1.5 text-[10px] text-[var(--muted-foreground)]">
+        <span>少</span>
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: bucketColor(0) }} />
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: bucketColor(0.25) }} />
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: bucketColor(0.5) }} />
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: bucketColor(0.75) }} />
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: bucketColor(1) }} />
+        <span>多</span>
+      </div>
+    </div>
+  )
+}
+
+function DayCell({ bucket }: { bucket: DailyBucket }) {
+  const [, m, d] = bucket.date.split('-')
+  const label = bucket.total > 0
+    ? `${m}/${parseInt(d, 10)}（${dowLabel(bucket.date)}）${currency(bucket.total)}（${bucket.count} 筆）`
+    : `${m}/${parseInt(d, 10)}（${dowLabel(bucket.date)}）無記錄`
+
+  if (bucket.total === 0) {
+    return (
+      <div
+        className="aspect-square rounded-sm"
+        style={{ backgroundColor: bucketColor(0) }}
+        title={label}
+        aria-label={label}
+      />
+    )
+  }
+
+  return (
+    <Link
+      href={`/records?start=${bucket.date}&end=${bucket.date}`}
+      className="aspect-square rounded-sm hover:ring-2 hover:ring-[var(--primary)] transition-all"
+      style={{ backgroundColor: bucketColor(bucket.intensity) }}
+      title={label}
+      aria-label={label}
+    />
+  )
+}

--- a/src/lib/spending-heatmap.ts
+++ b/src/lib/spending-heatmap.ts
@@ -1,0 +1,92 @@
+/**
+ * Aggregate expenses into a fixed-size daily window for heatmap rendering
+ * (Issue #290). Pure function — caller passes raw expenses + window size,
+ * receives an array of {date, total, count} aligned to consecutive days
+ * ending today.
+ */
+import { toDate } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+export interface DailyBucket {
+  /** ISO YYYY-MM-DD. */
+  date: string
+  total: number
+  count: number
+  /** 0..1 intensity vs the max bucket in the same window. 0 when empty. */
+  intensity: number
+}
+
+interface AggregateInput {
+  expenses: readonly Expense[]
+  /** How many days back from `now`, inclusive of today. */
+  days: number
+  now?: number
+}
+
+function startOfDay(t: number): number {
+  const d = new Date(t)
+  return Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())
+}
+
+function isoDay(t: number): string {
+  const d = new Date(t)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+export function aggregateDailyBuckets({
+  expenses,
+  days,
+  now = Date.now(),
+}: AggregateInput): DailyBucket[] {
+  if (days <= 0) return []
+
+  // Build the window from `days-1` days ago up to today, in local time
+  const today = new Date(now)
+  const todayLocal = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+  const windowStartTs = todayLocal.getTime() - (days - 1) * 86_400_000
+
+  // Index expenses by local-day key
+  const byDay = new Map<string, { total: number; count: number }>()
+  for (const e of expenses) {
+    if (typeof e.amount !== 'number' || !Number.isFinite(e.amount)) continue
+    let dt: Date
+    try {
+      dt = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(dt.getTime())) continue
+    const key = `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`
+    const cur = byDay.get(key) ?? { total: 0, count: 0 }
+    cur.total += e.amount
+    cur.count += 1
+    byDay.set(key, cur)
+  }
+
+  // Build the consecutive-day array
+  const buckets: DailyBucket[] = []
+  for (let i = 0; i < days; i++) {
+    const t = windowStartTs + i * 86_400_000
+    const localD = new Date(t)
+    // Use local date components — startOfDay used UTC variant which is
+    // fine for stable iso keys but we want match against byDay keys which
+    // are local. Recompute the local key here.
+    const key = `${localD.getFullYear()}-${String(localD.getMonth() + 1).padStart(2, '0')}-${String(localD.getDate()).padStart(2, '0')}`
+    const data = byDay.get(key) ?? { total: 0, count: 0 }
+    buckets.push({ date: key, total: data.total, count: data.count, intensity: 0 })
+  }
+
+  // Compute intensity 0..1 against window max
+  let max = 0
+  for (const b of buckets) if (b.total > max) max = b.total
+  if (max > 0) {
+    for (const b of buckets) {
+      b.intensity = b.total / max
+    }
+  }
+
+  return buckets
+}
+
+/** Pure helper exported for tests. */
+export { startOfDay, isoDay }


### PR DESCRIPTION
## Idea
GitHub contribution graph 的概念套到家庭支出。30 個方格 = 30 天，深淺 = 該日花費 vs window max。家庭看 pattern（週末/月中飆升）一目了然。

## Why creative
不是另一個 number card / chart。視覺化「時間 × 強度」二維資訊。低 cost、高 information density。

## Files
- \`src/lib/spending-heatmap.ts\` (pure)
- \`src/components/spending-heatmap.tsx\` (UI)
- \`src/app/(auth)/page.tsx\` (整合)
- \`__tests__/spending-heatmap.test.ts\` (10 cases)

Closes #290