### PR TITLE
feat(home): 週幾花費模式洞察 — 揭露 day-of-week 消費盲點 (Closes #292)

### DIFF
--- a/__tests__/dow-insight.test.ts
+++ b/__tests__/dow-insight.test.ts
@@ -1,0 +1,195 @@
+import {
+  analyzeDayOfWeekPattern,
+  isInsightWorthShowing,
+  dowLabelTC,
+} from '@/lib/dow-insight'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, 2026 = Wednesday
+
+function mk(id: string, amount: number, daysAgo: number): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('analyzeDayOfWeekPattern', () => {
+  it('returns null when days <= 0', () => {
+    expect(analyzeDayOfWeekPattern({ expenses: [], days: 0, now: NOW })).toBeNull()
+    expect(analyzeDayOfWeekPattern({ expenses: [], days: -1, now: NOW })).toBeNull()
+  })
+
+  it('returns zero distribution for empty expenses', () => {
+    const r = analyzeDayOfWeekPattern({ expenses: [], days: 60, now: NOW })
+    expect(r).not.toBeNull()
+    expect(r!.averages).toEqual([0, 0, 0, 0, 0, 0, 0])
+    expect(r!.peakRatio).toBeNull()
+    expect(r!.lowestDow).toBeNull()
+    expect(r!.weekendShare).toBe(0)
+    expect(r!.totalSpendingDays).toBe(0)
+  })
+
+  it('counts each weekday occurrence in 60-day window correctly (Wed-anchored)', () => {
+    // April 15 (Wed) back 59 days = Feb 15 (Sun). Window = Feb 15..Apr 15 (60 days).
+    // 60 / 7 = 8 weeks + 4 extra days starting Sun.
+    // Sun/Mon/Tue/Wed = 9 each, Thu/Fri/Sat = 8 each.
+    const r = analyzeDayOfWeekPattern({ expenses: [], days: 60, now: NOW })
+    expect(r!.occurrences).toEqual([9, 9, 9, 9, 8, 8, 8])
+  })
+
+  it('aggregates spending by weekday', () => {
+    const expenses = [
+      mk('a', 700, 0), // Wed (today)
+      mk('b', 700, 7), // Wed (last week)
+      mk('c', 100, 1), // Tue (yesterday)
+    ]
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(r!.totals[3]).toBe(1400) // Wed
+    expect(r!.totals[2]).toBe(100) // Tue
+    expect(r!.averages[3]).toBeCloseTo(1400 / 9)
+    expect(r!.averages[2]).toBeCloseTo(100 / 9)
+    expect(r!.peakDow).toBe(3)
+    expect(r!.lowestDow).toBe(2)
+    expect(r!.peakRatio).toBeCloseTo(14, 1) // 1400/100
+  })
+
+  it('skips records outside window', () => {
+    const expenses = [mk('inside', 100, 0), mk('outside', 999, 90)]
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(r!.totals.reduce((s, x) => s + x, 0)).toBe(100)
+  })
+
+  it('skips records with bad amounts', () => {
+    const expenses = [
+      mk('ok', 100, 0),
+      mk('nan', NaN, 0),
+      mk('inf', Infinity, 0),
+      mk('zero', 0, 0),
+      mk('neg', -50, 0),
+    ]
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(r!.totals[3]).toBe(100)
+  })
+
+  it('skips records with bad date', () => {
+    const bad = { ...mk('a', 100, 0), date: 'oops' } as unknown as Expense
+    const good = mk('b', 50, 0)
+    const r = analyzeDayOfWeekPattern({ expenses: [bad, good], days: 60, now: NOW })
+    expect(r!.totals[3]).toBe(50)
+  })
+
+  it('weekendShare counts Sat+Sun share of total', () => {
+    const expenses = [
+      mk('sat', 100, 4), // April 11 (Sat)
+      mk('sun', 100, 3), // April 12 (Sun)
+      mk('mon', 100, 2), // April 13 (Mon)
+    ]
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(r!.totals[6]).toBe(100) // Sat
+    expect(r!.totals[0]).toBe(100) // Sun
+    expect(r!.totals[1]).toBe(100) // Mon
+    expect(r!.weekendShare).toBeCloseTo(2 / 3)
+  })
+
+  it('combines multiple expenses on same day', () => {
+    const expenses = [mk('a', 100, 5), mk('b', 200, 5), mk('c', 50, 5)]
+    // 5 days ago = April 10 = Friday (dow 5)
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(r!.totals[5]).toBe(350)
+    expect(r!.totalSpendingDays).toBe(1)
+  })
+
+  it('totalSpendingDays counts unique dates only', () => {
+    const expenses = [
+      mk('a', 100, 0),
+      mk('b', 100, 0), // same day as a
+      mk('c', 100, 1),
+      mk('d', 100, 7),
+    ]
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(r!.totalSpendingDays).toBe(3)
+  })
+
+  it('lowestDow equals peakDow when only one weekday has spending', () => {
+    const expenses = [mk('a', 100, 0)] // Wed only
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(r!.peakDow).toBe(3)
+    expect(r!.lowestDow).toBe(3)
+    expect(r!.peakRatio).toBe(1)
+  })
+})
+
+describe('isInsightWorthShowing', () => {
+  it('rejects when not enough distinct spending days', () => {
+    const r = analyzeDayOfWeekPattern({
+      expenses: [mk('a', 5000, 0), mk('b', 5000, 1)],
+      days: 60,
+      now: NOW,
+    })
+    expect(isInsightWorthShowing(r!)).toBe(false) // only 2 distinct dates
+  })
+
+  it('rejects when total spend too low', () => {
+    const expenses = Array.from({ length: 10 }, (_, i) => mk(String(i), 50, i))
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(isInsightWorthShowing(r!)).toBe(false) // total only 500
+  })
+
+  it('shows insight when peakRatio >= 1.5', () => {
+    const expenses = [
+      // Saturday-heavy: 5 sats × 1000, 5 weekday days × 100
+      mk('s1', 1000, 4), // Sat
+      mk('s2', 1000, 11), // Sat
+      mk('s3', 1000, 18), // Sat
+      mk('s4', 1000, 25), // Sat
+      mk('s5', 1000, 32), // Sat
+      mk('w1', 100, 1), // Tue
+      mk('w2', 100, 2), // Mon
+      mk('w3', 100, 8), // Tue
+      mk('w4', 100, 9), // Mon
+      mk('w5', 100, 15), // Tue
+    ]
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(isInsightWorthShowing(r!)).toBe(true)
+    expect(r!.peakRatio!).toBeGreaterThan(1.5)
+  })
+
+  it('shows insight when weekendShare >= 0.55', () => {
+    // Spread across weekend + a couple weekdays, weekend dominates
+    const expenses = [
+      mk('s1', 800, 4), // Sat
+      mk('s2', 800, 3), // Sun
+      mk('s3', 800, 11), // Sat
+      mk('s4', 800, 10), // Sun
+      mk('w1', 100, 1), // Tue
+      mk('w2', 100, 2), // Mon
+    ]
+    const r = analyzeDayOfWeekPattern({ expenses, days: 60, now: NOW })
+    expect(r!.weekendShare).toBeGreaterThanOrEqual(0.55)
+    expect(isInsightWorthShowing(r!)).toBe(true)
+  })
+})
+
+describe('dowLabelTC', () => {
+  it('returns Chinese weekday labels', () => {
+    expect(dowLabelTC(0)).toBe('日')
+    expect(dowLabelTC(1)).toBe('一')
+    expect(dowLabelTC(6)).toBe('六')
+    expect(dowLabelTC(99)).toBe('?')
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -20,6 +20,7 @@ import { MemberSpendingBreakdown } from '@/components/member-spending-breakdown'
 import { SubscriptionSuggestions } from '@/components/subscription-suggestions'
 import { CatchupNudge } from '@/components/catchup-nudge'
 import { SpendingHeatmap } from '@/components/spending-heatmap'
+import { DowInsight } from '@/components/dow-insight'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -243,6 +244,9 @@ export default function HomePage() {
 
       {/* 30 天每日花費熱力圖 (Issue #290) */}
       <SpendingHeatmap expenses={expenses} />
+
+      {/* 週幾花費模式洞察 (Issue #292) */}
+      <DowInsight expenses={expenses} />
 
       {/* Dashboard grid: 桌面版 2 欄，手機版單欄 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 mt-4 md:mt-6">

--- a/src/components/dow-insight.tsx
+++ b/src/components/dow-insight.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  analyzeDayOfWeekPattern,
+  dowLabelTC,
+  isInsightWorthShowing,
+  type DowInsightData,
+} from '@/lib/dow-insight'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface DowInsightProps {
+  expenses: Expense[]
+  /** Window length back from today. Default 60. */
+  days?: number
+}
+
+function composeSentences(d: DowInsightData): string[] {
+  const sentences: string[] = []
+
+  if (d.peakRatio !== null && d.peakRatio >= 1.5 && d.lowestDow !== null) {
+    const peakAvg = d.averages[d.peakDow]
+    sentences.push(
+      `你週${dowLabelTC(d.peakDow)}平均花費 ${currency(peakAvg)}，是週${dowLabelTC(d.lowestDow)}的 ${d.peakRatio.toFixed(1)} 倍`,
+    )
+  }
+
+  if (d.weekendShare >= 0.55) {
+    const pct = Math.round(d.weekendShare * 100)
+    sentences.push(`週末（六/日）佔了本週 ${pct}% 的支出`)
+  } else if (d.weekendShare > 0 && d.weekendShare <= 0.2) {
+    const pct = Math.round(d.weekendShare * 100)
+    sentences.push(`你是平日支出派 — 週末只佔 ${pct}%`)
+  }
+
+  return sentences
+}
+
+/**
+ * Day-of-week pattern insight (Issue #292). Surfaces cyclical spending
+ * habits the user may not consciously notice — peak weekday, weekend
+ * concentration. Renders a mini bar chart for the seven weekdays so the
+ * narrative claim is visually verifiable.
+ */
+export function DowInsight({ expenses, days = 60 }: DowInsightProps) {
+  const data = useMemo(
+    () => analyzeDayOfWeekPattern({ expenses, days }),
+    [expenses, days],
+  )
+
+  if (!data || !isInsightWorthShowing(data)) return null
+
+  const sentences = composeSentences(data)
+  if (sentences.length === 0) return null
+
+  const max = Math.max(...data.averages, 1)
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        🗓️ 最近 {data.windowDays} 天 · 週幾花費模式
+      </div>
+
+      <div className="space-y-1.5">
+        {sentences.map((s, i) => (
+          <p
+            key={i}
+            className="text-sm leading-relaxed text-[var(--foreground)]"
+            style={i === 0 ? { fontWeight: 500 } : undefined}
+          >
+            {s}
+          </p>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 gap-1 pt-1">
+        {data.averages.map((avg, i) => {
+          const h = max > 0 ? Math.max(4, Math.round((avg / max) * 32)) : 4
+          const isPeak = i === data.peakDow && avg > 0
+          return (
+            <div key={i} className="flex flex-col items-center gap-1">
+              <div className="flex items-end h-9 w-full">
+                <div
+                  className="w-full rounded-sm transition-all"
+                  style={{
+                    height: `${h}px`,
+                    backgroundColor: isPeak
+                      ? 'var(--primary)'
+                      : 'color-mix(in oklch, var(--primary) 35%, transparent)',
+                  }}
+                  title={`週${dowLabelTC(i)} ${currency(avg)}/次`}
+                  aria-label={`週${dowLabelTC(i)} 平均 ${currency(avg)}`}
+                />
+              </div>
+              <span className="text-[10px] text-[var(--muted-foreground)]">
+                {dowLabelTC(i)}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/dow-insight.ts
+++ b/src/lib/dow-insight.ts
@@ -1,0 +1,139 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface DowInsightData {
+  /** Average spending per occurrence of each weekday (index 0=Sun..6=Sat). */
+  averages: number[]
+  /** Total spending per weekday across the window. */
+  totals: number[]
+  /** Number of distinct dates falling on each weekday within the window. */
+  occurrences: number[]
+  /** Day-of-week with highest average. */
+  peakDow: number
+  /** Day-of-week with lowest non-zero average, or null if no spending. */
+  lowestDow: number | null
+  /** peakAvg / lowestAvg, or null if either is zero. */
+  peakRatio: number | null
+  /** Share of total spending on Saturday + Sunday (0..1). */
+  weekendShare: number
+  /** Distinct dates with positive spending in window. Quality signal. */
+  totalSpendingDays: number
+  /** Window length in days. */
+  windowDays: number
+}
+
+interface AnalyzeOptions {
+  expenses: Expense[]
+  /** Now in epoch ms; defaults to Date.now(). */
+  now?: number
+  /** Window length back from today (inclusive). Default 60. */
+  days?: number
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Cyclical day-of-week aggregation over a rolling window. Uses occurrence
+ * counts per weekday so averages are stable when the window is uneven (60
+ * days = 8-9 of each weekday). Returns null only for malformed window input;
+ * an all-zero result is still meaningful (caller decides whether to render).
+ */
+export function analyzeDayOfWeekPattern({
+  expenses,
+  now = Date.now(),
+  days = 60,
+}: AnalyzeOptions): DowInsightData | null {
+  if (!Number.isFinite(days) || days <= 0) return null
+
+  const endLocal = new Date(now)
+  endLocal.setHours(23, 59, 59, 999)
+  const startLocal = new Date(endLocal)
+  startLocal.setDate(startLocal.getDate() - (days - 1))
+  startLocal.setHours(0, 0, 0, 0)
+  const startMs = startLocal.getTime()
+  const endMs = endLocal.getTime()
+
+  const dateTotals = new Map<string, number>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    const ts = d.getTime()
+    if (!Number.isFinite(ts) || ts < startMs || ts > endMs) continue
+    const k = dateKey(d)
+    dateTotals.set(k, (dateTotals.get(k) ?? 0) + amount)
+  }
+
+  const totals = [0, 0, 0, 0, 0, 0, 0]
+  const occurrences = [0, 0, 0, 0, 0, 0, 0]
+  const cur = new Date(startLocal)
+  for (let i = 0; i < days; i++) {
+    const dow = cur.getDay()
+    occurrences[dow]++
+    totals[dow] += dateTotals.get(dateKey(cur)) ?? 0
+    cur.setDate(cur.getDate() + 1)
+  }
+
+  const averages = totals.map((t, i) => (occurrences[i] > 0 ? t / occurrences[i] : 0))
+
+  let peakDow = 0
+  for (let i = 1; i < 7; i++) {
+    if (averages[i] > averages[peakDow]) peakDow = i
+  }
+
+  let lowestDow: number | null = null
+  for (let i = 0; i < 7; i++) {
+    if (averages[i] > 0 && (lowestDow === null || averages[i] < averages[lowestDow])) {
+      lowestDow = i
+    }
+  }
+
+  const peakRatio =
+    lowestDow !== null && averages[lowestDow] > 0 && averages[peakDow] > 0
+      ? averages[peakDow] / averages[lowestDow]
+      : null
+
+  const totalSpend = totals.reduce((s, x) => s + x, 0)
+  const weekendSpend = totals[0] + totals[6]
+  const weekendShare = totalSpend > 0 ? weekendSpend / totalSpend : 0
+
+  return {
+    averages,
+    totals,
+    occurrences,
+    peakDow,
+    lowestDow,
+    peakRatio,
+    weekendShare,
+    totalSpendingDays: dateTotals.size,
+    windowDays: days,
+  }
+}
+
+const DOW_LABEL_TC = ['日', '一', '二', '三', '四', '五', '六']
+
+export function dowLabelTC(dow: number): string {
+  return DOW_LABEL_TC[dow] ?? '?'
+}
+
+/**
+ * Whether the data is "interesting enough" to surface as a banner.
+ * Filter out trivial windows (too little spending, too little variation)
+ * so the home page only shows insights worth reading.
+ */
+export function isInsightWorthShowing(d: DowInsightData): boolean {
+  if (d.totalSpendingDays < 5) return false
+  const totalSpend = d.totals.reduce((s, x) => s + x, 0)
+  if (totalSpend < 1000) return false
+  const significantRatio = d.peakRatio !== null && d.peakRatio >= 1.5
+  const significantWeekend = d.weekendShare >= 0.55 || d.weekendShare > 0 && d.weekendShare <= 0.2
+  return significantRatio || significantWeekend
+}


### PR DESCRIPTION
## 為什麼

熱力圖（#290）視覺化每日強度，Money Diary（#282）用敘事描述月度。但都沒回答一個基本盲點：**「我在哪幾天最容易花錢？」**

人對自己的 day-of-week 偏好通常沒感覺——可能週六平均花費是週一的 3 倍但無意識重複。

## 做了什麼

`src/lib/dow-insight.ts` — 純函式：
- 滾動 60 天視窗，按 occurrence count 平均（避免「週一只出現 8 次」這類視窗不均偏差）
- 計算 7 個 weekday 的 totals/averages/occurrences
- 找出 peak dow + lowest non-zero dow + peak/lowest 比例
- 計算週末花費佔比（Sat+Sun / total）
- 返回 `DowInsightData`，由 caller 決定是否呈現

`isInsightWorthShowing(data)` — threshold gate，只在以下條件呈現：
- 至少 5 個花費日（避免 1-2 筆資料瞎猜）
- 總花費 ≥ NT\$1,000（避免微量不必要 surface）
- peakRatio ≥ 1.5 OR weekendShare ≥ 55% OR weekendShare ≤ 20%（必須有顯著 pattern）

`src/components/dow-insight.tsx` — UI：
- 1-2 句敘事洞察（中文，自然語氣）
- 7-day mini bar chart（peak dow 用 primary 色突顯，其餘 35% alpha mix）
- 只在 `isInsightWorthShowing` 為 true 時 render（一致與其他 widget 的「靜默原則」）

`src/app/(auth)/page.tsx` — 整合：
- SpendingHeatmap 之後，BudgetProgress 之前
- 形成「日強度（heatmap）→ 週模式（DowInsight）→ 月敘事（Money Diary）」的 self-awareness 三層

## 範例輸出

> 你週六平均花費 NT\$623，是週一的 2.3 倍
> 週末（六/日）佔了本週 58% 的支出

或：
> 你是平日支出派 — 週末只佔 12%

## 測試

16 個單元測試 ✅
- null on bad input (`days <= 0`)
- 空資料返回 zero distribution
- 60 天視窗 weekday occurrence 計算正確（Wed-anchored）
- 多筆同日聚合
- 跳過視窗外、bad amount/date 紀錄
- weekend share 計算
- 邊界：單一 dow 時 peak == lowest
- `isInsightWorthShowing` threshold gate
- `dowLabelTC` Chinese label

整套 `npm run test`：1084/1084 passed。

## 風險與回退

- 無資料變更，純讀取
- 純函式無 Firebase 依賴，jsdom test 安全
- 若資料不滿 threshold，元件靜默不 render（與 Money Diary、CatchupNudge、SubscriptionDetector 一致）

Closes #292