### PR TITLE
feat(records): 搜尋同名描述時 inline 顯示價格走勢圖 (Closes #309)

### DIFF
--- a/__tests__/description-price-trend.test.ts
+++ b/__tests__/description-price-trend.test.ts
@@ -1,0 +1,180 @@
+import { buildPriceTrendSeries } from '@/lib/description-price-trend'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime()
+
+function mk(id: string, amount: number, description: string, daysAgo: number): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description,
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('buildPriceTrendSeries', () => {
+  it('returns null when description is empty', () => {
+    expect(
+      buildPriceTrendSeries({ expenses: [], description: '', now: NOW }),
+    ).toBeNull()
+  })
+
+  it('returns null when matches below minMatches', () => {
+    const expenses = [mk('a', 100, '咖啡', 1), mk('b', 100, '咖啡', 2)]
+    expect(
+      buildPriceTrendSeries({
+        expenses,
+        description: '咖啡',
+        minMatches: 3,
+        now: NOW,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when matches exceed maxMatches', () => {
+    const expenses = Array.from({ length: 200 }, (_, i) => mk(String(i), 100, '咖啡', i))
+    expect(
+      buildPriceTrendSeries({
+        expenses,
+        description: '咖啡',
+        maxMatches: 100,
+        days: 999,
+        now: NOW,
+      }),
+    ).toBeNull()
+  })
+
+  it('series is chronological (asc by date)', () => {
+    const expenses = [
+      mk('a', 80, '咖啡', 5),
+      mk('b', 90, '咖啡', 1),
+      mk('c', 100, '咖啡', 10),
+    ]
+    const r = buildPriceTrendSeries({ expenses, description: '咖啡', now: NOW })
+    expect(r!.series.map((p) => p.amount)).toEqual([100, 80, 90])
+  })
+
+  it('computes averagePrice, min, max correctly', () => {
+    const expenses = [
+      mk('a', 100, '午餐', 5),
+      mk('b', 200, '午餐', 4),
+      mk('c', 50, '午餐', 3),
+      mk('d', 150, '午餐', 2),
+    ]
+    const r = buildPriceTrendSeries({ expenses, description: '午餐', now: NOW })
+    expect(r!.averagePrice).toBe(125)
+    expect(r!.minPrice).toBe(50)
+    expect(r!.maxPrice).toBe(200)
+  })
+
+  it('detects upward trend (later avg > earlier avg)', () => {
+    // earlier: [100, 100], later: [200, 200] → +100% trend
+    const expenses = [
+      mk('a', 100, '咖啡', 30),
+      mk('b', 100, '咖啡', 25),
+      mk('c', 200, '咖啡', 5),
+      mk('d', 200, '咖啡', 1),
+    ]
+    const r = buildPriceTrendSeries({ expenses, description: '咖啡', now: NOW })
+    expect(r!.trend).toBe('up')
+    expect(r!.trendPct!).toBeCloseTo(1.0)
+  })
+
+  it('detects downward trend', () => {
+    const expenses = [
+      mk('a', 200, '咖啡', 30),
+      mk('b', 200, '咖啡', 25),
+      mk('c', 100, '咖啡', 5),
+      mk('d', 100, '咖啡', 1),
+    ]
+    const r = buildPriceTrendSeries({ expenses, description: '咖啡', now: NOW })
+    expect(r!.trend).toBe('down')
+    expect(r!.trendPct!).toBeCloseTo(-0.5)
+  })
+
+  it('detects flat when |delta| within threshold', () => {
+    const expenses = [
+      mk('a', 100, '咖啡', 30),
+      mk('b', 100, '咖啡', 25),
+      mk('c', 102, '咖啡', 5),
+      mk('d', 103, '咖啡', 1),
+    ]
+    const r = buildPriceTrendSeries({
+      expenses,
+      description: '咖啡',
+      flatThreshold: 0.05,
+      now: NOW,
+    })
+    expect(r!.trend).toBe('flat')
+  })
+
+  it('case-insensitive normalization', () => {
+    const expenses = [
+      mk('a', 100, 'Coffee', 1),
+      mk('b', 110, 'COFFEE ', 2),
+      mk('c', 90, ' coffee', 3),
+    ]
+    const r = buildPriceTrendSeries({ expenses, description: ' CoFfEe ', now: NOW })
+    expect(r!.count).toBe(3)
+  })
+
+  it('skips bad amount and date', () => {
+    const bad = { ...mk('z', 100, '咖啡', 0), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mk('a', 100, '咖啡', 1),
+      mk('b', 100, '咖啡', 2),
+      mk('c', 100, '咖啡', 3),
+      mk('nan', NaN, '咖啡', 0),
+      bad,
+    ]
+    const r = buildPriceTrendSeries({ expenses, description: '咖啡', now: NOW })
+    expect(r!.count).toBe(3)
+  })
+
+  it('skips expenses outside days window', () => {
+    const expenses = [
+      mk('a', 100, '咖啡', 1),
+      mk('b', 100, '咖啡', 2),
+      mk('c', 100, '咖啡', 400), // > 365 default
+    ]
+    const r = buildPriceTrendSeries({ expenses, description: '咖啡', now: NOW })
+    expect(r).toBeNull() // only 2 inside window
+  })
+
+  it('ignores future-dated records', () => {
+    const expenses = [
+      mk('past1', 100, '咖啡', 1),
+      mk('past2', 100, '咖啡', 2),
+      mk('past3', 100, '咖啡', 3),
+      mk('future', 999, '咖啡', -10),
+    ]
+    const r = buildPriceTrendSeries({ expenses, description: '咖啡', now: NOW })
+    expect(r!.count).toBe(3)
+  })
+
+  it('trendPct null when earlierAvg is 0 (insufficient data)', () => {
+    // Only 3 points → half = 1, earlier=[0..1], later=[2..3]
+    // both halves exist, so earlierAvg > 0
+    // But what if exactly the boundary? Let's check 2-point edge (below minMatches anyway)
+    const expenses = [
+      mk('a', 100, '咖啡', 1),
+      mk('b', 100, '咖啡', 2),
+      mk('c', 100, '咖啡', 3),
+    ]
+    const r = buildPriceTrendSeries({ expenses, description: '咖啡', now: NOW })
+    expect(r!.trendPct).not.toBeNull() // 3 points → half=1, both halves present
+    expect(r!.trend).toBe('flat')
+  })
+})

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -9,6 +9,7 @@ import {
   type AmountRangeKey,
 } from '@/lib/amount-range-filter'
 import { AmountRangeChips } from '@/components/amount-range-chips'
+import { DescriptionPriceTrend } from '@/components/description-price-trend'
 import { useSwipe } from '@/hooks/use-swipe'
 import { usePullToRefresh } from '@/hooks/use-pull-to-refresh'
 import { useGroup } from '@/lib/hooks/use-group'
@@ -571,6 +572,14 @@ export default function RecordsPage() {
             </button>
           </div>
         </div>
+      )}
+
+      {/* 同名描述價格走勢 (Issue #309) */}
+      {!loading && searchQuery && (
+        <DescriptionPriceTrend
+          expenses={filtered}
+          description={searchQuery}
+        />
       )}
 
       {/* Content */}

--- a/src/components/description-price-trend.tsx
+++ b/src/components/description-price-trend.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts'
+import { buildPriceTrendSeries } from '@/lib/description-price-trend'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface DescriptionPriceTrendProps {
+  expenses: Expense[]
+  description: string
+}
+
+const TREND_LABELS = {
+  up: { icon: '↑', label: '價格趨勢上升', color: 'var(--destructive)' },
+  down: { icon: '↓', label: '價格趨勢下降', color: 'var(--primary)' },
+  flat: { icon: '→', label: '價格趨勢穩定', color: 'var(--muted-foreground)' },
+} as const
+
+/**
+ * Inline price trend visualization for the records page when a single
+ * description is being searched (Issue #309). Uses a scatter plot rather
+ * than a line because each point is a discrete purchase event — drawing
+ * straight lines between would imply continuity that doesn't exist.
+ */
+export function DescriptionPriceTrend({
+  expenses,
+  description,
+}: DescriptionPriceTrendProps) {
+  const data = useMemo(
+    () => buildPriceTrendSeries({ expenses, description }),
+    [expenses, description],
+  )
+
+  if (!data) return null
+
+  const trendInfo = TREND_LABELS[data.trend]
+  const pctText =
+    data.trendPct !== null
+      ? `${data.trendPct > 0 ? '+' : ''}${Math.round(data.trendPct * 100)}%`
+      : ''
+
+  const chartData = data.series.map((p) => ({
+    x: p.ts,
+    y: p.amount,
+    label: p.dateLabel,
+  }))
+
+  return (
+    <div className="card p-4 md:p-5 space-y-2 mb-4 animate-fade-up">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+          📈 「{description}」價格走勢 · {data.count} 筆
+        </div>
+        <div className="text-xs" style={{ color: trendInfo.color }}>
+          {trendInfo.icon} {trendInfo.label}
+          {pctText && ` (${pctText})`}
+        </div>
+      </div>
+
+      <div className="h-[140px] -mx-2">
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
+            <XAxis
+              dataKey="x"
+              type="number"
+              domain={['dataMin', 'dataMax']}
+              tickFormatter={(ts) => {
+                const d = new Date(ts)
+                return `${d.getMonth() + 1}/${d.getDate()}`
+              }}
+              tick={{ fontSize: 10 }}
+              stroke="var(--muted-foreground)"
+            />
+            <YAxis
+              dataKey="y"
+              type="number"
+              domain={['dataMin - 50', 'dataMax + 50']}
+              tickFormatter={(v) => currency(v as number)}
+              tick={{ fontSize: 10 }}
+              stroke="var(--muted-foreground)"
+              width={60}
+            />
+            <ReferenceLine
+              y={data.averagePrice}
+              stroke="var(--muted-foreground)"
+              strokeDasharray="3 3"
+              label={{
+                value: `平均 ${currency(data.averagePrice)}`,
+                position: 'right',
+                fill: 'var(--muted-foreground)',
+                fontSize: 10,
+              }}
+            />
+            <Tooltip
+              content={({ active, payload }) => {
+                if (!active || !payload?.[0]) return null
+                const p = payload[0].payload as { x: number; y: number; label: string }
+                return (
+                  <div className="rounded border border-[var(--border)] bg-[var(--card)] px-2 py-1 text-xs shadow">
+                    <div className="font-medium">{p.label}</div>
+                    <div className="text-[var(--primary)]">{currency(p.y)}</div>
+                  </div>
+                )
+              }}
+            />
+            <Scatter
+              data={chartData}
+              fill="var(--primary)"
+              shape="circle"
+            />
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-[var(--muted-foreground)]">
+        <span>最低 {currency(data.minPrice)}</span>
+        <span>最高 {currency(data.maxPrice)}</span>
+        <span>平均 {currency(data.averagePrice)}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/description-price-trend.ts
+++ b/src/lib/description-price-trend.ts
@@ -1,0 +1,128 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface TrendPoint {
+  /** Date as YYYY-MM-DD (local). */
+  dateLabel: string
+  /** Epoch ms — used for chart x-axis. */
+  ts: number
+  amount: number
+}
+
+export type PriceTrend = 'up' | 'down' | 'flat'
+
+export interface PriceTrendData {
+  /** Chronological points (oldest first). */
+  series: TrendPoint[]
+  averagePrice: number
+  minPrice: number
+  maxPrice: number
+  /** Median split: avg(later half) vs avg(earlier half). */
+  trend: PriceTrend
+  /** Percent delta later vs earlier ((late - early) / early). null when input too small. */
+  trendPct: number | null
+  count: number
+}
+
+interface BuildOptions {
+  expenses: Expense[]
+  /** Description (raw — will be normalized). */
+  description: string
+  /** Days back to consider. Default 365. */
+  days?: number
+  /** Minimum matches to surface trend. Default 3. */
+  minMatches?: number
+  /** Maximum matches before bailing (signal-overload defence). Default 100. */
+  maxMatches?: number
+  /** Now in epoch ms; defaults to Date.now(). */
+  now?: number
+  /** Threshold for flat (|pct| ≤ this). Default 0.05 (5%). */
+  flatThreshold?: number
+}
+
+function normalize(s: string): string {
+  return (s ?? '').trim().toLowerCase()
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Build a price-over-time trend for purchases matching a single description.
+ * Distinct from same-description-history (#307): that one is the form-side
+ * anchor (last few entries + average); this one is the records-side
+ * batch trend (chronological series + slope).
+ */
+export function buildPriceTrendSeries({
+  expenses,
+  description,
+  days = 365,
+  minMatches = 3,
+  maxMatches = 100,
+  now = Date.now(),
+  flatThreshold = 0.05,
+}: BuildOptions): PriceTrendData | null {
+  const normalized = normalize(description)
+  if (!normalized) return null
+
+  const cutoff = now - days * 86_400_000
+  const points: TrendPoint[] = []
+
+  for (const e of expenses) {
+    if (normalize(e.description) !== normalized) continue
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    const ts = d.getTime()
+    if (!Number.isFinite(ts) || ts < cutoff || ts > now) continue
+    points.push({ dateLabel: dateKey(d), ts, amount })
+  }
+
+  if (points.length < minMatches) return null
+  if (points.length > maxMatches) return null
+
+  points.sort((a, b) => a.ts - b.ts)
+
+  let total = 0
+  let min = Infinity
+  let max = -Infinity
+  for (const p of points) {
+    total += p.amount
+    if (p.amount < min) min = p.amount
+    if (p.amount > max) max = p.amount
+  }
+  const averagePrice = total / points.length
+
+  const half = Math.floor(points.length / 2)
+  const earlier = points.slice(0, half)
+  const later = points.slice(points.length - half)
+  const earlierAvg =
+    earlier.length > 0 ? earlier.reduce((s, p) => s + p.amount, 0) / earlier.length : 0
+  const laterAvg =
+    later.length > 0 ? later.reduce((s, p) => s + p.amount, 0) / later.length : 0
+
+  let trendPct: number | null = null
+  let trend: PriceTrend = 'flat'
+  if (earlierAvg > 0 && half >= 1) {
+    trendPct = (laterAvg - earlierAvg) / earlierAvg
+    if (trendPct > flatThreshold) trend = 'up'
+    else if (trendPct < -flatThreshold) trend = 'down'
+    else trend = 'flat'
+  }
+
+  return {
+    series: points,
+    averagePrice,
+    minPrice: min,
+    maxPrice: max,
+    trend,
+    trendPct,
+    count: points.length,
+  }
+}


### PR DESCRIPTION
## 為什麼

records page 已有搜尋功能。當搜「午餐」、「咖啡」這類重複購買時，使用者真正想看到的是**價格走勢**——「我每次喝咖啡有沒有變貴？」

但現在只有列表。**走勢圖**才是這類查詢的最佳呈現。

## 三種同名歷史的呈現

| Surface | 訊息 | 形式 |
|---------|------|------|
| form (#307) | 上次多少 | inline anchor |
| records list (既有) | 全部紀錄 | list |
| **records trend (#309)** | **整體走勢** | **chart** |

同樣資料，三種視覺，三種使用情境。互不重複。

## 做了什麼

`src/lib/description-price-trend.ts` — 純函式：
- 描述正規化 + 365 天視窗
- 排序 chronologically
- average / min / max
- trend：split 前後半 → `up` / `down` / `flat`（5% threshold）
- < 3 筆或 > 100 筆都不顯示（兩端雜訊 defence）

`src/components/description-price-trend.tsx` — UI：
- Recharts **ScatterChart**（避免折線誤導 — 每筆是離散事件，不應假設連續）
- Reference line on average
- 客製 tooltip
- trend 箭頭著色

`src/app/(auth)/records/page.tsx`：
- 僅在 searchQuery 有值時 render
- 放在 filter summary 之後、列表之前

## 測試

13 個單元測試 ✅
- 描述空 → null
- minMatches / maxMatches threshold
- chronological sort
- average / min / max
- trend up / down / flat（含 flatThreshold 邊界）
- normalize (case-insensitive)
- 視窗外排除
- future date 排除
- bad amount/date defensive

整套：1181/1181 passed (新增 13 個).

## 風險與回退

- 純讀取
- recharts 已在 deps
- 條件 render（無搜尋 / 太少匹配 / 太多匹配 → 不 render）

Closes #309