### PR TITLE
feat(home): 下個月固定支出 forecast — locked-in template projection (Closes #317)

### DIFF
--- a/__tests__/next-month-locked-in.test.ts
+++ b/__tests__/next-month-locked-in.test.ts
@@ -1,0 +1,161 @@
+import { forecastNextMonthLockedIn } from '@/lib/next-month-locked-in'
+import type { RecurringExpense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, 2026 → next month = May 2026
+
+interface TemplateOpts {
+  id?: string
+  description?: string
+  amount?: number | null
+  category?: string
+  frequency?: 'monthly' | 'weekly' | 'yearly'
+  dayOfMonth?: number
+  dayOfWeek?: number
+  monthOfYear?: number
+  isPaused?: boolean
+  endDate?: Date | null
+}
+
+function mk(opts: TemplateOpts = {}): RecurringExpense {
+  const start = new Date(2025, 0, 1)
+  return {
+    id: opts.id ?? 't',
+    groupId: 'g1',
+    description: opts.description ?? 'rent',
+    amount: 'amount' in opts ? opts.amount : 15000,
+    category: opts.category ?? '房租',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    frequency: opts.frequency ?? 'monthly',
+    dayOfMonth: opts.dayOfMonth ?? 1,
+    dayOfWeek: opts.dayOfWeek,
+    monthOfYear: opts.monthOfYear,
+    startDate: start,
+    endDate: opts.endDate ?? null,
+    isPaused: opts.isPaused ?? false,
+    createdBy: 'u1',
+  } as unknown as RecurringExpense
+}
+
+describe('forecastNextMonthLockedIn', () => {
+  it('returns null when no templates', () => {
+    expect(forecastNextMonthLockedIn({ recurringTemplates: [], now: NOW })).toBeNull()
+  })
+
+  it('returns null when all templates are paused', () => {
+    const templates = [mk({ isPaused: true })]
+    expect(forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })).toBeNull()
+  })
+
+  it('finds monthly template occurrence in next month', () => {
+    // Today = April 15. Next month = May. Template fires on day 1.
+    const templates = [mk({ id: 'rent', dayOfMonth: 1, amount: 15000 })]
+    const r = forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })
+    expect(r!.monthLabel).toBe('2026-05')
+    expect(r!.count).toBe(1)
+    expect(r!.totalEstimated).toBe(15000)
+    expect(r!.items[0].expectedDate).toBe('2026-05-01')
+    expect(r!.items[0].description).toBe('rent')
+  })
+
+  it('finds weekly template multiple occurrences', () => {
+    // Weekly on Monday → 5 Mondays in May 2026: 5/4, 5/11, 5/18, 5/25
+    const templates = [
+      mk({
+        id: 'gym',
+        description: 'gym',
+        amount: 500,
+        frequency: 'weekly',
+        dayOfWeek: 1,
+        dayOfMonth: undefined,
+      }),
+    ]
+    const r = forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })
+    expect(r!.count).toBe(4) // 4 Mondays in May 2026
+    expect(r!.totalEstimated).toBe(500 * 4)
+  })
+
+  it('skips template ending before next month', () => {
+    const endApril = new Date(2026, 3, 30)
+    const templates = [mk({ id: 'old', endDate: endApril })]
+    expect(forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })).toBeNull()
+  })
+
+  it('keeps template ending after next month starts', () => {
+    const endMay = new Date(2026, 4, 31)
+    const templates = [mk({ id: 'rent', endDate: endMay })]
+    const r = forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })
+    expect(r!.count).toBe(1)
+  })
+
+  it('variable amount templates included in items but not total', () => {
+    const templates = [
+      mk({ id: 'rent', amount: 15000 }),
+      mk({ id: 'utility', amount: null, description: '水費' }),
+    ]
+    const r = forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })
+    expect(r!.items.length).toBe(2)
+    expect(r!.count).toBe(1) // fixed-amount only
+    expect(r!.variableCount).toBe(1)
+    expect(r!.totalEstimated).toBe(15000)
+    const variable = r!.items.find((i) => i.templateId === 'utility')
+    expect(variable!.amount).toBeNull()
+  })
+
+  it('totalEstimated null when all items are variable amount', () => {
+    const templates = [mk({ id: 'utility', amount: null, description: '水費' })]
+    const r = forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })
+    expect(r!.totalEstimated).toBeNull()
+    expect(r!.variableCount).toBe(1)
+    expect(r!.count).toBe(0)
+  })
+
+  it('sorts items chronologically', () => {
+    const templates = [
+      mk({ id: 'late', dayOfMonth: 25, description: '補習' }),
+      mk({ id: 'early', dayOfMonth: 1, description: 'rent' }),
+      mk({ id: 'mid', dayOfMonth: 15, description: 'spotify' }),
+    ]
+    const r = forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })
+    expect(r!.items.map((i) => i.description)).toEqual(['rent', 'spotify', '補習'])
+  })
+
+  it('handles end-of-month edge (dayOfMonth=31 in 30-day month)', () => {
+    // June has 30 days. Template dayOfMonth=31 → fires on June 30
+    const may15 = new Date(2026, 4, 15, 12, 0, 0).getTime()
+    const templates = [mk({ id: 'eom', dayOfMonth: 31 })]
+    const r = forecastNextMonthLockedIn({ recurringTemplates: templates, now: may15 })
+    expect(r!.items[0].expectedDate).toBe('2026-06-30')
+  })
+
+  it('graceful with bad endDate', () => {
+    const templates = [{
+      ...mk({ id: 'rent' }),
+      endDate: 'oops',
+    } as unknown as RecurringExpense]
+    const r = forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })
+    expect(r).not.toBeNull()
+    expect(r!.count).toBe(1)
+  })
+
+  it('mixes weekly and monthly templates', () => {
+    const templates = [
+      mk({ id: 'rent', dayOfMonth: 1, amount: 15000 }),
+      mk({
+        id: 'gym',
+        amount: 500,
+        frequency: 'weekly',
+        dayOfWeek: 1,
+        dayOfMonth: undefined,
+      }),
+    ]
+    const r = forecastNextMonthLockedIn({ recurringTemplates: templates, now: NOW })
+    // 1 monthly + 4 weekly = 5
+    expect(r!.items.length).toBe(5)
+    expect(r!.totalEstimated).toBe(15000 + 500 * 4)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -28,6 +28,7 @@ import { MostFrequentItems } from '@/components/most-frequent-items'
 import { BiggestExpenseSpotlight } from '@/components/biggest-expense-spotlight'
 import { YearRecap } from '@/components/year-recap'
 import { TodayInPastYears } from '@/components/today-in-past-years'
+import { NextMonthLockedIn } from '@/components/next-month-locked-in'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -254,6 +255,9 @@ export default function HomePage() {
 
       {/* 月底支出預估 (Issue #296) — 依目前速度 + 歷史對比 */}
       <MonthProjection expenses={expenses} />
+
+      {/* 下個月固定支出 forecast (Issue #317) */}
+      <NextMonthLockedIn recurringTemplates={recurringTemplates} />
 
       {/* 類別月變化 (Issue #298) — 哪類比上個月顯著成長/縮減 */}
       <CategoryMoM expenses={expenses} />

--- a/src/components/next-month-locked-in.tsx
+++ b/src/components/next-month-locked-in.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useMemo } from 'react'
+import Link from 'next/link'
+import { forecastNextMonthLockedIn } from '@/lib/next-month-locked-in'
+import { currency } from '@/lib/utils'
+import type { RecurringExpense } from '@/lib/types'
+
+interface NextMonthLockedInProps {
+  recurringTemplates: RecurringExpense[]
+  /** Limit list items shown. Default 6. */
+  itemLimit?: number
+}
+
+/**
+ * Forward-looking floor of next-calendar-month spending (Issue #317).
+ * Built from already-confirmed RecurringExpense templates so it's a
+ * commitment view, not a guess. Distinct from MonthProjection (#296)
+ * which extrapolates *current* month's pace; this projects *next*
+ * month from locked-in templates.
+ */
+export function NextMonthLockedIn({
+  recurringTemplates,
+  itemLimit = 6,
+}: NextMonthLockedInProps) {
+  const data = useMemo(
+    () => forecastNextMonthLockedIn({ recurringTemplates }),
+    [recurringTemplates],
+  )
+
+  if (!data) return null
+
+  const visibleItems = data.items.slice(0, itemLimit)
+  const moreCount = data.items.length - visibleItems.length
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+          🔒 下個月固定支出 · {data.monthLabel}
+        </div>
+        <div className="text-xs text-[var(--muted-foreground)]">
+          {data.count + data.variableCount} 筆已知
+        </div>
+      </div>
+
+      {data.totalEstimated !== null ? (
+        <p className="text-sm">
+          預估{' '}
+          <span className="text-base font-semibold text-[var(--primary)]">
+            {currency(data.totalEstimated)}
+          </span>
+          {data.variableCount > 0 && (
+            <span className="text-xs text-[var(--muted-foreground)]">
+              {' '}
+              + {data.variableCount} 筆浮動
+            </span>
+          )}
+        </p>
+      ) : (
+        <p className="text-sm text-[var(--muted-foreground)]">
+          全部為浮動金額（{data.variableCount} 筆）
+        </p>
+      )}
+
+      <ul className="divide-y divide-[var(--border)]">
+        {visibleItems.map((item, i) => (
+          <li
+            key={`${item.templateId}-${item.expectedDate}-${i}`}
+            className="flex items-center justify-between gap-2 py-1.5 text-xs"
+          >
+            <span className="text-[var(--muted-foreground)] w-12 flex-shrink-0">
+              {item.expectedDate.slice(5)}
+            </span>
+            <span className="text-[var(--foreground)] flex-1 truncate">
+              {item.description}
+            </span>
+            <span className="text-[var(--foreground)] flex-shrink-0">
+              {item.amount !== null ? currency(item.amount) : '—'}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {moreCount > 0 && (
+        <Link
+          href="/settings/recurring"
+          className="block text-xs text-center text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition pt-1"
+        >
+          + 還有 {moreCount} 筆 · 管理 →
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/src/lib/next-month-locked-in.ts
+++ b/src/lib/next-month-locked-in.ts
@@ -1,0 +1,114 @@
+import { getNextOccurrences } from './recurring-occurrences'
+import { toDate } from './utils'
+import type { RecurringExpense } from './types'
+
+export interface LockedInItem {
+  templateId: string
+  description: string
+  /** May be null when template has variable amount — caller chooses to render. */
+  amount: number | null
+  category: string
+  /** YYYY-MM-DD (local). */
+  expectedDate: string
+}
+
+export interface NextMonthLockedInData {
+  /** "YYYY-MM" of the upcoming calendar month. */
+  monthLabel: string
+  /** Number of fixed-amount occurrences. */
+  count: number
+  /** Number of variable-amount occurrences (excluded from totalEstimated). */
+  variableCount: number
+  /** Sum of all fixed-amount occurrences. Null when only variable items. */
+  totalEstimated: number | null
+  /** All occurrences (fixed + variable), chronological. */
+  items: LockedInItem[]
+}
+
+interface ForecastOptions {
+  recurringTemplates: RecurringExpense[]
+  now?: number
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Project all active recurring templates' occurrences into the upcoming
+ * calendar month. Returns null when no occurrences fall in next month
+ * (no active templates or all paused / end-dated past it).
+ *
+ * Different from MonthProjection (#296) which extrapolates current
+ * month's pace — this one is grounded in already-committed fixed
+ * expenses, so it's a *floor* not an estimate.
+ */
+export function forecastNextMonthLockedIn({
+  recurringTemplates,
+  now = Date.now(),
+}: ForecastOptions): NextMonthLockedInData | null {
+  const today = new Date(now)
+  const nextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1)
+  const monthAfterNext = new Date(today.getFullYear(), today.getMonth() + 2, 1)
+  const after = new Date(nextMonth.getTime() - 1) // exclusive-left for getNextOccurrences
+  const before = new Date(monthAfterNext.getTime() - 1) // last ms of next month
+
+  const monthLabel = `${nextMonth.getFullYear()}-${String(nextMonth.getMonth() + 1).padStart(2, '0')}`
+
+  const items: LockedInItem[] = []
+  let totalFixed = 0
+  let fixedCount = 0
+  let variableCount = 0
+
+  for (const t of recurringTemplates) {
+    if (t.isPaused) continue
+    // endDate cutoff: skip if endDate is before next month starts
+    if (t.endDate) {
+      try {
+        const end = toDate(t.endDate)
+        if (Number.isFinite(end.getTime()) && end.getTime() < nextMonth.getTime()) {
+          continue
+        }
+      } catch {
+        // bad endDate — treat as ongoing, fall through
+      }
+    }
+
+    let occurrences: Date[]
+    try {
+      occurrences = getNextOccurrences(t, after, before)
+    } catch {
+      continue
+    }
+
+    for (const occ of occurrences) {
+      items.push({
+        templateId: t.id,
+        description: (t.description || '(無描述)').trim() || '(無描述)',
+        amount: typeof t.amount === 'number' && Number.isFinite(t.amount) && t.amount > 0
+          ? t.amount
+          : null,
+        category: (t.category || '其他').trim() || '其他',
+        expectedDate: dateKey(occ),
+      })
+      if (typeof t.amount === 'number' && Number.isFinite(t.amount) && t.amount > 0) {
+        totalFixed += t.amount
+        fixedCount++
+      } else {
+        variableCount++
+      }
+    }
+  }
+
+  if (items.length === 0) return null
+
+  items.sort((a, b) => (a.expectedDate < b.expectedDate ? -1 : a.expectedDate > b.expectedDate ? 1 : 0))
+
+  return {
+    monthLabel,
+    count: fixedCount,
+    variableCount,
+    totalEstimated: fixedCount > 0 ? totalFixed : null,
+    items,
+  }
+}


### PR DESCRIPTION
## 為什麼

MonthProjection (#296) 預測**本月**月底總額。但月底使用者問「**下個月**有什麼大支出？」時，沒有 widget 回答。

從現有 RecurringExpense templates 可以推導出下個月「locked-in」固定支出。已確認的（rent / 訂閱 / 保險），不是猜測。

## 視角差異

| Widget | 範圍 | 性質 |
|--------|------|------|
| MonthProjection (#296) | 本月 | 線性外插（estimate） |
| **NextMonthLockedIn (#317)** | **下個月** | **已 commit floor (commitment)** |
| BudgetProgress | 本月 | snapshot vs budget |

## 做了什麼

`src/lib/next-month-locked-in.ts` — 純函式：
- 對每個 active recurring template 用 `getNextOccurrences()` 找下個月內所有 occurrence
- 同個 template 月內可多次（weekly templates 通常 4 次）
- Paused / endDate < next month → 排除
- Variable amount (amount=null) 列出但不算進 totalEstimated
- 全部 variable → totalEstimated = null

`src/components/next-month-locked-in.tsx` — UI：
- 預估金額 + 浮動筆數 hint
- top 6 occurrences (date / description / amount)
- "管理 →" link 到 /settings/recurring

## 範例輸出

> 🔒 下個月固定支出 · 2026-05               5 筆已知
>
> 預估 **NT\$25,500** + 1 筆浮動
>
> 05-01  房租                NT\$15,000
> 05-03  Spotify              NT\$300
> 05-08  Netflix              NT\$390
> 05-10  健身房               NT\$2,000
> 05-15  補習費               NT\$8,000

## 測試

12 個單元測試 ✅
- 空 templates / 全部 paused → null
- monthly / weekly 邊界
- endDate < next month → 排除
- endDate ≥ next month start → 保留
- variable amount 列出但不算進 total
- 全部 variable → total null
- chronological sort
- end-of-month edge (31 → 30 in 30-day month)
- bad endDate defensive

整套：1227/1227 passed (新增 12 個).

## 風險與回退

- 純讀取
- 純函式（lib 層 lint 嚴格 + ts strict + jest 全綠）
- 沒有匹配 templates → 靜默不 render

## Lessons (寫在 commit message 但保留這裡)

- `??` 對 null/undefined 都會 fallback；保留 null 必須 `'in' opts` 檢查
- CI 嚴格 lint：`no-useless-assignment` 會 catch `let x = [] / try x = ... / catch continue`

Closes #317