### PR TITLE
feat(home): 本月最大筆 spotlight + 6 月 pctile 排名 (Closes #303)

### DIFF
--- a/__tests__/biggest-expense-spotlight.test.ts
+++ b/__tests__/biggest-expense-spotlight.test.ts
@@ -1,0 +1,144 @@
+import { analyzeBiggestExpense } from '@/lib/biggest-expense-spotlight'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15
+
+function mk(id: string, amount: number, daysAgo: number, opts: Partial<Expense> = {}): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description: opts.description ?? `e-${id}`,
+    amount,
+    category: opts.category ?? 'X',
+    payerId: 'm1',
+    payerName: opts.payerName ?? '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('analyzeBiggestExpense', () => {
+  it('returns null when too early in month', () => {
+    const day3 = new Date(2026, 3, 3, 12, 0, 0).getTime()
+    expect(analyzeBiggestExpense({ expenses: [], now: day3 })).toBeNull()
+  })
+
+  it('returns null when no current-month expenses', () => {
+    const expenses = [mk('a', 100, 60)] // March
+    expect(analyzeBiggestExpense({ expenses, now: NOW })).toBeNull()
+  })
+
+  it('finds biggest expense of current month', () => {
+    const expenses = [
+      mk('small', 100, 5),
+      mk('big', 3500, 2, { description: '機票', category: '交通' }),
+      mk('mid', 1200, 8),
+    ]
+    const r = analyzeBiggestExpense({ expenses, now: NOW })
+    expect(r!.biggest.id).toBe('big')
+    expect(r!.biggest.description).toBe('機票')
+    expect(r!.biggest.amount).toBe(3500)
+    expect(r!.biggest.category).toBe('交通')
+  })
+
+  it('monthTop contains top N expenses sorted desc', () => {
+    const expenses = [
+      mk('a', 100, 1),
+      mk('b', 5000, 2),
+      mk('c', 200, 3),
+      mk('d', 1000, 4),
+      mk('e', 3000, 5),
+    ]
+    const r = analyzeBiggestExpense({ expenses, now: NOW })
+    expect(r!.monthTop.map((e) => e.amount)).toEqual([5000, 3000, 1000])
+  })
+
+  it('respects custom topN', () => {
+    const expenses = [
+      mk('a', 100, 1),
+      mk('b', 200, 2),
+      mk('c', 300, 3),
+      mk('d', 400, 4),
+      mk('e', 500, 5),
+    ]
+    const r = analyzeBiggestExpense({ expenses, now: NOW, topN: 5 })
+    expect(r!.monthTop.length).toBe(5)
+  })
+
+  it('pctile null when historical sample too thin', () => {
+    const expenses = [
+      mk('a', 5000, 5), // current month biggest
+      ...[1, 2, 3].map((i) => mk(`h${i}`, 100, 60 + i * 5)), // 3 historical
+    ]
+    const r = analyzeBiggestExpense({ expenses, now: NOW, minHistoricalCount: 10 })
+    expect(r!.pctile).toBeNull()
+    expect(r!.historicalCount).toBe(3)
+  })
+
+  it('pctile computed when enough history', () => {
+    const expenses = [
+      mk('big', 5000, 5),
+      // 10 historical amounts, all < 5000
+      ...Array.from({ length: 10 }, (_, i) => mk(`h${i}`, 100 + i * 100, 60 + i)),
+    ]
+    const r = analyzeBiggestExpense({ expenses, now: NOW, minHistoricalCount: 10 })
+    expect(r!.pctile).toBe(1) // 5000 ≥ all historical
+    expect(r!.historicalCount).toBe(10)
+  })
+
+  it('pctile reflects relative rank correctly', () => {
+    // 10 historical amounts: 100..1000 (step 100). Biggest current = 500.
+    // Number ≤ 500: 5 (100,200,300,400,500) → pctile = 0.5
+    const expenses = [
+      mk('big', 500, 5),
+      ...Array.from({ length: 10 }, (_, i) => mk(`h${i}`, (i + 1) * 100, 60 + i)),
+    ]
+    const r = analyzeBiggestExpense({ expenses, now: NOW, minHistoricalCount: 10 })
+    expect(r!.pctile).toBe(0.5)
+  })
+
+  it('historical only includes last N months', () => {
+    const expenses = [
+      mk('curr', 1000, 5),
+      // 10 within 6 months
+      ...Array.from({ length: 10 }, (_, i) => mk(`h${i}`, 500, 60 + i * 5)),
+      // 1 outside 6 months (200 days ago — definitely > 6 months)
+      mk('old', 999, 200),
+    ]
+    const r = analyzeBiggestExpense({ expenses, now: NOW, historicalMonths: 6 })
+    expect(r!.historicalCount).toBe(10) // old excluded
+  })
+
+  it('skips bad amount and date', () => {
+    const bad = { ...mk('bad', 100, 5), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mk('valid', 1000, 5),
+      mk('nan', NaN, 5),
+      mk('zero', 0, 5),
+      mk('neg', -100, 5),
+      bad,
+    ]
+    const r = analyzeBiggestExpense({ expenses, now: NOW })
+    expect(r!.biggest.amount).toBe(1000)
+  })
+
+  it('handles missing description / category / payerName gracefully', () => {
+    const e = {
+      ...mk('a', 1000, 5),
+      description: '',
+      category: '',
+      payerName: '',
+    } as unknown as Expense
+    const r = analyzeBiggestExpense({ expenses: [e], now: NOW })
+    expect(r!.biggest.description).toBe('(無描述)')
+    expect(r!.biggest.category).toBe('其他')
+    expect(r!.biggest.payerName).toBe('?')
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -25,6 +25,7 @@ import { RecordingStreak } from '@/components/recording-streak'
 import { MonthProjection } from '@/components/month-projection'
 import { CategoryMoM } from '@/components/category-mom'
 import { MostFrequentItems } from '@/components/most-frequent-items'
+import { BiggestExpenseSpotlight } from '@/components/biggest-expense-spotlight'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -257,6 +258,9 @@ export default function HomePage() {
 
       {/* 最常買 Top 5 (Issue #301) — 90 天 description 維度習慣 */}
       <MostFrequentItems expenses={expenses} />
+
+      {/* 本月最大筆 spotlight (Issue #303) — 單筆極值 + pctile 排名 */}
+      <BiggestExpenseSpotlight expenses={expenses} />
 
       {/* 30 天每日花費熱力圖 (Issue #290) */}
       <SpendingHeatmap expenses={expenses} />

--- a/src/components/biggest-expense-spotlight.tsx
+++ b/src/components/biggest-expense-spotlight.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { analyzeBiggestExpense } from '@/lib/biggest-expense-spotlight'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface BiggestExpenseSpotlightProps {
+  expenses: Expense[]
+}
+
+function pctileLabel(p: number): string {
+  if (p >= 0.95) return '比過去 P95 還高（前 5% 大筆）'
+  if (p >= 0.85) return `比過去 P${Math.round(p * 100)} 還高（前 ${Math.round((1 - p) * 100)}% 大筆）`
+  if (p >= 0.5) return `落在過去 P${Math.round(p * 100)}（中段）`
+  return `比過去 P${Math.round(p * 100)} 還低（小於一半的歷史紀錄）`
+}
+
+/**
+ * Surfaces the largest single-line expense of the current month with a
+ * percentile rank against trailing 6-month distribution. Emotionally
+ * different from MoneyDiary's narrative — this one says "this purchase
+ * stood out" and shows just how much.
+ */
+export function BiggestExpenseSpotlight({ expenses }: BiggestExpenseSpotlightProps) {
+  const data = useMemo(
+    () => analyzeBiggestExpense({ expenses }),
+    [expenses],
+  )
+
+  if (!data) return null
+
+  const { biggest, monthTop, pctile } = data
+  const others = monthTop.slice(1)
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        💎 本月最大筆支出 · {data.monthLabel}
+      </div>
+
+      <Link
+        href={`/expense/${biggest.id}`}
+        className="block hover:opacity-80 transition"
+      >
+        <div className="flex items-baseline gap-2">
+          <span className="text-2xl md:text-3xl font-bold text-[var(--primary)]">
+            {currency(biggest.amount)}
+          </span>
+        </div>
+        <p className="text-sm text-[var(--foreground)] mt-1">
+          {biggest.description}
+        </p>
+        <p className="text-xs text-[var(--muted-foreground)]">
+          {biggest.category} · {biggest.dateLabel} · {biggest.payerName}付
+        </p>
+      </Link>
+
+      {pctile !== null && (
+        <p className="text-xs text-[var(--muted-foreground)] italic">
+          ★ {pctileLabel(pctile)}
+        </p>
+      )}
+
+      {others.length > 0 && (
+        <div className="pt-2 border-t border-[var(--border)] space-y-1">
+          <p className="text-[11px] font-medium text-[var(--muted-foreground)]">
+            其他大筆
+          </p>
+          {others.map((e) => (
+            <Link
+              key={e.id}
+              href={`/expense/${e.id}`}
+              className="flex items-center justify-between gap-2 text-xs hover:bg-[var(--muted)] transition rounded px-2 -mx-2 py-1"
+            >
+              <span className="text-[var(--foreground)] truncate">
+                {e.description}
+              </span>
+              <span className="text-[var(--muted-foreground)] flex-shrink-0">
+                {currency(e.amount)}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/biggest-expense-spotlight.ts
+++ b/src/lib/biggest-expense-spotlight.ts
@@ -1,0 +1,122 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface BiggestExpenseEntry {
+  id: string
+  description: string
+  amount: number
+  /** Date as YYYY-MM-DD (local). */
+  dateLabel: string
+  category: string
+  payerName: string
+}
+
+export interface BiggestExpenseSpotlight {
+  /** The single largest expense of the current calendar month. */
+  biggest: BiggestExpenseEntry
+  /** Up to 3 largest expenses of the current month, including biggest at index 0. */
+  monthTop: BiggestExpenseEntry[]
+  /**
+   * Percentile rank of `biggest.amount` among the trailing N-month single-amount
+   * distribution (excluding current month). null when historical sample too thin.
+   */
+  pctile: number | null
+  /** Count of historical expenses used to compute pctile. */
+  historicalCount: number
+  monthLabel: string
+}
+
+interface AnalyzeOptions {
+  expenses: Expense[]
+  now?: number
+  /** Days into the month before analysis runs. Default 5. */
+  minDaysSoFar?: number
+  /** Trailing months for historical comparison. Default 6. */
+  historicalMonths?: number
+  /** Minimum historical sample count required for pctile. Default 10. */
+  minHistoricalCount?: number
+  /** How many top expenses to surface. Default 3. */
+  topN?: number
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function toEntry(e: Expense, d: Date): BiggestExpenseEntry {
+  return {
+    id: e.id,
+    description: (e.description || '(無描述)').trim() || '(無描述)',
+    amount: Number(e.amount),
+    dateLabel: dateKey(d),
+    category: (e.category || '其他').trim() || '其他',
+    payerName: (e.payerName || '').trim() || '?',
+  }
+}
+
+/**
+ * Surface the biggest single-line expense of the current month with a
+ * percentile-rank against the trailing N-month distribution. Distinct
+ * from form-side outlier-detector (#284) which warns *before* a record
+ * is saved — this one celebrates / explains *after* the fact.
+ */
+export function analyzeBiggestExpense({
+  expenses,
+  now = Date.now(),
+  minDaysSoFar = 5,
+  historicalMonths = 6,
+  minHistoricalCount = 10,
+  topN = 3,
+}: AnalyzeOptions): BiggestExpenseSpotlight | null {
+  const today = new Date(now)
+  if (today.getDate() < minDaysSoFar) return null
+
+  const year = today.getFullYear()
+  const month = today.getMonth()
+  const monthLabel = `${year}-${String(month + 1).padStart(2, '0')}`
+
+  const historyStart = new Date(year, month - historicalMonths, 1)
+  const historyStartMs = historyStart.getTime()
+
+  const currentMonthExpenses: BiggestExpenseEntry[] = []
+  const historicalAmounts: number[] = []
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+
+    const isCurrentMonth = d.getFullYear() === year && d.getMonth() === month
+    if (isCurrentMonth) {
+      currentMonthExpenses.push(toEntry(e, d))
+    } else if (d.getTime() >= historyStartMs) {
+      historicalAmounts.push(amount)
+    }
+  }
+
+  if (currentMonthExpenses.length === 0) return null
+
+  currentMonthExpenses.sort((a, b) => b.amount - a.amount)
+  const biggest = currentMonthExpenses[0]
+  const monthTop = currentMonthExpenses.slice(0, topN)
+
+  let pctile: number | null = null
+  if (historicalAmounts.length >= minHistoricalCount) {
+    const lessOrEqual = historicalAmounts.filter((a) => a <= biggest.amount).length
+    pctile = lessOrEqual / historicalAmounts.length
+  }
+
+  return {
+    biggest,
+    monthTop,
+    pctile,
+    historicalCount: historicalAmounts.length,
+    monthLabel,
+  }
+}


### PR DESCRIPTION
## 為什麼

每月通常有 1-2 筆「特別大」的支出（機票、家電、繳稅）。但月底回看 records 列表時看不到「這筆很特別」的標記。

這個 widget 把它放到首頁，並用過去 6 個月所有單筆的分布作為錨點：「比歷史 P85 還高」即時讓使用者體會這筆有多稀有。

## 視角差異 vs outlier-detector

| Widget | 時機 | 訊息 |
|--------|------|------|
| outlier-detector (#284) | form-side | 「這筆比平常貴」（輸入時警告） |
| **BiggestExpenseSpotlight** | **home-side** | **「這筆是本月最大」（回顧時 surface）** |

兩個都用「金額異常」訊號，但時機與訊息完全不同。互補。

## 做了什麼

`src/lib/biggest-expense-spotlight.ts` — 純函式：
- 找本月最大筆 + top 3
- 對比過去 6 個月單筆分布 → pctile 排名
- 用 `≤` 比例（含相等）：5000 ≥ all 10 historical → pctile = 1.0
- 歷史 < 10 筆 → pctile = null（避免 N=2 情境誤導）
- 月初 < 5 天 → null

`src/components/biggest-expense-spotlight.tsx` — UI：
- 大字 emotional spotlight 呈現金額
- pctile label 用人話：「P95+」「前 X% 大筆」「中段」
- 每筆 link 到 `/expense/{id}` drill 進編輯頁
- top 2 其他大筆作為 secondary list

## 範例輸出

> 💎 本月最大筆支出 · 2026-04
>
> **NT\$3,500**
> 香港機票
> 交通 · 2026-04-13 · 爸付
>
> ★ 比過去 P92 還高（前 8% 大筆）
>
> ─── 其他大筆 ───
> 機車保養                NT\$2,800
> 體檢                     NT\$1,200

## 測試

11 個單元測試 ✅
- 月初邊界、無當月支出 → null
- biggest sort + topN
- pctile：null on small history、相對排名邊界（0/0.5/1）
- 視窗過濾（200 天前不算）
- bad amount/date defensive
- 空 description/category/payerName fallback

整套：1145/1145 passed (新增 11 個).

## 風險與回退

- 純讀取
- 純函式
- 沒符合條件 → 靜默不 render

Closes #303