### PR TITLE
feat(home): 年度回顧 mini — YTD 累計 + 預估全年 + 對比去年同期 (Closes #305)

### DIFF
--- a/__tests__/year-recap.test.ts
+++ b/__tests__/year-recap.test.ts
@@ -1,0 +1,146 @@
+import { analyzeYearRecap } from '@/lib/year-recap'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, 2026 — day 105 of year (non-leap)
+
+function mkOnDate(id: string, amount: number, year: number, month: number, day: number, category = 'X'): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category,
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('analyzeYearRecap', () => {
+  it('returns null when too early in year (< minDaysSoFar)', () => {
+    const day10 = new Date(2026, 0, 10, 12, 0, 0).getTime()
+    expect(analyzeYearRecap({ expenses: [], now: day10, minDaysSoFar: 30 })).toBeNull()
+  })
+
+  it('returns null when no current-year spending', () => {
+    const expenses = [mkOnDate('a', 100, 2025, 5, 15)]
+    expect(analyzeYearRecap({ expenses, now: NOW })).toBeNull()
+  })
+
+  it('computes YTD total and projects annual', () => {
+    const expenses = [
+      mkOnDate('a', 10000, 2026, 0, 15),
+      mkOnDate('b', 5000, 2026, 1, 20),
+      mkOnDate('c', 8000, 2026, 3, 10),
+    ]
+    const r = analyzeYearRecap({ expenses, now: NOW })
+    expect(r!.year).toBe(2026)
+    expect(r!.ytdTotal).toBe(23000)
+    expect(r!.daysSoFarInYear).toBe(105)
+    expect(r!.daysInYear).toBe(365)
+    expect(r!.projectedAnnual).toBeCloseTo((23000 / 105) * 365)
+  })
+
+  it('topCategory finds highest YTD category with share pct', () => {
+    const expenses = [
+      mkOnDate('a', 5000, 2026, 0, 15, '餐飲'),
+      mkOnDate('b', 8000, 2026, 1, 20, '餐飲'),
+      mkOnDate('c', 3000, 2026, 2, 10, '交通'),
+    ]
+    const r = analyzeYearRecap({ expenses, now: NOW })
+    expect(r!.topCategory!.name).toBe('餐飲')
+    expect(r!.topCategory!.amount).toBe(13000)
+    expect(r!.topCategory!.pct).toBeCloseTo(13000 / 16000)
+  })
+
+  it('topMonth finds highest-spend month YTD', () => {
+    const expenses = [
+      mkOnDate('a', 1000, 2026, 0, 15), // Jan: 1000
+      mkOnDate('b', 5000, 2026, 1, 10), // Feb: 5000
+      mkOnDate('c', 1500, 2026, 1, 20), // Feb: +1500 = 6500
+      mkOnDate('d', 500, 2026, 2, 5), // Mar: 500
+    ]
+    const r = analyzeYearRecap({ expenses, now: NOW })
+    expect(r!.topMonth!.month).toBe(2) // February
+    expect(r!.topMonth!.amount).toBe(6500)
+  })
+
+  it('lastYearSamePeriodTotal includes only last year up to same day-of-year', () => {
+    // Day 105 = April 15.
+    // Last year (2025): include up to April 15
+    const expenses = [
+      mkOnDate('curr', 1000, 2026, 3, 5),
+      mkOnDate('lyJan', 2000, 2025, 0, 15), // Day 15 — included
+      mkOnDate('lyMar', 3000, 2025, 2, 15), // Day 74 — included
+      mkOnDate('lyJun', 999, 2025, 5, 15), // Day 166 — excluded
+    ]
+    const r = analyzeYearRecap({ expenses, now: NOW })
+    // minLastYearDays default 30 — but we're counting expense rows, not days
+    // lastYearSamePeriodCount is rows, not unique days. With 2 in same period it doesn't reach 30.
+    // Need enough rows for comparable
+    const expensesMany = [
+      mkOnDate('curr', 1000, 2026, 3, 5),
+      ...Array.from({ length: 30 }, (_, i) => mkOnDate(`ly${i}`, 100, 2025, 0, 15 + i)),
+    ]
+    const r2 = analyzeYearRecap({ expenses: expensesMany, now: NOW })
+    expect(r2!.lastYearSamePeriodTotal).toBe(3000) // 30 × 100
+    expect(r2!.vsLastYearSameDate).toBe(1000 - 3000)
+  })
+
+  it('lastYearSamePeriodTotal null when too few records', () => {
+    const expenses = [
+      mkOnDate('curr', 1000, 2026, 3, 5),
+      mkOnDate('lyA', 100, 2025, 0, 15),
+      mkOnDate('lyB', 100, 2025, 1, 15),
+    ]
+    const r = analyzeYearRecap({ expenses, now: NOW })
+    expect(r!.lastYearSamePeriodTotal).toBeNull()
+    expect(r!.vsLastYearSameDate).toBeNull()
+  })
+
+  it('lastYearTotal null when full year too thin', () => {
+    const expenses = [
+      mkOnDate('curr', 1000, 2026, 3, 5),
+      mkOnDate('lyA', 100, 2025, 0, 15),
+    ]
+    const r = analyzeYearRecap({ expenses, now: NOW })
+    expect(r!.lastYearTotal).toBeNull()
+  })
+
+  it('skips bad amount/date defensively', () => {
+    const bad = { ...mkOnDate('bad', 100, 2026, 3, 5), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mkOnDate('valid', 5000, 2026, 0, 15),
+      mkOnDate('nan', NaN, 2026, 0, 15),
+      mkOnDate('zero', 0, 2026, 0, 15),
+      mkOnDate('neg', -100, 2026, 0, 15),
+      bad,
+    ]
+    const r = analyzeYearRecap({ expenses, now: NOW })
+    expect(r!.ytdTotal).toBe(5000)
+  })
+
+  it('handles leap year (2024 had 366 days)', () => {
+    const apr15_2024 = new Date(2024, 3, 15, 12, 0, 0).getTime()
+    const expenses = [mkOnDate('a', 1000, 2024, 1, 29)] // Feb 29, 2024
+    const r = analyzeYearRecap({ expenses, now: apr15_2024 })
+    expect(r!.daysInYear).toBe(366)
+  })
+
+  it('does not count current-year expenses past today', () => {
+    const expenses = [
+      mkOnDate('past', 1000, 2026, 0, 5),
+      mkOnDate('future', 999, 2026, 5, 10), // June 10 (future as of April 15)
+    ]
+    const r = analyzeYearRecap({ expenses, now: NOW })
+    expect(r!.ytdTotal).toBe(1000)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -26,6 +26,7 @@ import { MonthProjection } from '@/components/month-projection'
 import { CategoryMoM } from '@/components/category-mom'
 import { MostFrequentItems } from '@/components/most-frequent-items'
 import { BiggestExpenseSpotlight } from '@/components/biggest-expense-spotlight'
+import { YearRecap } from '@/components/year-recap'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -261,6 +262,9 @@ export default function HomePage() {
 
       {/* 本月最大筆 spotlight (Issue #303) — 單筆極值 + pctile 排名 */}
       <BiggestExpenseSpotlight expenses={expenses} />
+
+      {/* 年度回顧 mini (Issue #305) — YTD 累計 + 預估全年 + 對比去年同期 */}
+      <YearRecap expenses={expenses} />
 
       {/* 30 天每日花費熱力圖 (Issue #290) */}
       <SpendingHeatmap expenses={expenses} />

--- a/src/components/year-recap.tsx
+++ b/src/components/year-recap.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useMemo } from 'react'
+import { analyzeYearRecap } from '@/lib/year-recap'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface YearRecapProps {
+  expenses: Expense[]
+}
+
+/**
+ * Year-to-date overview (Issue #305). The only annual-cadence widget on
+ * the home page — fills the time-axis gap left by month-and-shorter
+ * widgets. Renders silently before day 30 of the year, where linear
+ * extrapolation is too noisy to be useful.
+ */
+export function YearRecap({ expenses }: YearRecapProps) {
+  const data = useMemo(
+    () => analyzeYearRecap({ expenses }),
+    [expenses],
+  )
+
+  if (!data) return null
+
+  const yearProgressPct = Math.round((data.daysSoFarInYear / data.daysInYear) * 100)
+
+  let comparison: { label: string; color: string } | null = null
+  if (
+    data.lastYearSamePeriodTotal !== null &&
+    data.vsLastYearSameDate !== null &&
+    data.lastYearSamePeriodTotal > 0
+  ) {
+    const pct = Math.round(
+      (data.vsLastYearSameDate / data.lastYearSamePeriodTotal) * 100,
+    )
+    if (pct > 0) {
+      comparison = {
+        label: `↑ 比去年同期多 ${pct}%（去年 ${currency(data.lastYearSamePeriodTotal)}）`,
+        color: 'var(--destructive)',
+      }
+    } else if (pct < 0) {
+      comparison = {
+        label: `↓ 比去年同期少 ${Math.abs(pct)}%（去年 ${currency(data.lastYearSamePeriodTotal)}）`,
+        color: 'var(--primary)',
+      }
+    } else {
+      comparison = {
+        label: `→ 與去年同期相當（去年 ${currency(data.lastYearSamePeriodTotal)}）`,
+        color: 'var(--muted-foreground)',
+      }
+    }
+  }
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+          📅 {data.year} 年度回顧
+        </div>
+        <div className="text-xs text-[var(--muted-foreground)]">
+          已過 {yearProgressPct}% ({data.daysSoFarInYear}/{data.daysInYear} 天)
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-sm text-[var(--foreground)]">
+          本年累計 <span className="font-semibold">{currency(data.ytdTotal)}</span>
+        </p>
+        <p className="text-base text-[var(--foreground)]">
+          預估全年{' '}
+          <span className="font-semibold text-[var(--primary)]">
+            {currency(data.projectedAnnual)}
+          </span>
+        </p>
+      </div>
+
+      {comparison && (
+        <p className="text-xs" style={{ color: comparison.color }}>
+          {comparison.label}
+        </p>
+      )}
+
+      <div className="pt-2 border-t border-[var(--border)] flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--muted-foreground)]">
+        {data.topCategory && (
+          <span>
+            主類別：{data.topCategory.name} {currency(data.topCategory.amount)} (
+            {Math.round(data.topCategory.pct * 100)}%)
+          </span>
+        )}
+        {data.topMonth && (
+          <span>
+            最高月：{data.topMonth.month} 月 {currency(data.topMonth.amount)}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/year-recap.ts
+++ b/src/lib/year-recap.ts
@@ -1,0 +1,153 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface CategorySummary {
+  name: string
+  amount: number
+  /** 0..1 share of YTD total. */
+  pct: number
+}
+
+export interface MonthSummary {
+  /** 1..12 (1-indexed for human readability). */
+  month: number
+  amount: number
+}
+
+export interface YearRecapData {
+  year: number
+  /** YTD total for current year. */
+  ytdTotal: number
+  daysSoFarInYear: number
+  daysInYear: number
+  /** Linear annual extrapolation (`ytdTotal / daysSoFar * daysInYear`). */
+  projectedAnnual: number
+  /** Sum of last year's expenses up to same day-of-year. null if not enough data. */
+  lastYearSamePeriodTotal: number | null
+  /** Sum of last year's full-year expenses, null when incomplete history. */
+  lastYearTotal: number | null
+  /** ytdTotal - lastYearSamePeriodTotal. null when no comparable. */
+  vsLastYearSameDate: number | null
+  /** Top YTD category. null when no spending. */
+  topCategory: CategorySummary | null
+  /** Highest-spend calendar month YTD (1-indexed). null when no data. */
+  topMonth: MonthSummary | null
+}
+
+interface AnalyzeOptions {
+  expenses: Expense[]
+  now?: number
+  /** Min days into the year before producing analysis. Default 30. */
+  minDaysSoFar?: number
+  /** Min days of last-year data to surface comparisons. Default 30. */
+  minLastYearDays?: number
+}
+
+function isLeap(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0
+}
+
+function daysInYearFor(year: number): number {
+  return isLeap(year) ? 366 : 365
+}
+
+function dayOfYear(d: Date): number {
+  const start = new Date(d.getFullYear(), 0, 0)
+  const diff = d.getTime() - start.getTime()
+  return Math.floor(diff / 86_400_000)
+}
+
+/**
+ * Year-to-date overview with last-year same-period comparison. Produces
+ * the only annual-cadence widget on the home page — fills the
+ * "year" gap left by the rest of the time-axis stack
+ * (day → week → month).
+ */
+export function analyzeYearRecap({
+  expenses,
+  now = Date.now(),
+  minDaysSoFar = 30,
+  minLastYearDays = 30,
+}: AnalyzeOptions): YearRecapData | null {
+  const today = new Date(now)
+  const year = today.getFullYear()
+  const daysSoFarInYear = dayOfYear(today)
+  if (daysSoFarInYear < minDaysSoFar) return null
+  const daysInYear = daysInYearFor(year)
+
+  const lastYear = year - 1
+  const lastYearSamePeriodCutoff = new Date(lastYear, 0, 1)
+  lastYearSamePeriodCutoff.setDate(daysSoFarInYear)
+  lastYearSamePeriodCutoff.setHours(23, 59, 59, 999)
+
+  const ytdByCategory = new Map<string, number>()
+  const ytdByMonth = new Map<number, number>()
+  let ytdTotal = 0
+  let lastYearSamePeriodTotal = 0
+  let lastYearSamePeriodCount = 0
+  let lastYearTotal = 0
+  let lastYearTotalCount = 0
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+
+    if (d.getFullYear() === year && d.getTime() <= today.getTime()) {
+      ytdTotal += amount
+      const category = (e.category || '其他').trim() || '其他'
+      ytdByCategory.set(category, (ytdByCategory.get(category) ?? 0) + amount)
+      const m = d.getMonth() + 1
+      ytdByMonth.set(m, (ytdByMonth.get(m) ?? 0) + amount)
+    } else if (d.getFullYear() === lastYear) {
+      lastYearTotal += amount
+      lastYearTotalCount++
+      if (d.getTime() <= lastYearSamePeriodCutoff.getTime()) {
+        lastYearSamePeriodTotal += amount
+        lastYearSamePeriodCount++
+      }
+    }
+  }
+
+  if (ytdTotal <= 0) return null
+
+  const projectedAnnual = (ytdTotal / daysSoFarInYear) * daysInYear
+
+  let topCategory: CategorySummary | null = null
+  for (const [name, amount] of ytdByCategory) {
+    if (!topCategory || amount > topCategory.amount) {
+      topCategory = { name, amount, pct: amount / ytdTotal }
+    }
+  }
+
+  let topMonth: MonthSummary | null = null
+  for (const [month, amount] of ytdByMonth) {
+    if (!topMonth || amount > topMonth.amount) {
+      topMonth = { month, amount }
+    }
+  }
+
+  const lastYearComparable = lastYearSamePeriodCount >= minLastYearDays
+  const lastYearFull = lastYearTotalCount >= minLastYearDays
+
+  return {
+    year,
+    ytdTotal,
+    daysSoFarInYear,
+    daysInYear,
+    projectedAnnual,
+    lastYearSamePeriodTotal: lastYearComparable ? lastYearSamePeriodTotal : null,
+    lastYearTotal: lastYearFull ? lastYearTotal : null,
+    vsLastYearSameDate: lastYearComparable
+      ? ytdTotal - lastYearSamePeriodTotal
+      : null,
+    topCategory,
+    topMonth,
+  }
+}


### PR DESCRIPTION
## 為什麼

之前所有 widget 的時間軸：**日 (heatmap)** → **週 (dow)** → **月 (diary, projection)**。**年度視角從未被觸及。**

對使用 1+ 年的家庭：「我今年比去年是花更多還更少？預估全年會破紀錄嗎？」是個關鍵長期問題。沒有 widget 回答它。

## 做了什麼

`src/lib/year-recap.ts` — 純函式：
- YTD 累計 + 線性預估全年
- 去年同期對比（用 day-of-year 對齊）
- 去年全年總額（如資料完整）
- topCategory：YTD 最大類別
- topMonth：YTD 花費最高月
- 年初 < 30 天 → null（外插太粗）
- 跳過未來日期紀錄（不算進 ytd）
- leap year 處理（2024 366 天）

`src/components/year-recap.tsx` — UI：
- 三段：累計 + 預估｜對比去年｜metadata
- 對比著色：多用紅、少用綠、相當用灰

## 範例輸出

> 📅 2026 年度回顧                    已過 29% (105/365 天)
>
> 本年累計 **NT\$45,000**
> 預估全年 **NT\$155,000**
>
> ↑ 比去年同期多 12%（去年 NT\$40,179）
>
> ─────
> 主類別：餐飲 NT\$15,200 (34%)  ·  最高月：3 月 NT\$18,500

## 測試

11 個單元測試 ✅
- 年初 < 30 天 → null
- 無 YTD 資料 → null
- YTD total + 預估計算
- topCategory + topMonth
- 去年同期 + vsLastYearSameDate
- minLastYearDays threshold
- leap year (2024 = 366)
- 跳過 future date
- bad amount/date defensive

整套：1156/1156 passed (新增 11 個).

## 風險與回退

- 純讀取
- 純函式
- 沒符合條件 → 靜默不 render

Closes #305