### PR TITLE
feat(expense-form): 輸入描述時 inline 顯示同名歷史價格 (Closes #307)

### DIFF
--- a/__tests__/same-description-history.test.ts
+++ b/__tests__/same-description-history.test.ts
@@ -1,0 +1,169 @@
+import { findSameDescriptionHistory } from '@/lib/same-description-history'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15
+
+function mk(id: string, amount: number, description: string, daysAgo: number): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description,
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('findSameDescriptionHistory', () => {
+  it('returns null when description too short', () => {
+    expect(
+      findSameDescriptionHistory({
+        description: 'a',
+        expenses: [mk('1', 100, 'a', 0)],
+        now: NOW,
+      }),
+    ).toBeNull()
+    expect(
+      findSameDescriptionHistory({ description: '', expenses: [], now: NOW }),
+    ).toBeNull()
+  })
+
+  it('returns null when no matches', () => {
+    const expenses = [mk('1', 100, '午餐', 0)]
+    expect(
+      findSameDescriptionHistory({ description: '咖啡', expenses, now: NOW }),
+    ).toBeNull()
+  })
+
+  it('matches case-insensitive normalized descriptions', () => {
+    const expenses = [
+      mk('1', 100, 'Lunch', 1),
+      mk('2', 120, 'lunch', 2),
+      mk('3', 110, 'LUNCH ', 3),
+    ]
+    const r = findSameDescriptionHistory({
+      description: ' LuNcH ',
+      expenses,
+      now: NOW,
+    })
+    expect(r!.count).toBe(3)
+    expect(r!.averagePrice).toBe(110)
+  })
+
+  it('returns recentEntries sorted desc by date', () => {
+    const expenses = [
+      mk('a', 100, '午餐', 5),
+      mk('b', 200, '午餐', 1),
+      mk('c', 300, '午餐', 10),
+    ]
+    const r = findSameDescriptionHistory({ description: '午餐', expenses, now: NOW })
+    expect(r!.recentEntries.map((e) => e.amount)).toEqual([200, 100, 300])
+  })
+
+  it('respects limit', () => {
+    const expenses = Array.from({ length: 5 }, (_, i) => mk(String(i), 100, '午餐', i + 1))
+    const r = findSameDescriptionHistory({
+      description: '午餐',
+      expenses,
+      limit: 3,
+      now: NOW,
+    })
+    expect(r!.recentEntries.length).toBe(3)
+    expect(r!.count).toBe(5)
+  })
+
+  it('lastEntry equals recentEntries[0]', () => {
+    const expenses = [
+      mk('a', 100, '午餐', 5),
+      mk('b', 200, '午餐', 1),
+    ]
+    const r = findSameDescriptionHistory({ description: '午餐', expenses, now: NOW })
+    expect(r!.lastEntry).toEqual(r!.recentEntries[0])
+    expect(r!.lastEntry.amount).toBe(200)
+  })
+
+  it('daysSinceLast computed correctly', () => {
+    const expenses = [mk('a', 100, '午餐', 7)]
+    const r = findSameDescriptionHistory({ description: '午餐', expenses, now: NOW })
+    expect(r!.daysSinceLast).toBe(7)
+  })
+
+  it('excludes currentId (when editing)', () => {
+    const expenses = [
+      mk('current', 999, '午餐', 0),
+      mk('other', 100, '午餐', 5),
+    ]
+    const r = findSameDescriptionHistory({
+      description: '午餐',
+      expenses,
+      currentId: 'current',
+      now: NOW,
+    })
+    expect(r!.count).toBe(1)
+    expect(r!.recentEntries[0].amount).toBe(100)
+  })
+
+  it('skips expenses outside windowDays', () => {
+    const expenses = [
+      mk('inside', 100, '午餐', 100),
+      mk('outside', 999, '午餐', 400), // > 365 days
+    ]
+    const r = findSameDescriptionHistory({
+      description: '午餐',
+      expenses,
+      windowDays: 365,
+      now: NOW,
+    })
+    expect(r!.count).toBe(1)
+    expect(r!.recentEntries[0].amount).toBe(100)
+  })
+
+  it('skips bad amount and bad date', () => {
+    const bad = { ...mk('z', 100, '午餐', 0), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mk('valid', 100, '午餐', 1),
+      mk('nan', NaN, '午餐', 0),
+      mk('zero', 0, '午餐', 0),
+      mk('neg', -50, '午餐', 0),
+      bad,
+    ]
+    const r = findSameDescriptionHistory({ description: '午餐', expenses, now: NOW })
+    expect(r!.count).toBe(1)
+  })
+
+  it('ignores future-dated records', () => {
+    const expenses = [mk('future', 999, '午餐', -10)] // 10 days in future
+    expect(
+      findSameDescriptionHistory({ description: '午餐', expenses, now: NOW }),
+    ).toBeNull()
+  })
+
+  it('averagePrice is mean across all matches (not just shown)', () => {
+    const expenses = [
+      mk('a', 100, '午餐', 1),
+      mk('b', 200, '午餐', 2),
+      mk('c', 300, '午餐', 3),
+      mk('d', 400, '午餐', 4),
+      mk('e', 500, '午餐', 5),
+    ]
+    const r = findSameDescriptionHistory({
+      description: '午餐',
+      expenses,
+      limit: 3,
+      now: NOW,
+    })
+    expect(r!.averagePrice).toBe(300) // (100+200+300+400+500) / 5
+    expect(r!.count).toBe(5)
+    expect(r!.recentEntries.length).toBe(3) // only 3 shown
+  })
+})

--- a/src/components/description-price-history.tsx
+++ b/src/components/description-price-history.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { findSameDescriptionHistory } from '@/lib/same-description-history'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface DescriptionPriceHistoryProps {
+  description: string
+  expenses: Expense[]
+  /** ID of the expense being edited (excluded from history). */
+  currentExpenseId?: string
+  /** Debounce ms before query fires. Default 200. */
+  debounceMs?: number
+}
+
+/**
+ * Inline same-description price history for the expense form (Issue #307).
+ * Surfaces the user's last few payments for an identical description so
+ * they can sense-check the amount they're about to enter — distinct from
+ * duplicate-detector which warns about *very recent* near-identical
+ * records (an anti-double-record defence).
+ */
+export function DescriptionPriceHistory({
+  description,
+  expenses,
+  currentExpenseId,
+  debounceMs = 200,
+}: DescriptionPriceHistoryProps) {
+  const [debouncedDescription, setDebouncedDescription] = useState(description)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedDescription(description), debounceMs)
+    return () => clearTimeout(t)
+  }, [description, debounceMs])
+
+  const data = useMemo(
+    () =>
+      findSameDescriptionHistory({
+        description: debouncedDescription,
+        expenses,
+        currentId: currentExpenseId,
+      }),
+    [debouncedDescription, expenses, currentExpenseId],
+  )
+
+  if (!data) return null
+
+  const sinceLastLabel =
+    data.daysSinceLast === 0
+      ? '今天'
+      : data.daysSinceLast === 1
+        ? '昨天'
+        : `${data.daysSinceLast} 天前`
+
+  return (
+    <div
+      className="mt-1.5 px-3 py-2 rounded-md text-xs animate-fade-up"
+      style={{
+        backgroundColor: 'color-mix(in oklch, var(--primary) 8%, transparent)',
+        borderLeft: '2px solid var(--primary)',
+      }}
+      role="note"
+      aria-live="polite"
+    >
+      <p className="text-[var(--foreground)]">
+        上次 <span className="font-semibold">{currency(data.lastEntry.amount)}</span>
+        <span className="text-[var(--muted-foreground)]"> · {sinceLastLabel}</span>
+      </p>
+      {data.count >= 2 && (
+        <p className="text-[var(--muted-foreground)] mt-0.5">
+          共 {data.count} 次 · 平均 {currency(data.averagePrice)}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -31,6 +31,7 @@ import { ref as storageRef, getDownloadURL } from 'firebase/storage'
 import { storage } from '@/lib/firebase'
 import { logger } from '@/lib/logger'
 import { ReceiptGallery } from '@/components/receipt-gallery'
+import { DescriptionPriceHistory } from '@/components/description-price-history'
 import type { Expense, SplitMethod, PaymentMethod, SplitDetail } from '@/lib/types'
 import type { ParsedExpense } from '@/lib/services/local-expense-parser'
 
@@ -686,6 +687,12 @@ export function ExpenseForm({ existingExpense, duplicateFrom, initialDate, onSav
             ))}
           </div>
         )}
