### PR TITLE
feat(split): 結算節奏統計卡 — 上次多久前 + YTD + 平均/最久週期 (Closes #311)

### DIFF
--- a/__tests__/settlement-cadence.test.ts
+++ b/__tests__/settlement-cadence.test.ts
@@ -1,0 +1,129 @@
+import { analyzeSettlementCadence } from '@/lib/settlement-cadence'
+import type { Settlement } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15
+
+function mk(id: string, amount: number, daysAgo: number): Settlement {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    fromMemberId: 'm1',
+    fromMemberName: '爸',
+    toMemberId: 'm2',
+    toMemberName: '媽',
+    amount,
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+  } as unknown as Settlement
+}
+
+describe('analyzeSettlementCadence', () => {
+  it('returns null when no settlements', () => {
+    expect(analyzeSettlementCadence({ settlements: [], now: NOW })).toBeNull()
+  })
+
+  it('returns null when only invalid records', () => {
+    const bad = { ...mk('a', 100, 1), date: 'oops' } as unknown as Settlement
+    const expenses = [bad, mk('zero', 0, 1), mk('nan', NaN, 1), mk('neg', -10, 1)]
+    expect(analyzeSettlementCadence({ settlements: expenses, now: NOW })).toBeNull()
+  })
+
+  it('computes single-settlement cadence (no gap data)', () => {
+    const settlements = [mk('a', 1500, 5)]
+    const r = analyzeSettlementCadence({ settlements, now: NOW })
+    expect(r!.daysSinceLast).toBe(5)
+    expect(r!.lastSettlementDate).toBe('2026-04-10')
+    expect(r!.ytdCount).toBe(1)
+    expect(r!.ytdAmount).toBe(1500)
+    expect(r!.avgDaysBetween).toBeNull()
+    expect(r!.longestGap).toBeNull()
+  })
+
+  it('computes avg gap and longest gap', () => {
+    // Settlements 60, 30, 10 days ago → gaps: 30 days (60→30), 20 days (30→10)
+    // avg = 25, longest = 30
+    const settlements = [mk('a', 100, 60), mk('b', 100, 30), mk('c', 100, 10)]
+    const r = analyzeSettlementCadence({ settlements, now: NOW })
+    expect(r!.avgDaysBetween).toBeCloseTo(25)
+    expect(r!.longestGap).toBeCloseTo(30)
+    expect(r!.daysSinceLast).toBe(10)
+  })
+
+  it('YTD count and amount limited to current calendar year', () => {
+    // Last year: Dec 2025 (~120 days ago in April 2026)
+    // Current year: this year settlements
+    const settlements = [
+      mk('lastYear', 999, 200), // Sep 2025 — outside YTD
+      mk('curr1', 100, 30), // March 2026
+      mk('curr2', 200, 60), // Feb 2026
+      mk('curr3', 300, 5), // April 2026
+    ]
+    const r = analyzeSettlementCadence({ settlements, now: NOW })
+    expect(r!.ytdCount).toBe(3)
+    expect(r!.ytdAmount).toBe(600)
+  })
+
+  it('skips bad amount/date defensively', () => {
+    const bad = { ...mk('bad', 100, 5), date: 'oops' } as unknown as Settlement
+    const settlements = [
+      mk('valid', 100, 5),
+      mk('zero', 0, 5),
+      mk('nan', NaN, 5),
+      mk('neg', -50, 5),
+      bad,
+    ]
+    const r = analyzeSettlementCadence({ settlements, now: NOW })
+    expect(r!.daysSinceLast).toBe(5)
+    expect(r!.ytdCount).toBe(1)
+  })
+
+  it('skips future-dated settlements', () => {
+    const future = mk('future', 999, -10)
+    const past = mk('past', 100, 5)
+    const r = analyzeSettlementCadence({ settlements: [future, past], now: NOW })
+    expect(r!.daysSinceLast).toBe(5)
+    expect(r!.ytdCount).toBe(1)
+  })
+
+  it('orders by date — last settlement is most recent ts', () => {
+    // Out-of-order input
+    const settlements = [mk('old', 100, 60), mk('new', 200, 1), mk('mid', 150, 30)]
+    const r = analyzeSettlementCadence({ settlements, now: NOW })
+    expect(r!.daysSinceLast).toBe(1)
+    expect(r!.lastSettlementDate).toBe('2026-04-14')
+  })
+
+  it('handles 0-day-since-last (settled today)', () => {
+    const settlements = [mk('a', 100, 0)]
+    const r = analyzeSettlementCadence({ settlements, now: NOW })
+    expect(r!.daysSinceLast).toBe(0)
+  })
+
+  it('avgDaysBetween reflects exactly N-1 gaps', () => {
+    // 4 settlements at 0, 10, 20, 30 days ago → 3 gaps of 10 days each
+    const settlements = [
+      mk('a', 100, 30),
+      mk('b', 100, 20),
+      mk('c', 100, 10),
+      mk('d', 100, 0),
+    ]
+    const r = analyzeSettlementCadence({ settlements, now: NOW })
+    expect(r!.avgDaysBetween).toBeCloseTo(10)
+    expect(r!.longestGap).toBeCloseTo(10)
+  })
+
+  it('longestGap is true max even with mixed gaps', () => {
+    // 4 settlements: 100, 90, 30, 0 days ago → gaps: 10, 60, 30
+    const settlements = [
+      mk('a', 100, 100),
+      mk('b', 100, 90),
+      mk('c', 100, 30),
+      mk('d', 100, 0),
+    ]
+    const r = analyzeSettlementCadence({ settlements, now: NOW })
+    expect(r!.longestGap).toBeCloseTo(60)
+    expect(r!.avgDaysBetween).toBeCloseTo((10 + 60 + 30) / 3)
+  })
+})

