### PR TITLE
feat(home): 最常買 Top 5 — 90 天 description 維度習慣 (Closes #301)

### DIFF
--- a/__tests__/most-frequent-items.test.ts
+++ b/__tests__/most-frequent-items.test.ts
@@ -1,0 +1,164 @@
+import { analyzeMostFrequent } from '@/lib/most-frequent-items'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15
+
+function mk(id: string, amount: number, description: string, daysAgo: number): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description,
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('analyzeMostFrequent', () => {
+  it('returns empty array when days <= 0', () => {
+    expect(analyzeMostFrequent({ expenses: [], days: 0, now: NOW })).toEqual([])
+    expect(analyzeMostFrequent({ expenses: [], days: -1, now: NOW })).toEqual([])
+  })
+
+  it('returns empty when no expenses', () => {
+    expect(analyzeMostFrequent({ expenses: [], now: NOW })).toEqual([])
+  })
+
+  it('aggregates by normalized description', () => {
+    const expenses = [
+      mk('a', 100, '午餐', 0),
+      mk('b', 120, ' 午餐 ', 1), // padding
+      mk('c', 110, '午餐', 2),
+    ]
+    const r = analyzeMostFrequent({ expenses, now: NOW })
+    expect(r.length).toBe(1)
+    expect(r[0].count).toBe(3)
+    expect(r[0].totalAmount).toBe(330)
+    expect(r[0].averagePrice).toBe(110)
+  })
+
+  it('filters items below minCount threshold', () => {
+    const expenses = [
+      mk('a', 100, '午餐', 0),
+      mk('b', 100, '午餐', 1), // count=2, below min
+      mk('c', 100, '咖啡', 0),
+      mk('d', 100, '咖啡', 1),
+      mk('e', 100, '咖啡', 2), // count=3, OK
+    ]
+    const r = analyzeMostFrequent({ expenses, now: NOW, minCount: 3 })
+    expect(r.length).toBe(1)
+    expect(r[0].description).toBe('咖啡')
+  })
+
+  it('sorts by count desc, then by totalAmount desc on tie', () => {
+    const expenses = [
+      // 午餐: 3 records, total 300
+      mk('a', 100, '午餐', 0),
+      mk('b', 100, '午餐', 1),
+      mk('c', 100, '午餐', 2),
+      // 早餐: 3 records, total 150 (tie on count, lower total)
+      mk('d', 50, '早餐', 0),
+      mk('e', 50, '早餐', 1),
+      mk('f', 50, '早餐', 2),
+      // 加油: 5 records, top
+      mk('g', 1500, '加油', 0),
+      mk('h', 1500, '加油', 1),
+      mk('i', 1500, '加油', 2),
+      mk('j', 1500, '加油', 3),
+      mk('k', 1500, '加油', 4),
+    ]
+    const r = analyzeMostFrequent({ expenses, now: NOW })
+    expect(r[0].description).toBe('加油')
+    expect(r[1].description).toBe('午餐')
+    expect(r[2].description).toBe('早餐')
+  })
+
+  it('respects limit', () => {
+    // 6 distinct descriptions, all qualifying
+    const descriptions = ['A', 'B', 'C', 'D', 'E', 'F']
+    const expenses = descriptions.flatMap((desc, i) =>
+      [0, 1, 2].map((d) => mk(`${desc}${d}`, 100 + i, desc, d)),
+    )
+    const r = analyzeMostFrequent({ expenses, now: NOW, limit: 5 })
+    expect(r.length).toBe(5)
+  })
+
+  it('skips expenses outside window', () => {
+    const expenses = [
+      mk('a', 100, '午餐', 0),
+      mk('b', 100, '午餐', 1),
+      mk('c', 100, '午餐', 2),
+      mk('outside', 100, '午餐', 100), // outside default 90
+    ]
+    const r = analyzeMostFrequent({ expenses, now: NOW, days: 90 })
+    expect(r[0].count).toBe(3) // outside excluded
+  })
+
+  it('skips bad amount and bad date', () => {
+    const bad = { ...mk('z', 100, '午餐', 0), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mk('a', 100, '午餐', 0),
+      mk('b', 100, '午餐', 1),
+      mk('c', 100, '午餐', 2),
+      mk('z2', NaN, '午餐', 0),
+      mk('z3', -50, '午餐', 0),
+      bad,
+    ]
+    const r = analyzeMostFrequent({ expenses, now: NOW })
+    expect(r[0].count).toBe(3)
+    expect(r[0].totalAmount).toBe(300)
+  })
+
+  it('skips records with empty description', () => {
+    const expenses = [
+      mk('a', 100, '', 0),
+      mk('b', 100, '   ', 1),
+      mk('c', 100, '咖啡', 0),
+      mk('d', 100, '咖啡', 1),
+      mk('e', 100, '咖啡', 2),
+    ]
+    const r = analyzeMostFrequent({ expenses, now: NOW })
+    expect(r.length).toBe(1)
+    expect(r[0].description).toBe('咖啡')
+  })
+
+  it('lastDate uses most recent occurrence', () => {
+    const expenses = [
+      mk('a', 100, '午餐', 5),
+      mk('b', 100, '午餐', 1),
+      mk('c', 100, '午餐', 10),
+    ]
+    const r = analyzeMostFrequent({ expenses, now: NOW })
+    expect(r[0].lastDate).toBe('2026-04-14') // 1 day ago
+  })
+
+  it('preserves display from most recent occurrence', () => {
+    const expenses = [
+      mk('a', 100, '咖啡', 5),
+      mk('b', 100, '咖啡 ', 1), // most recent — used as display
+      mk('c', 100, ' 咖啡', 10),
+    ]
+    const r = analyzeMostFrequent({ expenses, now: NOW })
+    expect(r[0].description).toBe('咖啡') // trimmed
+  })
+
+  it('case-insensitive normalization (English)', () => {
+    const expenses = [
+      mk('a', 100, 'Lunch', 0),
+      mk('b', 100, 'lunch', 1),
+      mk('c', 100, 'LUNCH', 2),
+    ]
+    const r = analyzeMostFrequent({ expenses, now: NOW })
+    expect(r[0].count).toBe(3)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -24,6 +24,7 @@ import { DowInsight } from '@/components/dow-insight'
 import { RecordingStreak } from '@/components/recording-streak'
 import { MonthProjection } from '@/components/month-projection'
 import { CategoryMoM } from '@/components/category-mom'
+import { MostFrequentItems } from '@/components/most-frequent-items'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -253,6 +254,9 @@ export default function HomePage() {
 
       {/* 類別月變化 (Issue #298) — 哪類比上個月顯著成長/縮減 */}
       <CategoryMoM expenses={expenses} />
+
+      {/* 最常買 Top 5 (Issue #301) — 90 天 description 維度習慣 */}
+      <MostFrequentItems expenses={expenses} />
 
       {/* 30 天每日花費熱力圖 (Issue #290) */}
       <SpendingHeatmap expenses={expenses} />

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -108,8 +108,10 @@ export default function RecordsPage() {
 
   const [galleryPaths, setGalleryPaths] = useState<string[] | null>(null)
   const [filter, setFilter] = useState<FilterType>('全部')
-  const [searchInput, setSearchInput] = useState('')
-  const [searchQuery, setSearchQuery] = useState('')
+  const [searchInput, setSearchInput] = useState(() => searchParams.get('q') ?? '')
+  const [searchQuery, setSearchQuery] = useState(() =>
+    (searchParams.get('q') ?? '').trim().toLowerCase(),
+  )
   const [showAdvanced, setShowAdvanced] = useState(false)
   // Default to current month for efficiency — families mostly care about the
   // current monthly summary. URL params (`?start=&end=`) override for deep

--- a/src/components/most-frequent-items.tsx
+++ b/src/components/most-frequent-items.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { analyzeMostFrequent } from '@/lib/most-frequent-items'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface MostFrequentItemsProps {
+  expenses: Expense[]
+  /** Days back from today. Default 90. */
+  days?: number
+  /** Top N to render. Default 5. */
+  limit?: number
+}
+
+/**
+ * Most-frequent purchases over a rolling window (Issue #301). The top
+ * description axis — complementary to the amount/category/time axes used
+ * by every other home widget. Each row links to the records page filtered
+ * by description, so users can drill into the price history.
+ */
+export function MostFrequentItems({
+  expenses,
+  days = 90,
+  limit = 5,
+}: MostFrequentItemsProps) {
+  const items = useMemo(
+    () => analyzeMostFrequent({ expenses, days, limit }),
+    [expenses, days, limit],
+  )
+
+  if (items.length === 0) return null
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        🔁 你最常買 · 近 {days} 天
+      </div>
+      <ul className="divide-y divide-[var(--border)]">
+        {items.map((item, i) => (
+          <li key={item.description}>
+            <Link
+              href={`/records?q=${encodeURIComponent(item.description)}`}
+              className="flex items-center justify-between gap-3 py-2 hover:bg-[var(--muted)] transition rounded px-2 -mx-2"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <span className="text-xs font-mono text-[var(--muted-foreground)] w-4 text-right">
+                  {i + 1}
+                </span>
+                <span className="text-sm font-medium text-[var(--foreground)] truncate">
+                  {item.description}
+                </span>
+              </div>
+              <div className="flex items-center gap-3 text-xs text-[var(--muted-foreground)] flex-shrink-0">
+                <span>{item.count} 次</span>
+                <span className="font-medium text-[var(--foreground)]">
+                  平均 {currency(item.averagePrice)}
+                </span>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/lib/most-frequent-items.ts
+++ b/src/lib/most-frequent-items.ts
@@ -1,0 +1,115 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface FrequentItem {
+  description: string
+  count: number
+  totalAmount: number
+  averagePrice: number
+  /** Most recent occurrence as YYYY-MM-DD (local). */
+  lastDate: string
+}
+
+interface AnalyzeOptions {
+  expenses: Expense[]
+  now?: number
+  /** Days back from today (inclusive). Default 90. */
+  days?: number
+  /** Min occurrences to qualify. Default 3. */
+  minCount?: number
+  /** Top N items to return. Default 5. */
+  limit?: number
+}
+
+function normalize(description: string): string {
+  return (description ?? '').trim().toLowerCase()
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Top recurring purchases by `description` over a rolling window. Surfaces
+ * the user's habitual buys (the "every Wednesday lunch" tier) and their
+ * average price, which doubles as a cheap price anchor for future entries.
+ *
+ * Description normalization is conservative — trim + lowercase only —
+ * because aggressive stemming would conflate distinct items the user types
+ * deliberately ("便當" vs "便當盒").
+ */
+export function analyzeMostFrequent({
+  expenses,
+  now = Date.now(),
+  days = 90,
+  minCount = 3,
+  limit = 5,
+}: AnalyzeOptions): FrequentItem[] {
+  if (!Number.isFinite(days) || days <= 0) return []
+
+  const endLocal = new Date(now)
+  endLocal.setHours(23, 59, 59, 999)
+  const startLocal = new Date(endLocal)
+  startLocal.setDate(startLocal.getDate() - (days - 1))
+  startLocal.setHours(0, 0, 0, 0)
+  const startMs = startLocal.getTime()
+  const endMs = endLocal.getTime()
+
+  type Acc = {
+    display: string
+    count: number
+    totalAmount: number
+    lastTs: number
+  }
+  const buckets = new Map<string, Acc>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    const ts = d.getTime()
+    if (!Number.isFinite(ts) || ts < startMs || ts > endMs) continue
+    const description = (e.description ?? '').trim()
+    if (!description) continue
+    const key = normalize(description)
+    if (!key) continue
+
+    const acc = buckets.get(key) ?? {
+      display: description,
+      count: 0,
+      totalAmount: 0,
+      lastTs: 0,
+    }
+    acc.count++
+    acc.totalAmount += amount
+    if (ts > acc.lastTs) {
+      acc.display = description
+      acc.lastTs = ts
+    }
+    buckets.set(key, acc)
+  }
+
+  const items: FrequentItem[] = []
+  for (const acc of buckets.values()) {
+    if (acc.count < minCount) continue
+    items.push({
+      description: acc.display,
+      count: acc.count,
+      totalAmount: acc.totalAmount,
+      averagePrice: acc.totalAmount / acc.count,
+      lastDate: dateKey(new Date(acc.lastTs)),
+    })
+  }
+
+  items.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count
+    return b.totalAmount - a.totalAmount
+  })
+
+  return items.slice(0, limit)
+}


### PR DESCRIPTION
## 為什麼

之前所有 widget 都從金額/類別/時間維度切入。**description 維度從未被利用**——但這是揭露「我每週都買咖啡？真的嗎？」這類盲點的最好角度。

平均價格也作為隱性錨點：下次輸入「午餐 200 元」時，使用者會記得「咦，平常是 135」。

## 做了什麼

`src/lib/most-frequent-items.ts` — 純函式 `analyzeMostFrequent`：
- description 正規化（trim + lowercase）
- 滾動 90 天視窗，count >= 3 才上榜
- 排序：count desc → totalAmount desc 為 tie-breaker
- 預設 top 5
- display 字串保留最近一次的原樣
- lastDate = 最近一次出現

`src/components/most-frequent-items.tsx` — UI：
- 精簡列表「1. 午餐 · 58 次 · 平均 NT\$135」
- 每列 link 到 `/records?q=<description>` drill 進價格歷史

順便：擴展 `src/app/(auth)/records/page.tsx`：
- searchInput / searchQuery 從 URL `q` 初始化
- 讓 deep link 可預填搜尋

## 範例輸出

> 🔁 你最常買 · 近 90 天
>
> 1. 午餐  ·  58 次  ·  平均 NT\$135
> 2. 咖啡  ·  42 次  ·  平均 NT\$80
> 3. 早餐  ·  35 次  ·  平均 NT\$60
> 4. 加油  ·  12 次  ·  平均 NT\$1,200
> 5. 便當  ·  8 次  ·  平均 NT\$110

## 測試

12 個單元測試 ✅
- 空資料/days <= 0 → []
- 正規化（trim + lowercase）
- minCount filter
- tie-breaking 排序
- limit
- 視窗外排除
- bad amount/date defensive
- 空 description 跳過
- lastDate 最新
- display 保留最近樣式
- 中英文混合

整套：1134/1134 passed (新增 12 個).

## 風險與回退

- 純讀取
- 純函式
- 沒符合條件 → 靜默不 render
- records page q 參數初始化是 additive，不影響現有行為

Closes #301