### PR TITLE
feat(home): 連續記帳天數 streak — gamify 健康記帳習慣 (Closes #294)

### DIFF
--- a/__tests__/recording-streak.test.ts
+++ b/__tests__/recording-streak.test.ts
@@ -1,0 +1,151 @@
+import { computeRecordingStreak } from '@/lib/recording-streak'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, 2026
+
+function mk(id: string, daysAgo: number, hour = 10): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  d.setHours(hour, 0, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount: 100,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('computeRecordingStreak', () => {
+  it('returns null when no expenses', () => {
+    expect(computeRecordingStreak({ expenses: [], now: NOW })).toBeNull()
+  })
+
+  it('returns null when only invalid createdAt entries', () => {
+    const bad = { ...mk('a', 0), createdAt: 'oops' } as unknown as Expense
+    expect(computeRecordingStreak({ expenses: [bad], now: NOW })).toBeNull()
+  })
+
+  it('counts current streak ending today inclusive', () => {
+    const expenses = [mk('a', 0), mk('b', 1), mk('c', 2)]
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.currentStreak).toBe(3)
+    expect(r!.recordedToday).toBe(true)
+    expect(r!.longestStreak).toBe(3)
+    expect(r!.isNewRecord).toBe(true)
+  })
+
+  it('counts current streak ending yesterday when today not yet recorded', () => {
+    const expenses = [mk('a', 1), mk('b', 2), mk('c', 3)]
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.currentStreak).toBe(3)
+    expect(r!.recordedToday).toBe(false)
+  })
+
+  it('current streak = 0 when last record is 2+ days ago', () => {
+    const expenses = [mk('old', 3), mk('older', 4)]
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.currentStreak).toBe(0)
+    expect(r!.recordedToday).toBe(false)
+    expect(r!.longestStreak).toBe(2)
+  })
+
+  it('longestStreak finds best historical run', () => {
+    // Streak 1: 2-3 days ago = 2 days. Streak 2: 6-9 days ago = 4 days.
+    const expenses = [mk('a', 2), mk('b', 3), mk('c', 6), mk('d', 7), mk('e', 8), mk('f', 9)]
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.longestStreak).toBe(4)
+    expect(r!.currentStreak).toBe(0)
+  })
+
+  it('multiple records on same day count as one streak day', () => {
+    const expenses = [mk('a', 0, 9), mk('b', 0, 14), mk('c', 0, 21), mk('d', 1)]
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.currentStreak).toBe(2)
+  })
+
+  it('isNewRecord is true only when currentStreak === longestStreak', () => {
+    const expenses = [mk('a', 0), mk('b', 1)] // current=2, longest=2
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.isNewRecord).toBe(true)
+
+    const broken = [mk('a', 0), mk('b', 5), mk('c', 6), mk('d', 7)] // current=1, longest=3
+    const r2 = computeRecordingStreak({ expenses: broken, now: NOW })
+    expect(r2!.currentStreak).toBe(1)
+    expect(r2!.longestStreak).toBe(3)
+    expect(r2!.isNewRecord).toBe(false)
+  })
+
+  it('isNewRecord false when streak is 0', () => {
+    const expenses = [mk('a', 5)]
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.currentStreak).toBe(0)
+    expect(r!.isNewRecord).toBe(false)
+  })
+
+  it('daysRecordedThisMonth counts distinct dates in current month only', () => {
+    // April 1..15 = current month
+    const expenses = [
+      mk('a', 0), // April 15
+      mk('b', 5), // April 10
+      mk('c', 14), // April 1
+      mk('d', 16), // March 30 — outside month
+      mk('e', 20), // March 26 — outside
+    ]
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.daysRecordedThisMonth).toBe(3)
+    expect(r!.daysInMonthSoFar).toBe(15)
+  })
+
+  it('lastRecordedDate is most recent record', () => {
+    const expenses = [mk('a', 5), mk('b', 0), mk('c', 10)]
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.lastRecordedDate).toBe('2026-04-15')
+  })
+
+  it('handles long streak (30 days) without errors', () => {
+    const expenses = Array.from({ length: 30 }, (_, i) => mk(String(i), i))
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.currentStreak).toBe(30)
+    expect(r!.longestStreak).toBe(30)
+  })
+
+  it('isNewRecord false for streak that ties but is not current', () => {
+    // Equal historical runs, current is shorter
+    const expenses = [
+      mk('a', 0), // current streak 1
+      mk('b', 5),
+      mk('c', 6),
+      mk('d', 7), // historical 3
+    ]
+    const r = computeRecordingStreak({ expenses, now: NOW })
+    expect(r!.currentStreak).toBe(1)
+    expect(r!.longestStreak).toBe(3)
+    expect(r!.isNewRecord).toBe(false)
+  })
+
+  it('uses createdAt not date — back-filled records do not count toward streak', () => {
+    const today = new Date(NOW)
+    today.setHours(10, 0, 0, 0)
+    const longAgoDate = new Date(NOW - 100 * 86_400_000)
+    longAgoDate.setHours(10, 0, 0, 0)
+    // Record was created today but date field set to long ago (back-fill)
+    const backFilled = {
+      ...mk('back', 100),
+      createdAt: today,
+      date: longAgoDate,
+    } as unknown as Expense
+    const r = computeRecordingStreak({ expenses: [backFilled], now: NOW })
+    expect(r!.currentStreak).toBe(1)
+    expect(r!.recordedToday).toBe(true)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -21,6 +21,7 @@ import { SubscriptionSuggestions } from '@/components/subscription-suggestions'
 import { CatchupNudge } from '@/components/catchup-nudge'
 import { SpendingHeatmap } from '@/components/spending-heatmap'
 import { DowInsight } from '@/components/dow-insight'
+import { RecordingStreak } from '@/components/recording-streak'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -190,6 +191,9 @@ export default function HomePage() {
 
       {/* Catch-up 提醒 (Issue #288) — 超過 3 天沒記時溫和提示 */}
       <CatchupNudge expenses={expenses} />
+
+      {/* 連續記帳 streak (Issue #294) — 鼓勵性 gamification */}
+      <RecordingStreak expenses={expenses} />
 
       {/* 隱藏訂閱建議 (Issue #286) */}
       <SubscriptionSuggestions

--- a/src/components/recording-streak.tsx
+++ b/src/components/recording-streak.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useMemo } from 'react'
+import { computeRecordingStreak } from '@/lib/recording-streak'
+import type { Expense } from '@/lib/types'
+
+interface RecordingStreakProps {
+  expenses: Expense[]
+}
+
+/**
+ * Recording-consistency streak (Issue #294). A small, gentle gamification
+ * card. Always renders (when there's any data) — both as encouragement
+ * when the streak is going and as a low-pressure invitation to restart
+ * after a break. Uses `createdAt`, not `date`, so back-filling can't fake
+ * a streak.
+ */
+export function RecordingStreak({ expenses }: RecordingStreakProps) {
+  const data = useMemo(
+    () => computeRecordingStreak({ expenses }),
+    [expenses],
+  )
+
+  if (!data) return null
+
+  const { currentStreak, longestStreak, daysRecordedThisMonth, daysInMonthSoFar, isNewRecord } = data
+  const monthRate =
+    daysInMonthSoFar > 0
+      ? Math.round((daysRecordedThisMonth / daysInMonthSoFar) * 100)
+      : 0
+
+  const headline = (() => {
+    if (currentStreak === 0 && longestStreak > 0) {
+      return `上次連續 ${longestStreak} 天 — 今天再開始？`
+    }
+    if (isNewRecord && currentStreak >= 2) {
+      return `🎉 新紀錄！連續記帳 ${currentStreak} 天`
+    }
+    if (currentStreak === 1) {
+      return `🌱 今天有記帳，繼續加油`
+    }
+    return `🔥 連續記帳 ${currentStreak} 天`
+  })()
+
+  const showBest = !isNewRecord && longestStreak > currentStreak && longestStreak >= 3
+
+  return (
+    <div className="card p-5 md:p-6 space-y-2 animate-fade-up">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        ✨ 記帳習慣
+      </div>
+      <p className="text-sm font-medium text-[var(--foreground)]">{headline}</p>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--muted-foreground)]">
+        {showBest && <span>歷史最佳 {longestStreak} 天</span>}
+        <span>
+          本月 {daysRecordedThisMonth} / {daysInMonthSoFar} 天 ({monthRate}%)
+        </span>
+      </div>
+      {currentStreak > 0 && (
+        <div className="flex gap-1 pt-1">
+          {Array.from({ length: Math.min(currentStreak, 14) }).map((_, i) => (
+            <span
+              key={i}
+              className="w-2 h-2 rounded-full"
+              style={{
+                backgroundColor:
+                  i < currentStreak
+                    ? 'var(--primary)'
+                    : 'color-mix(in oklch, var(--primary) 30%, transparent)',
+              }}
+              aria-hidden
+            />
+          ))}
+          {currentStreak > 14 && (
+            <span className="text-[10px] text-[var(--muted-foreground)] ml-1">
+              +{currentStreak - 14}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/recording-streak.ts
+++ b/src/lib/recording-streak.ts
@@ -1,0 +1,119 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface RecordingStreakData {
+  /** Consecutive days ending today (or yesterday if today not yet recorded) with at least one createdAt entry. */
+  currentStreak: number
+  /** All-time longest consecutive recording streak. */
+  longestStreak: number
+  /** Distinct dates within the current calendar month that have at least one createdAt entry. */
+  daysRecordedThisMonth: number
+  /** Number of days in the current calendar month up to (and including) today. */
+  daysInMonthSoFar: number
+  /** Whether today already has at least one entry. */
+  recordedToday: boolean
+  /** True iff currentStreak === longestStreak and currentStreak > 0 — celebrates a new record. */
+  isNewRecord: boolean
+  /** Date string (YYYY-MM-DD) of the most recent recording, or null if none. */
+  lastRecordedDate: string | null
+}
+
+interface ComputeOptions {
+  expenses: Expense[]
+  /** Now in epoch ms; defaults to Date.now(). */
+  now?: number
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d)
+  x.setHours(0, 0, 0, 0)
+  return x
+}
+
+/**
+ * Computes recording-consistency streak from `createdAt` (not `date`) so
+ * back-filling historical expenses can't fake a streak. The streak is the
+ * count of consecutive calendar days ending today (or yesterday if today
+ * has no record yet) on which the user added at least one expense.
+ *
+ * Returns null when there's no usable data so callers can render nothing
+ * gracefully.
+ */
+export function computeRecordingStreak({
+  expenses,
+  now = Date.now(),
+}: ComputeOptions): RecordingStreakData | null {
+  const recordedDays = new Set<string>()
+
+  for (const e of expenses) {
+    let createdAt: Date
+    try {
+      createdAt = toDate(e.createdAt)
+    } catch {
+      continue
+    }
+    const ts = createdAt.getTime()
+    if (!Number.isFinite(ts) || ts <= 0) continue
+    recordedDays.add(dateKey(createdAt))
+  }
+
+  if (recordedDays.size === 0) return null
+
+  const today = startOfDay(new Date(now))
+  const todayKey = dateKey(today)
+  const recordedToday = recordedDays.has(todayKey)
+
+  let currentStreak = 0
+  const cur = new Date(today)
+  if (!recordedToday) {
+    cur.setDate(cur.getDate() - 1)
+  }
+  while (recordedDays.has(dateKey(cur))) {
+    currentStreak++
+    cur.setDate(cur.getDate() - 1)
+  }
+
+  const sortedKeys = Array.from(recordedDays).sort()
+  let longestStreak = 0
+  let runLen = 0
+  let prevTs = -Infinity
+  for (const k of sortedKeys) {
+    const [y, m, d] = k.split('-').map(Number)
+    const ts = new Date(y, m - 1, d).getTime()
+    if (prevTs !== -Infinity && ts - prevTs === 86_400_000) {
+      runLen++
+    } else {
+      runLen = 1
+    }
+    if (runLen > longestStreak) longestStreak = runLen
+    prevTs = ts
+  }
+
+  const monthStart = new Date(today.getFullYear(), today.getMonth(), 1)
+  let daysRecordedThisMonth = 0
+  for (const k of recordedDays) {
+    const [y, m] = k.split('-').map(Number)
+    if (y === monthStart.getFullYear() && m - 1 === monthStart.getMonth()) {
+      daysRecordedThisMonth++
+    }
+  }
+  const daysInMonthSoFar = today.getDate()
+
+  const isNewRecord = currentStreak > 0 && currentStreak === longestStreak
+
+  const lastRecordedDate = sortedKeys[sortedKeys.length - 1] ?? null
+
+  return {
+    currentStreak,
+    longestStreak,
+    daysRecordedThisMonth,
+    daysInMonthSoFar,
+    recordedToday,
+    isNewRecord,
+    lastRecordedDate,
+  }
+}


### PR DESCRIPTION
## 為什麼

前 6 個 creative widget 都是分析/洞察。但有一個正向情緒缺口——**慶祝健康行為**。

家計本最大的痛點是「記著記著就忘了」。連續記帳天數讓使用者：
- 看到自己習慣養成的軌跡
- 達成新紀錄時的小成就感
- 中斷時不評判，溫和邀請重新開始

與 catchup-nudge 形成正反互補：catchup 偵測「沒記」，streak 慶祝「有記」。

## 做了什麼

`src/lib/recording-streak.ts` — 純函式：
- 用 `createdAt`（不是 `date`），所以回填歷史紀錄不會偽造 streak
- `currentStreak`：今天若已記則包含今天，否則從昨天回算
- `longestStreak`：歷史最佳
- `isNewRecord`：current === longest 時觸發 🎉
- `daysRecordedThisMonth` + `daysInMonthSoFar`：本月達成率
- `lastRecordedDate`：最近一次記帳

`src/components/recording-streak.tsx` — UI 根據狀態變化：
- 第 1 天：「🌱 今天有記帳，繼續加油」
- 連續 ≥2 且新紀錄：「🎉 新紀錄！連續記帳 N 天」
- 連續 ≥2 非新紀錄：「🔥 連續記帳 N 天｜歷史最佳 X 天」
- 中斷：「上次連續 X 天 — 今天再開始？」（**不評判**）
- 沒資料：完全靜默不顯示

加上 14 個藍色 dot 視覺進度條（最多 14 顆，超過顯示 +N）。

`src/app/(auth)/page.tsx` — 放在 CatchupNudge 之後（首屏最先看到）

## 設計理由

- 用 `createdAt` 杜絕「補登歷史」偽造 streak
- 不評判中斷：「重新開始？」比「你斷了」溫和
- 不發徽章/不 push 通知，靜默呈現避免遊戲化壓力

## 測試

14 個單元測試 ✅
- 空/壞資料返回 null
- current streak 包含今天/不含今天的分支
- 多筆同日視為一天
- isNewRecord true/false 邊界
- 跨月 daysRecordedThisMonth 計算
- 30 天長 streak 不出錯
- 回填歷史（createdAt=今天, date=100天前）→ 確認用 createdAt 而非 date

整套 `npm run test`：1098/1098 passed (新增 14 個).

## 風險與回退

- 純讀取，無資料變更
- 純函式無 Firebase 依賴
- 沒資料時靜默不 render

Closes #294