+        {/* 同名歷史價格 inline 提示 (Issue #307) */}
+        <DescriptionPriceHistory
+          description={description}
+          expenses={expenses}
+          currentExpenseId={existingExpense?.id}
+        />
       </div>
 
       {/* 金額 — 支援 700+150 四則運算 (Issue #220) */}

--- a/src/lib/same-description-history.ts
+++ b/src/lib/same-description-history.ts
@@ -1,0 +1,104 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface HistoryEntry {
+  /** Date as YYYY-MM-DD (local). */
+  dateLabel: string
+  /** Epoch ms — used for sort and "X days ago" calc. */
+  ts: number
+  amount: number
+}
+
+export interface SameDescriptionHistoryData {
+  /** Most recent entries first (up to limit). */
+  recentEntries: HistoryEntry[]
+  /** Mean across all matched entries within window. */
+  averagePrice: number
+  /** Total matched entries within window. */
+  count: number
+  /** The single most recent entry (recentEntries[0]). */
+  lastEntry: HistoryEntry
+  /** Days back from now to the lastEntry occurrence (≥ 0). */
+  daysSinceLast: number
+}
+
+interface FindOptions {
+  description: string
+  expenses: Expense[]
+  /** Exclude an expense id (used when editing). */
+  currentId?: string
+  /** Days back to consider. Default 365 (1 year). */
+  windowDays?: number
+  /** Top N recent entries to surface. Default 3. */
+  limit?: number
+  /** Min description length before matching. Default 2. */
+  minDescriptionLength?: number
+  /** Now in epoch ms; defaults to Date.now(). */
+  now?: number
+}
+
+function normalize(s: string): string {
+  return (s ?? '').trim().toLowerCase()
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Look up prior expenses whose description matches (case-insensitive,
+ * trimmed) so the form can inline a "last time you paid X for this"
+ * hint. Distinct from duplicate-detector which warns about *too-similar*
+ * recent entries (a defence against accidental double-record); this is
+ * an *informative* anchor across longer history.
+ */
+export function findSameDescriptionHistory({
+  description,
+  expenses,
+  currentId,
+  windowDays = 365,
+  limit = 3,
+  minDescriptionLength = 2,
+  now = Date.now(),
+}: FindOptions): SameDescriptionHistoryData | null {
+  const normalized = normalize(description)
+  if (normalized.length < minDescriptionLength) return null
+
+  const cutoff = now - windowDays * 86_400_000
+  const matches: HistoryEntry[] = []
+  let total = 0
+  let count = 0
+
+  for (const e of expenses) {
+    if (currentId && e.id === currentId) continue
+    if (normalize(e.description) !== normalized) continue
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    const ts = d.getTime()
+    if (!Number.isFinite(ts) || ts < cutoff || ts > now) continue
+    matches.push({ dateLabel: dateKey(d), ts, amount })
+    total += amount
+    count++
+  }
+
+  if (count === 0) return null
+
+  matches.sort((a, b) => b.ts - a.ts)
+  const recentEntries = matches.slice(0, limit)
+  const lastEntry = recentEntries[0]
+  const daysSinceLast = Math.max(0, Math.floor((now - lastEntry.ts) / 86_400_000))
+
+  return {
+    recentEntries,
+    averagePrice: total / count,
+    count,
+    lastEntry,
+    daysSinceLast,
+  }
+}


### PR DESCRIPTION
## 為什麼

12 個 home widget 已經很豐富，**pivot 到表單**：使用者輸入支出時最常自問「之前這個多少錢？」。輸入「機車保養」→ 上次 NT\$2,500（半年前），現在估價 NT\$3,000 → 是不是漲了？

這個資訊在 records 列表搜得到，但要打字 → 翻頁 → 過濾 → 看數字。**輸入時 inline 顯示**才是 right time。

## 視角差異 vs duplicate-detector

| Widget | 訊息 | 時間窗 |
|--------|------|------|
| duplicate-detector (#211) | 「太像了，怕重複輸入」 | 60 分鐘（anti-double-record） |
| **DescriptionPriceHistory** | **「上次多少錢，給你參考」** | **365 天 (informative anchor)** |

兩個都用「同名歷史」訊號但意圖完全不同。互補。

## 做了什麼

`src/lib/same-description-history.ts` — 純函式：
- 描述正規化（trim + lowercase）後比對
- 預設 365 天視窗
- top 3 最近紀錄 + averagePrice（所有 match） + daysSinceLast
- 編輯模式 currentId 排除自己
- 跳過 future-dated、bad amount/date、< 2 字元

`src/components/description-price-history.tsx` — UI：
- 描述輸入框正下方 inline
- 左邊 primary 色 border（提示但不打擾）
- debounce 200ms（避免每次按鍵查）
- 沒 match 靜默不顯示

`src/components/expense-form.tsx`：
- 加 import + 在描述 input 之後 render

## 範例輸出

> 描述: 機車保養
> ▶ 上次 **NT\$2,500** · 180 天前
>   共 4 次 · 平均 NT\$2,400

## 測試

12 個單元測試 ✅
- 短描述（< 2 字元）跳過
- 無 match 返回 null
- normalize（中英文 case-insensitive、padding）
- recentEntries 排序
- limit
- lastEntry === recentEntries[0]
- daysSinceLast 計算
- currentId 排除（編輯場景）
- 視窗外排除
- bad amount/date defensive
- future date 排除
- averagePrice 是所有 match 平均（不僅顯示的）

整套：1168/1168 passed (新增 12 個).

## 風險與回退

- 純讀取
- debounce 避免效能問題
- 沒 match 靜默不 render
- 編輯模式排除自己

Closes #307