### PR TITLE
feat(statistics): 全年熱力圖 — 7×52 GitHub-style 視覺化全年每日花費 (Closes #313)

### DIFF
--- a/__tests__/year-heatmap.test.ts
+++ b/__tests__/year-heatmap.test.ts
@@ -1,0 +1,125 @@
+import { buildYearHeatmap } from '@/lib/year-heatmap'
+import type { Expense } from '@/lib/types'
+
+function mkOnDate(id: string, amount: number, year: number, month: number, day: number): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('buildYearHeatmap', () => {
+  it('returns null when year is non-finite', () => {
+    expect(buildYearHeatmap({ expenses: [], year: NaN })).toBeNull()
+  })
+
+  it('produces 365 cells for non-leap year', () => {
+    const r = buildYearHeatmap({ expenses: [], year: 2026 })
+    expect(r!.cells.length).toBe(365)
+  })
+
+  it('produces 366 cells for leap year', () => {
+    const r = buildYearHeatmap({ expenses: [], year: 2024 })
+    expect(r!.cells.length).toBe(366)
+  })
+
+  it('all-zero year has zero intensity everywhere', () => {
+    const r = buildYearHeatmap({ expenses: [], year: 2026 })
+    expect(r!.yearTotal).toBe(0)
+    expect(r!.yearMax).toBe(0)
+    expect(r!.daysWithSpend).toBe(0)
+    expect(r!.cells.every((c) => c.intensity === 0)).toBe(true)
+  })
+
+  it('aggregates daily totals and computes intensity vs yearMax', () => {
+    const expenses = [
+      mkOnDate('a', 100, 2026, 0, 5), // Jan 5
+      mkOnDate('b', 100, 2026, 0, 5), // same day → 200 total
+      mkOnDate('c', 50, 2026, 0, 6), // Jan 6
+    ]
+    const r = buildYearHeatmap({ expenses, year: 2026 })
+    expect(r!.yearMax).toBe(200) // Jan 5
+    expect(r!.yearTotal).toBe(250)
+    expect(r!.daysWithSpend).toBe(2)
+    const jan5 = r!.cells.find((c) => c.date === '2026-01-05')!
+    const jan6 = r!.cells.find((c) => c.date === '2026-01-06')!
+    expect(jan5.amount).toBe(200)
+    expect(jan5.intensity).toBe(1)
+    expect(jan6.amount).toBe(50)
+    expect(jan6.intensity).toBeCloseTo(0.25)
+  })
+
+  it('cells are dow-correct (Jan 1 2026 = Thursday, dow=4)', () => {
+    const r = buildYearHeatmap({ expenses: [], year: 2026 })
+    expect(r!.cells[0].date).toBe('2026-01-01')
+    expect(r!.cells[0].dow).toBe(4)
+  })
+
+  it('weekIndex starts at 0 for first week', () => {
+    const r = buildYearHeatmap({ expenses: [], year: 2026 })
+    // Jan 1, 2026 = Thursday (dow=4), so partial first week
+    expect(r!.cells[0].weekIndex).toBe(0)
+    // Saturday Jan 3 = end of week 0
+    const jan3 = r!.cells.find((c) => c.date === '2026-01-03')!
+    expect(jan3.weekIndex).toBe(0)
+    // Sunday Jan 4 = start of week 1
+    const jan4 = r!.cells.find((c) => c.date === '2026-01-04')!
+    expect(jan4.weekIndex).toBe(1)
+  })
+
+  it('weeksCount reflects last weekIndex + 1', () => {
+    const r = buildYearHeatmap({ expenses: [], year: 2026 })
+    expect(r!.weeksCount).toBe(r!.cells[r!.cells.length - 1].weekIndex + 1)
+  })
+
+  it('skips expenses outside the year', () => {
+    const expenses = [
+      mkOnDate('this', 100, 2026, 5, 10), // June 2026
+      mkOnDate('past', 999, 2025, 5, 10), // June 2025 — excluded
+      mkOnDate('future', 999, 2027, 5, 10), // 2027 — excluded
+    ]
+    const r = buildYearHeatmap({ expenses, year: 2026 })
+    expect(r!.yearTotal).toBe(100)
+  })
+
+  it('skips bad amount and date records', () => {
+    const bad = { ...mkOnDate('bad', 100, 2026, 0, 1), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mkOnDate('good', 100, 2026, 0, 1),
+      mkOnDate('nan', NaN, 2026, 0, 1),
+      mkOnDate('zero', 0, 2026, 0, 1),
+      mkOnDate('neg', -50, 2026, 0, 1),
+      bad,
+    ]
+    const r = buildYearHeatmap({ expenses, year: 2026 })
+    expect(r!.yearTotal).toBe(100)
+  })
+
+  it('cells span every calendar day in chronological order', () => {
+    const r = buildYearHeatmap({ expenses: [], year: 2026 })
+    const firstDate = r!.cells[0].date
+    const lastDate = r!.cells[r!.cells.length - 1].date
+    expect(firstDate).toBe('2026-01-01')
+    expect(lastDate).toBe('2026-12-31')
+  })
+
+  it('handles year 2024 leap correctly (Feb 29 present)', () => {
+    const r = buildYearHeatmap({ expenses: [], year: 2024 })
+    const feb29 = r!.cells.find((c) => c.date === '2024-02-29')
+    expect(feb29).toBeDefined()
+  })
+})

--- a/src/app/(auth)/statistics/page.tsx
+++ b/src/app/(auth)/statistics/page.tsx
@@ -9,6 +9,7 @@ import { toDate, fmtDateFull, currency } from '@/lib/utils'
 import { aggregateYearStats } from '@/lib/year-stats'
 import { TopExpensesCard } from '@/components/top-expenses-card'
 import { MoneyDiary } from '@/components/money-diary'
+import { YearHeatmap } from '@/components/year-heatmap'
 import type { Expense } from '@/lib/types'
 import type { StatisticsChartsProps } from '@/components/statistics-charts'
 
@@ -300,6 +301,9 @@ export default function StatisticsPage() {
         previousMonthTotal={previousMonthTotal > 0 ? previousMonthTotal : null}
         selectedMonth={selectedMonth}
       />
+
+      {/* 全年熱力圖 (Issue #313) — 7×52 GitHub-style 年度視窗 */}
+      <YearHeatmap expenses={expenses} year={selectedMonth.year} />
 
       {/* Charts — lazily loaded to avoid including recharts in initial bundle */}
       <StatisticsCharts

--- a/src/components/year-heatmap.tsx
+++ b/src/components/year-heatmap.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useMemo } from 'react'
+import Link from 'next/link'
+import { buildYearHeatmap, type YearHeatmapCell } from '@/lib/year-heatmap'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface YearHeatmapProps {
+  expenses: Expense[]
+  year: number
+}
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const DOW_LABELS = ['日', '一', '二', '三', '四', '五', '六']
+
+function cellColor(intensity: number): string {
+  if (intensity <= 0) return 'var(--muted)'
+  const alpha = 15 + Math.round(intensity * 75)
+  return `color-mix(in oklch, var(--primary) ${alpha}%, transparent)`
+}
+
+function ariaLabel(c: YearHeatmapCell): string {
+  if (c.amount <= 0) return `${c.date} 無記錄`
+  return `${c.date} ${currency(c.amount)}`
+}
+
+function tooltip(c: YearHeatmapCell): string {
+  if (c.amount <= 0) return `${c.date} · 無記錄`
+  return `${c.date} · ${currency(c.amount)}`
+}
+
+/**
+ * Full-year per-day spending heatmap (Issue #313). GitHub-style 7×52
+ * grid laid out by week-of-year × day-of-week. Distinct from home-page
+ * SpendingHeatmap (#290) which uses a 30-day rolling window — this is
+ * the seasonal-pattern lens.
+ */
+export function YearHeatmap({ expenses, year }: YearHeatmapProps) {
+  const data = useMemo(
+    () => buildYearHeatmap({ expenses, year }),
+    [expenses, year],
+  )
+
+  if (!data || data.yearTotal === 0) return null
+
+  const cellsByPos = new Map<string, YearHeatmapCell>()
+  for (const c of data.cells) {
+    cellsByPos.set(`${c.weekIndex}-${c.dow}`, c)
+  }
+
+  const monthMarkers: Array<{ weekIndex: number; label: string }> = []
+  for (let m = 0; m < 12; m++) {
+    const firstOfMonth = new Date(year, m, 1)
+    const dayOfYear = Math.floor(
+      (firstOfMonth.getTime() - new Date(year, 0, 1).getTime()) / 86_400_000,
+    )
+    const weekIndex = Math.floor((dayOfYear + new Date(year, 0, 1).getDay()) / 7)
+    monthMarkers.push({ weekIndex, label: MONTH_LABELS[m] })
+  }
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+          📅 {year} 全年花費熱力 · 已記 {data.daysWithSpend} 天 · 累計{' '}
+          {currency(data.yearTotal)}
+        </div>
+        <div className="text-[10px] text-[var(--muted-foreground)]">
+          單日最高 {currency(data.yearMax)}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto -mx-2 px-2">
+        <div className="inline-block min-w-full">
+          {/* Month labels */}
+          <div className="flex pl-7 mb-1 gap-px">
+            {monthMarkers.map((m, i) => (
+              <span
+                key={i}
+                className="text-[9px] text-[var(--muted-foreground)]"
+                style={{
+                  width: `calc(${
+                    i < 11
+                      ? monthMarkers[i + 1].weekIndex - m.weekIndex
+                      : data.weeksCount - m.weekIndex
+                  } * (10px + 1px))`,
+                  flexShrink: 0,
+                }}
+              >
+                {m.label}
+              </span>
+            ))}
+          </div>
+
+          {/* Grid */}
+          <div className="flex gap-[1px]">
+            {/* DOW labels */}
+            <div className="flex flex-col gap-[1px] mr-1">
+              {DOW_LABELS.map((d, i) => (
+                <span
+                  key={i}
+                  className="text-[9px] leading-[10px] text-[var(--muted-foreground)] h-[10px] w-5 text-right pr-0.5"
+                >
+                  {i % 2 === 1 ? d : ''}
+                </span>
+              ))}
+            </div>
+
+            {/* Cells: column per week */}
+            {Array.from({ length: data.weeksCount }, (_, w) => (
+              <div key={w} className="flex flex-col gap-[1px]">
+                {Array.from({ length: 7 }, (_, dow) => {
+                  const cell = cellsByPos.get(`${w}-${dow}`)
+                  if (!cell) {
+                    return <div key={dow} className="w-[10px] h-[10px]" />
+                  }
+                  if (cell.amount > 0) {
+                    return (
+                      <Link
+                        key={dow}
+                        href={`/records?start=${cell.date}&end=${cell.date}`}
+                        className="w-[10px] h-[10px] rounded-sm hover:ring-1 hover:ring-[var(--primary)] transition"
+                        style={{ backgroundColor: cellColor(cell.intensity) }}
+                        title={tooltip(cell)}
+                        aria-label={ariaLabel(cell)}
+                      />
+                    )
+                  }
+                  return (
+                    <div
+                      key={dow}
+                      className="w-[10px] h-[10px] rounded-sm"
+                      style={{ backgroundColor: cellColor(cell.intensity) }}
+                      title={tooltip(cell)}
+                      aria-label={ariaLabel(cell)}
+                    />
+                  )
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1.5 text-[10px] text-[var(--muted-foreground)]">
+        <span>少</span>
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: cellColor(0) }} />
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: cellColor(0.25) }} />
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: cellColor(0.5) }} />
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: cellColor(0.75) }} />
+        <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: cellColor(1) }} />
+        <span>多</span>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/year-heatmap.ts
+++ b/src/lib/year-heatmap.ts
@@ -1,0 +1,110 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface YearHeatmapCell {
+  /** Date as YYYY-MM-DD (local). */
+  date: string
+  /** 0..6 — day-of-week (0 = Sunday). */
+  dow: number
+  /** 0-based week index from year start. */
+  weekIndex: number
+  amount: number
+  /** 0..1 vs yearMax (0 when yearMax is 0). */
+  intensity: number
+}
+
+export interface YearHeatmapData {
+  cells: YearHeatmapCell[]
+  yearMax: number
+  yearTotal: number
+  /** Days with positive spending. */
+  daysWithSpend: number
+  year: number
+  /** Total weeks the grid spans. */
+  weeksCount: number
+}
+
+interface BuildOptions {
+  expenses: Expense[]
+  year: number
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function isLeap(y: number): boolean {
+  return (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0
+}
+
+function daysInYear(y: number): number {
+  return isLeap(y) ? 366 : 365
+}
+
+/**
+ * Per-day spending grid for a calendar year, laid out GitHub-style:
+ * dow on the row, week-of-year on the column. Intensity is normalized
+ * vs the year's max daily spend so within-year structure is preserved.
+ *
+ * Returns null only when input is malformed (`year` non-finite). An
+ * empty year still returns an all-zero grid so the caller can render
+ * "no spending yet" with shape preserved.
+ */
+export function buildYearHeatmap({
+  expenses,
+  year,
+}: BuildOptions): YearHeatmapData | null {
+  if (!Number.isFinite(year)) return null
+
+  const yearStart = new Date(year, 0, 1)
+  const totalDays = daysInYear(year)
+
+  const dailyTotals = new Map<string, number>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+    if (d.getFullYear() !== year) continue
+    const k = dateKey(d)
+    dailyTotals.set(k, (dailyTotals.get(k) ?? 0) + amount)
+  }
+
+  let yearMax = 0
+  let yearTotal = 0
+  for (const v of dailyTotals.values()) {
+    if (v > yearMax) yearMax = v
+    yearTotal += v
+  }
+
+  const cells: YearHeatmapCell[] = []
+  // First Sunday on or before Jan 1 — anchors weekIndex grid columns.
+  const yearStartDow = yearStart.getDay()
+  for (let i = 0; i < totalDays; i++) {
+    const cur = new Date(year, 0, 1 + i)
+    const dow = cur.getDay()
+    const dayOfYear = i // 0-indexed
+    const weekIndex = Math.floor((dayOfYear + yearStartDow) / 7)
+    const k = dateKey(cur)
+    const amount = dailyTotals.get(k) ?? 0
+    const intensity = yearMax > 0 ? amount / yearMax : 0
+    cells.push({ date: k, dow, weekIndex, amount, intensity })
+  }
+
+  const weeksCount = cells.length > 0 ? cells[cells.length - 1].weekIndex + 1 : 0
+
+  return {
+    cells,
+    yearMax,
+    yearTotal,
+    daysWithSpend: dailyTotals.size,
+    year,
+    weeksCount,
+  }
+}


### PR DESCRIPTION
## 為什麼

家計本中所有時間軸 widget：

- 日：SpendingHeatmap (home, 30 天)
- 週：DowInsight (週幾循環)
- 月：MoneyDiary, MonthProjection, ...
- 年：YearRecap (數字摘要)

**整年的每日強度視覺化從未被觸及**。GitHub contribution graph 是最直觀的「全年看一眼」呈現——夏天高於冬天嗎？寒暑假有明顯峰值嗎？

## 做了什麼

`src/lib/year-heatmap.ts` — 純函式：
- 為 calendar year 每天產生 cell（dow + weekIndex 座標）
- intensity = amount / yearMax（normalized）
- 跳過 bad amount/date、跨年紀錄
- 366/365 days 自動處理
- weekIndex 以年第一週為 0

`src/components/year-heatmap.tsx` — UI：
- 7×52 grid，每 cell 10×10 px
- intensity OKLCH alpha mix 著色
- Month labels 對齊
- 有花費 cell link 到 /records 過濾單日
- legend (少 → 多)
- 行動裝置可橫滑

`src/app/(auth)/statistics/page.tsx`：放在 MoneyDiary 之後、charts 之前

## 視窗對比

| Widget | 視窗 | 用途 |
|--------|------|------|
| SpendingHeatmap (home, #290) | 30 天 | 近期速覽 |
| **YearHeatmap (#313)** | **365/366 天** | **季節模式 / 全年回顧** |

不重複——觀察季節模式需要全年視窗。

## 測試

12 個單元測試 ✅
- NaN year → null
- 365 / 366 cells (leap)
- empty year → all-zero intensity
- yearMax / yearTotal / daysWithSpend 計算
- dow 對齊（Jan 1 2026 = Thursday）
- weekIndex 邊界（partial first week）
- 跨年紀錄排除
- bad data defensive
- cells 順序（Jan 1 → Dec 31）
- Feb 29 leap day 出現

整套：1204/1204 passed (新增 12 個).

## 風險與回退

- 純讀取
- yearTotal === 0 → 靜默不 render
- 純函式

Closes #313