### PR TITLE
feat(home): 類別月變化 — 揭示哪類比上月顯著成長/縮減 (Closes #298)

### DIFF
--- a/__tests__/category-mom.test.ts
+++ b/__tests__/category-mom.test.ts
@@ -1,0 +1,158 @@
+import { analyzeCategoryMoM } from '@/lib/category-mom'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15
+
+function mk(id: string, amount: number, category: string, year: number, month: number, day: number): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category,
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('analyzeCategoryMoM', () => {
+  it('returns null when too early in month', () => {
+    const day3 = new Date(2026, 3, 3, 12, 0, 0).getTime()
+    const r = analyzeCategoryMoM({ expenses: [], now: day3 })
+    expect(r).toBeNull()
+  })
+
+  it('returns null when both months have no spending', () => {
+    const r = analyzeCategoryMoM({ expenses: [], now: NOW })
+    expect(r).toBeNull()
+  })
+
+  it('detects categories that grew significantly', () => {
+    const expenses = [
+      mk('a', 8000, '餐飲', 2026, 2, 15), // March 餐飲: 8000
+      mk('b', 11000, '餐飲', 2026, 3, 5), // April 餐飲: 11000 (+38%)
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: NOW })
+    expect(r!.changes.length).toBe(1)
+    expect(r!.changes[0].category).toBe('餐飲')
+    expect(r!.changes[0].kind).toBe('grew')
+    expect(r!.changes[0].current).toBe(11000)
+    expect(r!.changes[0].previous).toBe(8000)
+    expect(r!.changes[0].deltaAmount).toBe(3000)
+    expect(r!.changes[0].deltaPct!).toBeCloseTo(3000 / 8000)
+  })
+
+  it('detects categories that shrank significantly', () => {
+    const expenses = [
+      mk('a', 5000, '交通', 2026, 2, 15), // March
+      mk('b', 1500, '交通', 2026, 3, 5), // April -70%
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: NOW })
+    expect(r!.changes[0].kind).toBe('shrank')
+    expect(r!.changes[0].deltaAmount).toBe(-3500)
+    expect(r!.changes[0].deltaPct!).toBeCloseTo(-0.7)
+  })
+
+  it('detects new categories (previous = 0)', () => {
+    const expenses = [
+      mk('a', 1500, '醫療', 2026, 3, 5), // April only
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: NOW })
+    expect(r!.changes[0].kind).toBe('new')
+    expect(r!.changes[0].previous).toBe(0)
+    expect(r!.changes[0].deltaPct).toBeNull()
+  })
+
+  it('detects gone categories (current = 0)', () => {
+    const expenses = [
+      mk('a', 2000, '娛樂', 2026, 2, 15), // March only
+      mk('b', 100, '其他', 2026, 3, 5), // April keep total non-zero
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: NOW })
+    const gone = r!.changes.find((c) => c.kind === 'gone')
+    expect(gone).toBeDefined()
+    expect(gone!.category).toBe('娛樂')
+    expect(gone!.current).toBe(0)
+  })
+
+  it('filters out trivial absolute changes', () => {
+    const expenses = [
+      mk('a', 100, '小', 2026, 2, 15),
+      mk('b', 200, '小', 2026, 3, 5), // delta=100 below threshold
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: NOW })
+    expect(r!.changes.length).toBe(0)
+  })
+
+  it('filters out small percentage changes', () => {
+    const expenses = [
+      mk('a', 10000, 'X', 2026, 2, 15),
+      mk('b', 11000, 'X', 2026, 3, 5), // +10% but |delta|=1000 OK
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: NOW, minDeltaPct: 0.3 })
+    expect(r!.changes.length).toBe(0) // pct too small
+  })
+
+  it('sorts changes by absolute deltaAmount descending', () => {
+    const expenses = [
+      mk('a', 1000, 'A', 2026, 2, 15),
+      mk('b', 5000, 'A', 2026, 3, 5), // delta=4000 (grew)
+      mk('c', 8000, 'B', 2026, 2, 15),
+      mk('d', 1000, 'B', 2026, 3, 5), // delta=-7000 (shrank)
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: NOW })
+    expect(r!.changes[0].category).toBe('B') // -7000 > 4000 in absolute
+    expect(r!.changes[1].category).toBe('A')
+  })
+
+  it('skips expenses outside both months', () => {
+    const expenses = [
+      mk('a', 1000, 'X', 2026, 0, 15), // January — irrelevant
+      mk('b', 2000, 'X', 2026, 3, 5), // April
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: NOW })
+    expect(r!.changes[0].kind).toBe('new')
+    expect(r!.changes[0].previous).toBe(0)
+  })
+
+  it('handles bad amount and date defensively', () => {
+    const bad = { ...mk('z', 100, 'X', 2026, 3, 5), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mk('a', 100, 'X', 2026, 3, 5),
+      mk('z2', NaN, 'X', 2026, 3, 5),
+      bad,
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: NOW })
+    // Only valid expense (100) — below threshold for significant change, but still computed
+    expect(r).not.toBeNull()
+  })
+
+  it('treats missing/empty category as 其他', () => {
+    const a = { ...mk('a', 5000, '', 2026, 2, 15) } as unknown as Expense
+    const b = { ...mk('b', 100, '', 2026, 3, 5) } as unknown as Expense
+    const r = analyzeCategoryMoM({ expenses: [a, b], now: NOW })
+    expect(r!.changes[0].category).toBe('其他')
+    expect(r!.changes[0].kind).toBe('shrank')
+  })
+
+  it('crosses year boundary (Jan vs Dec previous year)', () => {
+    const jan10 = new Date(2027, 0, 10, 12, 0, 0).getTime()
+    const expenses = [
+      mk('a', 5000, '餐飲', 2026, 11, 15), // Dec 2026
+      mk('b', 8000, '餐飲', 2027, 0, 5), // Jan 2027 +60%
+    ]
+    const r = analyzeCategoryMoM({ expenses, now: jan10 })
+    expect(r!.currentMonthLabel).toBe('2027-01')
+    expect(r!.previousMonthLabel).toBe('2026-12')
+    expect(r!.changes[0].kind).toBe('grew')
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -23,6 +23,7 @@ import { SpendingHeatmap } from '@/components/spending-heatmap'
 import { DowInsight } from '@/components/dow-insight'
 import { RecordingStreak } from '@/components/recording-streak'
 import { MonthProjection } from '@/components/month-projection'
+import { CategoryMoM } from '@/components/category-mom'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -249,6 +250,9 @@ export default function HomePage() {
 
       {/* 月底支出預估 (Issue #296) — 依目前速度 + 歷史對比 */}
       <MonthProjection expenses={expenses} />
+
+      {/* 類別月變化 (Issue #298) — 哪類比上個月顯著成長/縮減 */}
+      <CategoryMoM expenses={expenses} />
 
       {/* 30 天每日花費熱力圖 (Issue #290) */}
       <SpendingHeatmap expenses={expenses} />

--- a/src/components/category-mom.tsx
+++ b/src/components/category-mom.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useMemo } from 'react'
+import { analyzeCategoryMoM, type CategoryChange } from '@/lib/category-mom'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface CategoryMoMProps {
+  expenses: Expense[]
+  /** How many top changes to surface. Default 3. */
+  limit?: number
+}
+
+function changeIcon(c: CategoryChange): string {
+  switch (c.kind) {
+    case 'grew':
+      return '↑'
+    case 'shrank':
+      return '↓'
+    case 'new':
+      return '✨'
+    case 'gone':
+      return '◌'
+  }
+}
+
+function changeColor(c: CategoryChange): string {
+  switch (c.kind) {
+    case 'grew':
+      return 'var(--destructive)'
+    case 'shrank':
+      return 'var(--primary)'
+    case 'new':
+      return 'var(--primary)'
+    case 'gone':
+      return 'var(--muted-foreground)'
+  }
+}
+
+function describeChange(c: CategoryChange): string {
+  if (c.kind === 'new') {
+    return `${c.category}：新類別 ${currency(c.current)}`
+  }
+  if (c.kind === 'gone') {
+    return `${c.category}：本月沒了（上月 ${currency(c.previous)}）`
+  }
+  const pctText =
+    c.deltaPct !== null
+      ? `${c.deltaPct > 0 ? '+' : ''}${Math.round(c.deltaPct * 100)}%`
+      : ''
+  return `${c.category} ${pctText}（${currency(c.previous)} → ${currency(c.current)}）`
+}
+
+/**
+ * Category month-over-month diff (Issue #298). Surfaces the categories
+ * that meaningfully shifted from last month, separately from total-amount
+ * change. Filters trivial moves so the home page only renders shifts that
+ * change behavior.
+ */
+export function CategoryMoM({ expenses, limit = 3 }: CategoryMoMProps) {
+  const data = useMemo(
+    () => analyzeCategoryMoM({ expenses }),
+    [expenses],
+  )
+
+  if (!data || data.changes.length === 0) return null
+
+  const top = data.changes.slice(0, limit)
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        🔄 類別月變化 · {data.previousMonthLabel} → {data.currentMonthLabel}
+      </div>
+
+      <ul className="space-y-2">
+        {top.map((c) => (
+          <li key={c.category} className="flex items-center gap-2 text-sm">
+            <span
+              className="font-bold text-base"
+              style={{ color: changeColor(c) }}
+              aria-hidden
+            >
+              {changeIcon(c)}
+            </span>
+            <span className="text-[var(--foreground)]">{describeChange(c)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/lib/category-mom.ts
+++ b/src/lib/category-mom.ts
@@ -1,0 +1,134 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export type CategoryChangeKind = 'grew' | 'shrank' | 'new' | 'gone'
+
+export interface CategoryChange {
+  category: string
+  current: number
+  previous: number
+  deltaAmount: number
+  /** null when `previous === 0` (new category) — pct undefined. */
+  deltaPct: number | null
+  kind: CategoryChangeKind
+}
+
+export interface CategoryMoMData {
+  /** Most significant changes, sorted by absolute deltaAmount desc. */
+  changes: CategoryChange[]
+  currentMonthTotal: number
+  previousMonthTotal: number
+  /** Calendar month label e.g. "2026-04". */
+  currentMonthLabel: string
+  previousMonthLabel: string
+}
+
+interface AnalyzeOptions {
+  expenses: Expense[]
+  now?: number
+  /** Minimum days into the month before producing analysis. Default 7. */
+  minDaysSoFar?: number
+  /** Minimum |deltaAmount| (NT$) to count as significant. Default 500. */
+  minDeltaAmount?: number
+  /** Minimum |deltaPct| (0..1) to count as significant. Default 0.3. */
+  minDeltaPct?: number
+}
+
+function monthKey(year: number, month: number): string {
+  return `${year}-${String(month + 1).padStart(2, '0')}`
+}
+
+/**
+ * Per-category month-over-month change. Surfaces "what shifted" between
+ * last month and current month, separately from total-amount change. Hides
+ * trivial moves (small absolute or small percentage) so the home page only
+ * shows changes worth a second look.
+ */
+export function analyzeCategoryMoM({
+  expenses,
+  now = Date.now(),
+  minDaysSoFar = 7,
+  minDeltaAmount = 500,
+  minDeltaPct = 0.3,
+}: AnalyzeOptions): CategoryMoMData | null {
+  const today = new Date(now)
+  const daysSoFar = today.getDate()
+  if (daysSoFar < minDaysSoFar) return null
+
+  const year = today.getFullYear()
+  const month = today.getMonth()
+  const prev = new Date(year, month - 1, 1)
+  const prevYear = prev.getFullYear()
+  const prevMonth = prev.getMonth()
+
+  const currentMonthLabel = monthKey(year, month)
+  const previousMonthLabel = monthKey(prevYear, prevMonth)
+
+  const currentByCategory = new Map<string, number>()
+  const previousByCategory = new Map<string, number>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+    const category = (e.category || '其他').trim() || '其他'
+    if (d.getFullYear() === year && d.getMonth() === month) {
+      currentByCategory.set(category, (currentByCategory.get(category) ?? 0) + amount)
+    } else if (d.getFullYear() === prevYear && d.getMonth() === prevMonth) {
+      previousByCategory.set(category, (previousByCategory.get(category) ?? 0) + amount)
+    }
+  }
+
+  const currentMonthTotal = Array.from(currentByCategory.values()).reduce((s, x) => s + x, 0)
+  const previousMonthTotal = Array.from(previousByCategory.values()).reduce((s, x) => s + x, 0)
+
+  if (currentMonthTotal === 0 && previousMonthTotal === 0) return null
+
+  const allCategories = new Set<string>([
+    ...currentByCategory.keys(),
+    ...previousByCategory.keys(),
+  ])
+
+  const changes: CategoryChange[] = []
+  for (const category of allCategories) {
+    const current = currentByCategory.get(category) ?? 0
+    const previous = previousByCategory.get(category) ?? 0
+    const deltaAmount = current - previous
+
+    let kind: CategoryChangeKind
+    if (previous === 0 && current > 0) {
+      kind = 'new'
+    } else if (current === 0 && previous > 0) {
+      kind = 'gone'
+    } else if (deltaAmount > 0) {
+      kind = 'grew'
+    } else {
+      kind = 'shrank'
+    }
+
+    const deltaPct = previous > 0 ? deltaAmount / previous : null
+
+    if (Math.abs(deltaAmount) < minDeltaAmount) continue
+    if (kind === 'grew' || kind === 'shrank') {
+      if (deltaPct !== null && Math.abs(deltaPct) < minDeltaPct) continue
+    }
+
+    changes.push({ category, current, previous, deltaAmount, deltaPct, kind })
+  }
+
+  changes.sort((a, b) => Math.abs(b.deltaAmount) - Math.abs(a.deltaAmount))
+
+  return {
+    changes,
+    currentMonthTotal,
+    previousMonthTotal,
+    currentMonthLabel,
+    previousMonthLabel,
+  }
+}


### PR DESCRIPTION
## 為什麼

MonthProjection (#296) 預測「**多少**」會花。但更重要的是「**哪裡**」變了——例如本月餐飲突然多 40%。沒有 widget 顯示這個橫向對比。

## 做了什麼

`src/lib/category-mom.ts` — 純函式 `analyzeCategoryMoM`：
- 比較 currentMonth vs previousMonth 每個類別
- 4 種 kind：`grew` / `shrank` / `new`（prev=0）/ `gone`（curr=0）
- threshold gate：|delta| < NT\$500 或 |pct| < 30% 都不算
- 月初 < 7 天不分析（樣本太小）
- 跨年正確處理（12月 → 1月）
- 排序：絕對 deltaAmount 大的優先

`src/components/category-mom.tsx` — UI：
- top 3 變化
- ↑↓✨◌ 圖示 + 顏色（grew=destructive 紅，shrank/new=primary 綠，gone=muted）
- 描述句：「↑ 餐飲 +30%（NT\$8,000 → NT\$10,400）」

整合於 MonthProjection 之後，形成「總預估 → 類別變化」月度橫向對比。

## 範例輸出

> 🔄 類別月變化 · 2026-03 → 2026-04
>
> ↑ 餐飲 +30%（NT\$8,000 → NT\$10,400）
> ↓ 交通 -60%（NT\$5,000 → NT\$2,000）
> ✨ 醫療：新類別 NT\$1,500

## 測試

13 個單元測試 ✅
- 月初 < 7 天 → null
- 兩月皆無 → null
- grew / shrank / new / gone 4 種 kind
- threshold filter（|delta| < 500、|pct| < 30%）
- 排序正確
- 跨年（Dec → Jan）
- bad amount/date defensive
- 空 category 預設「其他」

整套：1122/1122 passed (新增 13 個).

## 風險與回退

- 純讀取，無 schema 變更
- 純函式無 Firebase 依賴
- 沒資料/threshold 不過 → 靜默不 render

Closes #298