### PR TITLE
feat(home): 月底支出預估 — 依速度推算 + 歷史對比 (Closes #296)

### DIFF
--- a/__tests__/month-projection.test.ts
+++ b/__tests__/month-projection.test.ts
@@ -1,0 +1,130 @@
+import { forecastCurrentMonth } from '@/lib/month-projection'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, 2026
+
+function mkOnDate(id: string, amount: number, year: number, month: number, day: number): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('forecastCurrentMonth', () => {
+  it('returns null when fewer than minDays elapsed', () => {
+    // Day 1 of April
+    const dayOne = new Date(2026, 3, 1, 12, 0, 0).getTime()
+    const r = forecastCurrentMonth({ expenses: [], now: dayOne, minDays: 3 })
+    expect(r).toBeNull()
+  })
+
+  it('returns null when no spending in current month', () => {
+    const r = forecastCurrentMonth({ expenses: [], now: NOW })
+    expect(r).toBeNull()
+  })
+
+  it('linear pace projection', () => {
+    // April 15 = day 15 of 30-day month. Spent 1500 so far → projected 3000.
+    const expenses = [
+      mkOnDate('a', 1000, 2026, 3, 1),
+      mkOnDate('b', 500, 2026, 3, 10),
+    ]
+    const r = forecastCurrentMonth({ expenses, now: NOW })
+    expect(r!.spentSoFar).toBe(1500)
+    expect(r!.daysSoFar).toBe(15)
+    expect(r!.daysInMonth).toBe(30)
+    expect(r!.projectedTotal).toBe(3000)
+  })
+
+  it('excludes expenses outside current month from spentSoFar', () => {
+    const expenses = [
+      mkOnDate('curr', 1000, 2026, 3, 5), // April 5 — current
+      mkOnDate('prev', 999, 2026, 2, 28), // March 28 — prior
+    ]
+    const r = forecastCurrentMonth({ expenses, now: NOW })
+    expect(r!.spentSoFar).toBe(1000)
+  })
+
+  it('historicalAverage uses last 3 complete months', () => {
+    const expenses = [
+      mkOnDate('curr', 1000, 2026, 3, 5), // April (current)
+      mkOnDate('mar', 3000, 2026, 2, 15), // March
+      mkOnDate('feb', 2000, 2026, 1, 15), // February
+      mkOnDate('jan', 1000, 2026, 0, 15), // January
+      mkOnDate('dec', 999, 2025, 11, 15), // December — beyond 3-month window
+    ]
+    const r = forecastCurrentMonth({ expenses, now: NOW })
+    // Avg of Mar/Feb/Jan = (3000 + 2000 + 1000) / 3 = 2000
+    expect(r!.monthsAveraged).toBe(3)
+    expect(r!.historicalAverage).toBe(2000)
+    expect(r!.vsHistorical).toBe(r!.projectedTotal - 2000)
+  })
+
+  it('historicalAverage = null when no prior months have spending', () => {
+    const expenses = [mkOnDate('curr', 1000, 2026, 3, 5)]
+    const r = forecastCurrentMonth({ expenses, now: NOW })
+    expect(r!.historicalAverage).toBeNull()
+    expect(r!.monthsAveraged).toBe(0)
+    expect(r!.vsHistorical).toBeNull()
+  })
+
+  it('historicalAverage averages only months that have spending', () => {
+    const expenses = [
+      mkOnDate('curr', 1000, 2026, 3, 5),
+      mkOnDate('feb', 2000, 2026, 1, 15),
+    ]
+    const r = forecastCurrentMonth({ expenses, now: NOW })
+    expect(r!.monthsAveraged).toBe(1)
+    expect(r!.historicalAverage).toBe(2000)
+  })
+
+  it('skips bad amount/date', () => {
+    const bad = { ...mkOnDate('bad', 100, 2026, 3, 5), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mkOnDate('a', 100, 2026, 3, 5),
+      mkOnDate('z', NaN, 2026, 3, 5),
+      bad,
+    ]
+    const r = forecastCurrentMonth({ expenses, now: NOW })
+    expect(r!.spentSoFar).toBe(100)
+  })
+
+  it('monthProgress reflects daysSoFar / daysInMonth', () => {
+    const expenses = [mkOnDate('a', 100, 2026, 3, 1)]
+    const r = forecastCurrentMonth({ expenses, now: NOW })
+    expect(r!.monthProgress).toBeCloseTo(15 / 30)
+  })
+
+  it('handles end of month correctly', () => {
+    const lastDay = new Date(2026, 3, 30, 23, 0, 0).getTime() // April 30
+    const expenses = [mkOnDate('a', 9000, 2026, 3, 15)]
+    const r = forecastCurrentMonth({ expenses, now: lastDay })
+    expect(r!.daysSoFar).toBe(30)
+    expect(r!.daysInMonth).toBe(30)
+    expect(r!.projectedTotal).toBe(9000) // Already at full month
+  })
+
+  it('handles February (28-day month)', () => {
+    // Feb 14, 2026
+    const feb14 = new Date(2026, 1, 14, 12, 0, 0).getTime()
+    const expenses = [mkOnDate('a', 700, 2026, 1, 7)]
+    const r = forecastCurrentMonth({ expenses, now: feb14 })
+    expect(r!.daysSoFar).toBe(14)
+    expect(r!.daysInMonth).toBe(28)
+    expect(r!.projectedTotal).toBeCloseTo((700 / 14) * 28)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -22,6 +22,7 @@ import { CatchupNudge } from '@/components/catchup-nudge'
 import { SpendingHeatmap } from '@/components/spending-heatmap'
 import { DowInsight } from '@/components/dow-insight'
 import { RecordingStreak } from '@/components/recording-streak'
+import { MonthProjection } from '@/components/month-projection'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -245,6 +246,9 @@ export default function HomePage() {
 
       {/* 月度預算進度 */}
       <BudgetProgress group={group} expenses={expenses} />
+
+      {/* 月底支出預估 (Issue #296) — 依目前速度 + 歷史對比 */}
+      <MonthProjection expenses={expenses} />
 
       {/* 30 天每日花費熱力圖 (Issue #290) */}
       <SpendingHeatmap expenses={expenses} />

--- a/src/components/month-projection.tsx
+++ b/src/components/month-projection.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useMemo } from 'react'
+import { forecastCurrentMonth } from '@/lib/month-projection'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface MonthProjectionProps {
+  expenses: Expense[]
+}
+
+/**
+ * Current-month spending projection (Issue #296). Linear pace extrapolation
+ * with comparison to the trailing 3-month average. Bridges the gap between
+ * BudgetProgress (snapshot vs budget) and MoneyDiary (retrospective).
+ *
+ * Renders silently when input is too thin: < 3 days into month, or no
+ * spending yet. The point is actionable foresight, not noise.
+ */
+export function MonthProjection({ expenses }: MonthProjectionProps) {
+  const data = useMemo(
+    () => forecastCurrentMonth({ expenses }),
+    [expenses],
+  )
+
+  if (!data) return null
+
+  const {
+    daysSoFar,
+    daysInMonth,
+    spentSoFar,
+    projectedTotal,
+    monthProgress,
+    historicalAverage,
+    vsHistorical,
+    monthsAveraged,
+  } = data
+
+  const progressPct = Math.round(monthProgress * 100)
+  const trendArrow =
+    vsHistorical === null
+      ? null
+      : vsHistorical > 0
+        ? '↑'
+        : vsHistorical < 0
+          ? '↓'
+          : '→'
+  const trendColor =
+    vsHistorical === null
+      ? 'var(--muted-foreground)'
+      : vsHistorical > 0
+        ? 'var(--destructive)'
+        : 'var(--primary)'
+
+  const vsHistoricalPct =
+    historicalAverage !== null && historicalAverage > 0
+      ? Math.round(((projectedTotal - historicalAverage) / historicalAverage) * 100)
+      : null
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+          🔮 月底支出預估
+        </div>
+        <div className="text-xs text-[var(--muted-foreground)]">
+          已過 {progressPct}% ({daysSoFar}/{daysInMonth} 天)
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-sm text-[var(--foreground)]">
+          目前已花 <span className="font-semibold">{currency(spentSoFar)}</span>
+        </p>
+        <p className="text-base text-[var(--foreground)]">
+          依目前速度，月底預估{' '}
+          <span className="font-semibold text-[var(--primary)]">
+            {currency(projectedTotal)}
+          </span>
+        </p>
+      </div>
+
+      {historicalAverage !== null && vsHistoricalPct !== null && trendArrow && (
+        <p className="text-xs" style={{ color: trendColor }}>
+          {trendArrow} 比過去 {monthsAveraged} 個月平均
+          {vsHistoricalPct > 0 ? '多' : vsHistoricalPct < 0 ? '少' : '相當'}{' '}
+          {Math.abs(vsHistoricalPct)}% (
+          {currency(historicalAverage)})
+        </p>
+      )}
+
+      <div className="relative h-2 w-full rounded-full bg-[var(--muted)]">
+        <div
+          className="absolute left-0 top-0 h-full rounded-full"
+          style={{
+            width: `${Math.min(100, progressPct)}%`,
+            backgroundColor: 'color-mix(in oklch, var(--primary) 50%, transparent)',
+          }}
+          aria-label="月份進度"
+        />
+        <div
+          className="absolute top-1/2 -translate-y-1/2 w-px h-3"
+          style={{
+            left: `${Math.min(100, Math.round((spentSoFar / projectedTotal) * 100 * (daysSoFar / daysInMonth)))}%`,
+            backgroundColor: 'var(--foreground)',
+            opacity: 0.4,
+          }}
+          aria-hidden
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/lib/month-projection.ts
+++ b/src/lib/month-projection.ts
@@ -1,0 +1,112 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface MonthProjectionData {
+  /** Year of the projected month. */
+  year: number
+  /** 0-indexed month. */
+  month: number
+  /** Days elapsed in current month (1..daysInMonth). */
+  daysSoFar: number
+  /** Total days in current month. */
+  daysInMonth: number
+  /** Sum of expense.amount for current month so far. */
+  spentSoFar: number
+  /** Projected total = spentSoFar / daysSoFar * daysInMonth. */
+  projectedTotal: number
+  /** Mean of complete prior months (up to 3 most recent). null if no history. */
+  historicalAverage: number | null
+  /** How many months were used in the historical average (0..3). */
+  monthsAveraged: number
+  /** projectedTotal - historicalAverage; null when historicalAverage is null. */
+  vsHistorical: number | null
+  /** Fractional progress through the month (daysSoFar / daysInMonth). */
+  monthProgress: number
+}
+
+interface ForecastOptions {
+  expenses: Expense[]
+  /** Now in epoch ms; defaults to Date.now(). */
+  now?: number
+  /**
+   * Minimum days into the month before producing a projection.
+   * Defaults to 3 — earlier than that, the linear extrapolation is too noisy.
+   */
+  minDays?: number
+}
+
+function monthKey(year: number, month: number): string {
+  return `${year}-${String(month).padStart(2, '0')}`
+}
+
+/**
+ * Linear pace projection for the current month plus a comparison against
+ * the trailing 3 *complete* months. Returns null when input is too thin to
+ * say anything useful (start of month, or no spending yet).
+ */
+export function forecastCurrentMonth({
+  expenses,
+  now = Date.now(),
+  minDays = 3,
+}: ForecastOptions): MonthProjectionData | null {
+  const today = new Date(now)
+  const year = today.getFullYear()
+  const month = today.getMonth()
+  const daysSoFar = today.getDate()
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+
+  if (daysSoFar < minDays) return null
+
+  const monthTotals = new Map<string, number>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+    const key = monthKey(d.getFullYear(), d.getMonth())
+    monthTotals.set(key, (monthTotals.get(key) ?? 0) + amount)
+  }
+
+  const currentKey = monthKey(year, month)
+  const spentSoFar = monthTotals.get(currentKey) ?? 0
+
+  if (spentSoFar <= 0) return null
+
+  const projectedTotal = (spentSoFar / daysSoFar) * daysInMonth
+
+  const priorKeys: string[] = []
+  for (let i = 1; i <= 3; i++) {
+    const d = new Date(year, month - i, 1)
+    priorKeys.push(monthKey(d.getFullYear(), d.getMonth()))
+  }
+  const priorTotals = priorKeys
+    .map((k) => monthTotals.get(k) ?? 0)
+    .filter((t) => t > 0)
+
+  const monthsAveraged = priorTotals.length
+  const historicalAverage =
+    monthsAveraged > 0
+      ? priorTotals.reduce((s, x) => s + x, 0) / monthsAveraged
+      : null
+  const vsHistorical =
+    historicalAverage !== null ? projectedTotal - historicalAverage : null
+
+  return {
+    year,
+    month,
+    daysSoFar,
+    daysInMonth,
+    spentSoFar,
+    projectedTotal,
+    historicalAverage,
+    monthsAveraged,
+    vsHistorical,
+    monthProgress: daysSoFar / daysInMonth,
+  }
+}


### PR DESCRIPTION
## 為什麼

填補「現在 → 月底」的時間軸缺口：

| Widget | 時間軸位置 |
|--------|----------|
| BudgetProgress | 現在 vs 預算 (snapshot) |
| **MonthProjection** | **現在 → 月底（預測）** |
| MoneyDiary | 月底回顧 (retrospective) |

使用者最常自問的金錢問題之一是「依我目前速度，月底會花多少？比平常高還低？」。

## 做了什麼

**`src/lib/month-projection.ts`** — 純函式：
- 線性 pace 預測：`projectedTotal = spentSoFar / daysSoFar * daysInMonth`
- 對比過去最多 3 個完整月的平均
- 月份 < 3 天或本月無花費 → 返回 null（避免線性外插太粗）
- 用 `expense.date`（衡量花費）—不是 `createdAt`（衡量記錄行為）
- 跳過 bad amount/bad date 紀錄

**`src/components/month-projection.tsx`** — UI：
- 三層敘事：spentSoFar → projectedTotal → vs 歷史
- ↑↓→ 視覺化方向（上升用 destructive 紅，下降用 primary）
- 月份進度 bar 視覺化

**整合**：放在 BudgetProgress 之後（互補而非取代）

## 範例輸出

> 🔮 月底支出預估                            已過 50% (15/30 天)
>
> 目前已花 **NT\$8,500**
> 依目前速度，月底預估 **NT\$17,000**
>
> ↑ 比過去 3 個月平均多 22% (NT\$13,900)

## 測試

11 個單元測試 ✅
- 月初邊界：< 3 天返回 null
- 沒有本月花費 → null
- 線性 pace 計算正確
- 排除非當月紀錄
- 歷史平均：使用最近 3 個完整月
- 歷史平均：跳過無花費月，月數 0/1/3 邊界
- 二月（28 天）正確處理
- 月底邊界（最後一天）

整套 `npm run test`：1109/1109 passed (新增 11 個).

## 風險與回退

- 純讀取，無資料變更
- 純函式無 Firebase 依賴
- 資料不足時靜默不 render

Closes #296