### PR TITLE
feat(home): X 年前的今天 — Facebook Memories 式時間旅行 (Closes #315)

### DIFF
--- a/__tests__/today-in-past-years.test.ts
+++ b/__tests__/today-in-past-years.test.ts
@@ -1,0 +1,141 @@
+import { findTodayInPastYears } from '@/lib/today-in-past-years'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, 2026
+
+function mkOnDate(id: string, amount: number, year: number, month: number, day: number, opts: Partial<Expense> = {}): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: opts.description ?? `e-${id}`,
+    amount,
+    category: opts.category ?? 'X',
+    payerId: 'm1',
+    payerName: opts.payerName ?? '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('findTodayInPastYears', () => {
+  it('returns empty array when no past records', () => {
+    expect(findTodayInPastYears({ expenses: [], now: NOW })).toEqual([])
+  })
+
+  it('returns empty array when no records on matching day', () => {
+    const expenses = [mkOnDate('a', 100, 2025, 3, 14)] // Apr 14 2025, not 15
+    expect(findTodayInPastYears({ expenses, now: NOW })).toEqual([])
+  })
+
+  it('finds records for 1 year ago today', () => {
+    const expenses = [
+      mkOnDate('a', 800, 2025, 3, 15, { description: '午餐' }),
+      mkOnDate('b', 200, 2025, 3, 15, { description: '咖啡' }),
+    ]
+    const r = findTodayInPastYears({ expenses, now: NOW })
+    expect(r.length).toBe(1)
+    expect(r[0].yearsAgo).toBe(1)
+    expect(r[0].date).toBe('2025-04-15')
+    expect(r[0].total).toBe(1000)
+    expect(r[0].count).toBe(2)
+    expect(r[0].biggest!.description).toBe('午餐')
+    expect(r[0].biggest!.amount).toBe(800)
+  })
+
+  it('finds multiple past years', () => {
+    const expenses = [
+      mkOnDate('a1', 500, 2025, 3, 15),
+      mkOnDate('a3', 5500, 2023, 3, 15, { description: '機票' }),
+    ]
+    const r = findTodayInPastYears({ expenses, now: NOW })
+    expect(r.length).toBe(2)
+    expect(r[0].yearsAgo).toBe(1)
+    expect(r[1].yearsAgo).toBe(3)
+    expect(r[1].biggest!.description).toBe('機票')
+  })
+
+  it('respects maxYears option', () => {
+    const expenses = [
+      mkOnDate('a1', 100, 2025, 3, 15),
+      mkOnDate('a3', 100, 2023, 3, 15),
+      mkOnDate('a5', 100, 2021, 3, 15), // beyond default 3
+    ]
+    const r = findTodayInPastYears({ expenses, now: NOW, maxYears: 3 })
+    expect(r.length).toBe(2) // a5 excluded
+  })
+
+  it('Feb 29 falls back to Feb 28 in non-leap past year', () => {
+    const feb29_2024 = new Date(2024, 1, 29, 12, 0, 0).getTime() // 2024 leap year, Feb 29
+    const expenses = [
+      mkOnDate('a', 200, 2023, 1, 28), // 2023 non-leap → Feb 28 should match
+      mkOnDate('b', 999, 2023, 1, 27), // not match
+    ]
+    const r = findTodayInPastYears({ expenses, now: feb29_2024, maxYears: 1 })
+    expect(r.length).toBe(1)
+    expect(r[0].date).toBe('2023-02-28')
+    expect(r[0].total).toBe(200)
+  })
+
+  it('skips bad amount/date records', () => {
+    const bad = { ...mkOnDate('bad', 100, 2025, 3, 15), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mkOnDate('valid', 100, 2025, 3, 15),
+      mkOnDate('nan', NaN, 2025, 3, 15),
+      mkOnDate('zero', 0, 2025, 3, 15),
+      mkOnDate('neg', -50, 2025, 3, 15),
+      bad,
+    ]
+    const r = findTodayInPastYears({ expenses, now: NOW })
+    expect(r.length).toBe(1)
+    expect(r[0].total).toBe(100)
+  })
+
+  it('only counts the exact past-year day, not surrounding dates', () => {
+    const expenses = [
+      mkOnDate('exact', 100, 2025, 3, 15), // Apr 15 ← match
+      mkOnDate('day_before', 100, 2025, 3, 14),
+      mkOnDate('day_after', 100, 2025, 3, 16),
+      mkOnDate('month_before', 100, 2025, 2, 15),
+    ]
+    const r = findTodayInPastYears({ expenses, now: NOW })
+    expect(r.length).toBe(1)
+    expect(r[0].count).toBe(1)
+    expect(r[0].total).toBe(100)
+  })
+
+  it('biggest is null when records list empty (defensive)', () => {
+    // Although we never reach this branch from public API (we filter empty),
+    // verify findBy still respects shape
+    const expenses = [mkOnDate('a', 100, 2025, 3, 15)]
+    const r = findTodayInPastYears({ expenses, now: NOW })
+    expect(r[0].biggest).not.toBeNull()
+  })
+
+  it('handles missing description / category gracefully', () => {
+    const e = {
+      ...mkOnDate('a', 100, 2025, 3, 15),
+      description: '',
+      category: '',
+    } as unknown as Expense
+    const r = findTodayInPastYears({ expenses: [e], now: NOW })
+    expect(r[0].biggest!.description).toBe('(無描述)')
+    expect(r[0].biggest!.category).toBe('其他')
+  })
+
+  it('results sorted by yearsAgo asc (most recent first)', () => {
+    const expenses = [
+      mkOnDate('a3', 100, 2023, 3, 15),
+      mkOnDate('a1', 100, 2025, 3, 15),
+      mkOnDate('a2', 100, 2024, 3, 15),
+    ]
+    const r = findTodayInPastYears({ expenses, now: NOW })
+    expect(r.map((m) => m.yearsAgo)).toEqual([1, 2, 3])
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -27,6 +27,7 @@ import { CategoryMoM } from '@/components/category-mom'
 import { MostFrequentItems } from '@/components/most-frequent-items'
 import { BiggestExpenseSpotlight } from '@/components/biggest-expense-spotlight'
 import { YearRecap } from '@/components/year-recap'
+import { TodayInPastYears } from '@/components/today-in-past-years'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -265,6 +266,9 @@ export default function HomePage() {
 
       {/* 年度回顧 mini (Issue #305) — YTD 累計 + 預估全年 + 對比去年同期 */}
       <YearRecap expenses={expenses} />
+
+      {/* X 年前的今天 (Issue #315) — Facebook Memories 式時間旅行 */}
+      <TodayInPastYears expenses={expenses} />
 
       {/* 30 天每日花費熱力圖 (Issue #290) */}
       <SpendingHeatmap expenses={expenses} />

--- a/src/components/today-in-past-years.tsx
+++ b/src/components/today-in-past-years.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useMemo } from 'react'
+import Link from 'next/link'
+import { findTodayInPastYears, type PastYearMemory } from '@/lib/today-in-past-years'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface TodayInPastYearsProps {
+  expenses: Expense[]
+  /** Years back to look. Default 3. */
+  maxYears?: number
+}
+
+function yearsAgoLabel(n: number): string {
+  return `${n} 年前`
+}
+
+function MemoryRow({ memory }: { memory: PastYearMemory }) {
+  return (
+    <div className="space-y-0.5">
+      <p className="text-sm">
+        <span className="font-semibold text-[var(--foreground)]">
+          {yearsAgoLabel(memory.yearsAgo)}
+        </span>
+        <span className="text-[var(--muted-foreground)]"> ({memory.date})</span>
+      </p>
+      <p className="text-xs text-[var(--muted-foreground)]">
+        共 {memory.count} 筆 · 總計{' '}
+        <span className="text-[var(--foreground)]">{currency(memory.total)}</span>
+        {memory.biggest && memory.count >= 2 && (
+          <>
+            {' · 最大：'}
+            <span className="text-[var(--foreground)]">{memory.biggest.description}</span>{' '}
+            {currency(memory.biggest.amount)}
+          </>
+        )}
+        {memory.biggest && memory.count === 1 && (
+          <>
+            {' · '}
+            <span className="text-[var(--foreground)]">{memory.biggest.description}</span>
+          </>
+        )}
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Facebook-Memories-style time-travel widget (Issue #315). Surfaces what
+ * the family spent on this exact date 1, 2, 3 years ago. Renders silently
+ * for new users — only adds value when there's enough history. Each
+ * memory links to /records filtered to that date.
+ */
+export function TodayInPastYears({ expenses, maxYears = 3 }: TodayInPastYearsProps) {
+  const memories = useMemo(
+    () => findTodayInPastYears({ expenses, maxYears }),
+    [expenses, maxYears],
+  )
+
+  if (memories.length === 0) return null
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        📔 X 年前的今天
+      </div>
+      <ul className="space-y-3 divide-y divide-[var(--border)]">
+        {memories.map((m) => (
+          <li key={m.yearsAgo} className="pt-3 first:pt-0">
+            <Link
+              href={`/records?start=${m.date}&end=${m.date}`}
+              className="block hover:bg-[var(--muted)] transition rounded -mx-2 px-2 py-1"
+            >
+              <MemoryRow memory={m} />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/lib/today-in-past-years.ts
+++ b/src/lib/today-in-past-years.ts
@@ -70,7 +70,7 @@ export function findTodayInPastYears({
   for (let i = 1; i <= maxYears; i++) {
     const targetYear = todayYear - i
     let targetDay = todayDate
-    let targetMonth = todayMonth
+    const targetMonth = todayMonth
 
     // Feb 29 fallback: if today is Feb 29 but target year not leap, try Feb 28.
     if (targetMonth === 1 && targetDay === 29) {

--- a/src/lib/today-in-past-years.ts
+++ b/src/lib/today-in-past-years.ts
@@ -1,0 +1,113 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface PastYearMemory {
+  /** 1, 2, 3, ... — number of years before now. */
+  yearsAgo: number
+  /** YYYY-MM-DD of that year's matching day (local). */
+  date: string
+  total: number
+  count: number
+  /** Largest single expense on that date (by amount). */
+  biggest: {
+    id: string
+    description: string
+    amount: number
+    category: string
+  } | null
+}
+
+interface FindOptions {
+  expenses: Expense[]
+  now?: number
+  /** Look back this many years. Default 3. */
+  maxYears?: number
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Surface "what happened on this day X years ago" — Facebook-Memories
+ * style. For each year 1..N back from today, return matching-day spending
+ * if any exists. Empty array when no past data — caller chooses to render
+ * nothing.
+ *
+ * Feb 29 handling: a request for Feb 29 in a non-leap-year past silently
+ * skips that year (no fake matches). A leap-year today querying non-leap
+ * past years matches Feb 28 instead — the closest meaningful equivalent.
+ */
+export function findTodayInPastYears({
+  expenses,
+  now = Date.now(),
+  maxYears = 3,
+}: FindOptions): PastYearMemory[] {
+  const today = new Date(now)
+  const todayMonth = today.getMonth()
+  const todayDate = today.getDate()
+  const todayYear = today.getFullYear()
+
+  // Bucket expenses by date key for fast lookup.
+  const byDate = new Map<string, Expense[]>()
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+    const k = dateKey(d)
+    const arr = byDate.get(k) ?? []
+    arr.push(e)
+    byDate.set(k, arr)
+  }
+
+  const results: PastYearMemory[] = []
+  for (let i = 1; i <= maxYears; i++) {
+    const targetYear = todayYear - i
+    let targetDay = todayDate
+    let targetMonth = todayMonth
+
+    // Feb 29 fallback: if today is Feb 29 but target year not leap, try Feb 28.
+    if (targetMonth === 1 && targetDay === 29) {
+      const isLeapTarget =
+        (targetYear % 4 === 0 && targetYear % 100 !== 0) || targetYear % 400 === 0
+      if (!isLeapTarget) {
+        targetDay = 28
+      }
+    }
+
+    const key = `${targetYear}-${String(targetMonth + 1).padStart(2, '0')}-${String(targetDay).padStart(2, '0')}`
+    const matches = byDate.get(key)
+    if (!matches || matches.length === 0) continue
+
+    let total = 0
+    let biggest: PastYearMemory['biggest'] = null
+    for (const e of matches) {
+      const amount = Number(e.amount)
+      total += amount
+      if (!biggest || amount > biggest.amount) {
+        biggest = {
+          id: e.id,
+          description: (e.description || '(無描述)').trim() || '(無描述)',
+          amount,
+          category: (e.category || '其他').trim() || '其他',
+        }
+      }
+    }
+
+    results.push({
+      yearsAgo: i,
+      date: key,
+      total,
+      count: matches.length,
+      biggest,
+    })
+  }
+
+  return results
+}


### PR DESCRIPTION
## 為什麼

之前的 widget 都是分析/數字/警告——理性視角。**情緒視角從未被觸及**。

Facebook Memories 證明「過去這一刻」呈現有強烈情緒共鳴。對家計本特別適合：「3 年前的今天，我們在沖繩」（看到 NT\$8,500 旅行支出）。

## 做了什麼

`src/lib/today-in-past-years.ts` — 純函式：
- 對 1..N 年前的同月日找紀錄
- total / count / biggest（單筆最大）
- **Feb 29 邊界**：閏年 today 對 non-leap past year fallback 到 Feb 28
- 跳過 bad amount/date、empty description
- 結果按 yearsAgo asc 排序

`src/components/today-in-past-years.tsx` — UI：
- 每年一行：「X 年前 (YYYY-MM-DD) · 共 N 筆 · 總計 NT\$Y · 最大：description」
- 整列 link 到 `/records?start=X&end=X` drill 到歷史
- 空陣列 → 靜默不 render（新使用者沒空狀態）

`src/app/(auth)/page.tsx`：放在 YearRecap 之後（年度視角群組）

## 範例輸出

> 📔 X 年前的今天
>
> **1 年前** (2025-04-15)
> 共 3 筆 · 總計 NT\$1,250 · 最大：午餐 NT\$680
>
> **3 年前** (2023-04-15)
> 共 2 筆 · 總計 NT\$5,800 · 最大：機票 NT\$5,500

## 測試

11 個單元測試 ✅
- 空資料 / 無匹配日 → []
- 單年 / 多年 / maxYears 限制
- **Feb 29 → Feb 28 fallback**（critical edge）
- bad amount/date 防呆
- 僅匹配當天（不含前後一天，不含上月同日）
- empty fields graceful
- yearsAgo asc 排序

整套：1215/1215 passed (新增 11 個).

## 風險與回退

- 純讀取
- 純函式
- 沒資料 → 靜默不 render
- 對長期使用者最有價值，新使用者不會看到

Closes #315