--- a/src/app/(auth)/split/page.tsx
+++ b/src/app/(auth)/split/page.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { hapticFeedback } from '@/lib/haptic'
 import { useAuth, getActor } from '@/lib/auth'
 import { useCurrentMember } from '@/lib/hooks/use-current-member'
+import { SettlementCadence } from '@/components/settlement-cadence'
 
 import { logger } from '@/lib/logger'
 
@@ -324,6 +325,9 @@ export default function SplitPage() {
       )}
 
       <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-4">
+        {/* 結算節奏統計卡 (Issue #311) */}
+        <SettlementCadence settlements={settlements} />
+
         {/* 老化債務提醒 banner (Issue #266) */}
         {staleDebts.length > 0 && (
           <div

--- a/src/components/settlement-cadence.tsx
+++ b/src/components/settlement-cadence.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useMemo } from 'react'
+import { analyzeSettlementCadence } from '@/lib/settlement-cadence'
+import { currency } from '@/lib/utils'
+import type { Settlement } from '@/lib/types'
+
+interface SettlementCadenceProps {
+  settlements: Settlement[]
+}
+
+/**
+ * Settlement-cadence statistics card for the /split page (Issue #311).
+ * Surfaces the rhythm of family settlements: how recent, how often, how
+ * much. Renders silently when there's no settlement history yet.
+ */
+export function SettlementCadence({ settlements }: SettlementCadenceProps) {
+  const data = useMemo(
+    () => analyzeSettlementCadence({ settlements }),
+    [settlements],
+  )
+
+  if (!data) return null
+
+  const sinceLastLabel =
+    data.daysSinceLast === 0
+      ? '今天結算'
+      : data.daysSinceLast === 1
+        ? '昨天結算'
+        : `${data.daysSinceLast} 天前結算（${data.lastSettlementDate}）`
+
+  return (
+    <div
+      className="card p-5 md:p-6 space-y-2 animate-fade-up"
+      style={{
+        backgroundColor: 'color-mix(in oklch, var(--primary) 4%, transparent)',
+      }}
+    >
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        ⚖ 結算節奏
+      </div>
+      <p className="text-sm font-medium text-[var(--foreground)]">
+        上次{sinceLastLabel}
+      </p>
+      <p className="text-xs text-[var(--muted-foreground)]">
+        今年已結算 <span className="text-[var(--foreground)]">{data.ytdCount}</span>{' '}
+        次，累計{' '}
+        <span className="text-[var(--foreground)]">{currency(data.ytdAmount)}</span>
+      </p>
+      {data.avgDaysBetween !== null && data.longestGap !== null && (
+        <p className="text-xs text-[var(--muted-foreground)]">
+          平均每 {Math.round(data.avgDaysBetween)} 天結算一次｜最久{' '}
+          {Math.round(data.longestGap)} 天
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/lib/settlement-cadence.ts
+++ b/src/lib/settlement-cadence.ts
@@ -1,0 +1,98 @@
+import { toDate } from './utils'
+import type { Settlement } from './types'
+
+export interface SettlementCadenceData {
+  /** Days since most recent settlement, ≥ 0. */
+  daysSinceLast: number
+  /** YYYY-MM-DD of most recent settlement (local). */
+  lastSettlementDate: string
+  /** Count of settlements in current calendar year (up to and including today). */
+  ytdCount: number
+  /** Total amount of settlements YTD. */
+  ytdAmount: number
+  /** Mean gap (days) between consecutive settlements over all history. null when < 2 settlements. */
+  avgDaysBetween: number | null
+  /** Largest gap (days) between consecutive settlements. null when < 2. */
+  longestGap: number | null
+}
+
+interface AnalyzeOptions {
+  settlements: Settlement[]
+  now?: number
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Cadence statistics over the family's settlement history. Distinct from
+ * the existing settlement list (which shows individual records) and the
+ * unsettled debt view (which shows the current snapshot) — this surfaces
+ * the *rhythm* of settlement, which can prompt action ("X days since last,
+ * we usually do this every Y").
+ */
+export function analyzeSettlementCadence({
+  settlements,
+  now = Date.now(),
+}: AnalyzeOptions): SettlementCadenceData | null {
+  const valid: Array<{ ts: number; amount: number; dateLabel: string }> = []
+
+  for (const s of settlements) {
+    const amount = Number(s.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(s.date)
+    } catch {
+      continue
+    }
+    const ts = d.getTime()
+    if (!Number.isFinite(ts) || ts <= 0 || ts > now) continue
+    valid.push({ ts, amount, dateLabel: dateKey(d) })
+  }
+
+  if (valid.length === 0) return null
+
+  valid.sort((a, b) => a.ts - b.ts)
+
+  const last = valid[valid.length - 1]
+  const daysSinceLast = Math.max(
+    0,
+    Math.floor((now - last.ts) / 86_400_000),
+  )
+
+  const today = new Date(now)
+  const yearStartMs = new Date(today.getFullYear(), 0, 1).getTime()
+  let ytdCount = 0
+  let ytdAmount = 0
+  for (const s of valid) {
+    if (s.ts >= yearStartMs) {
+      ytdCount++
+      ytdAmount += s.amount
+    }
+  }
+
+  let avgDaysBetween: number | null = null
+  let longestGap: number | null = null
+  if (valid.length >= 2) {
+    let totalGap = 0
+    let max = 0
+    for (let i = 1; i < valid.length; i++) {
+      const gap = (valid[i].ts - valid[i - 1].ts) / 86_400_000
+      totalGap += gap
+      if (gap > max) max = gap
+    }
+    avgDaysBetween = totalGap / (valid.length - 1)
+    longestGap = max
+  }
+
+  return {
+    daysSinceLast,
+    lastSettlementDate: last.dateLabel,
+    ytdCount,
+    ytdAmount,
+    avgDaysBetween,
+    longestGap,
+  }
+}


### PR DESCRIPTION
## 為什麼

/split 頁原本只顯示「當下未結算」snapshot。但缺少**結算習慣**的洞察：
- 我們家上次結算多久了？
- 今年結算過幾次？累計多少錢？
- 平均多久結一次？最長拖了多久？

這些對「家庭金流節奏」的自我覺察很重要——例如發現「上次 80 天前」可能就是該結了的訊號。

## 做了什麼

`src/lib/settlement-cadence.ts` — 純函式：
- 跳過 bad amount/date/future 紀錄後排序
- `daysSinceLast`：今天 = 0、昨天 = 1
- `ytdCount` + `ytdAmount`：calendar-year cutoff
- 至少 2 筆才有 `avgDaysBetween` + `longestGap`
- 單筆 settlement 也能用（avg/longest 為 null）

`src/components/settlement-cadence.tsx` — UI：
- 柔和 primary tint 卡片
- 三層資訊：上次結算 → YTD → 週期統計

`src/app/(auth)/split/page.tsx`：放在老化提醒之前（節奏 → 警告 → 動作 順序）

## 範例輸出

> ⚖ 結算節奏
>
> 上次 12 天前結算（2026-04-03）
> 今年已結算 5 次，累計 NT\$8,500
> 平均每 18 天結算一次｜最久 41 天

## 測試

11 個單元測試 ✅
- 空資料 → null
- 全 bad records → null
- 單筆/多筆邊界
- YTD 跨年正確
- bad amount/date defensive
- future date 排除
- out-of-order input
- 0-day-since-last（今天結算）
- avg = N-1 gaps
- longest 真正最大

整套：1192/1192 passed (新增 11 個).

## 風險與回退

- 純讀取
- 純函式
- 沒資料 → 靜默不 render

Closes #311