### PR TITLE
feat(expense-detail): 編輯時顯示 context strip (Closes #319)

### DIFF
--- a/__tests__/expense-context.test.ts
+++ b/__tests__/expense-context.test.ts
@@ -1,0 +1,180 @@
+import { buildExpenseContext } from '@/lib/expense-context'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime()
+
+interface MkOpts {
+  id?: string
+  amount?: number
+  description?: string
+  category?: string
+  daysAgo?: number
+}
+
+function mk(opts: MkOpts = {}): Expense {
+  const daysAgo = opts.daysAgo ?? 0
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id: opts.id ?? 'e',
+    groupId: 'g1',
+    description: opts.description ?? 'X',
+    amount: opts.amount ?? 100,
+    category: opts.category ?? 'food',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('buildExpenseContext', () => {
+  it('returns null when target date unreadable', () => {
+    const target = { ...mk({ id: 'target' }), date: 'oops' } as unknown as Expense
+    const r = buildExpenseContext({ expense: target, allExpenses: [target], now: NOW })
+    expect(r).toBeNull()
+  })
+
+  it('rank=1 when target is the only expense in its month', () => {
+    const target = mk({ id: 'target', amount: 100 })
+    const r = buildExpenseContext({ expense: target, allExpenses: [target], now: NOW })
+    expect(r!.monthRank).toBe(1)
+    expect(r!.monthCount).toBe(1)
+  })
+
+  it('rank reflects position among month expenses', () => {
+    const target = mk({ id: 'target', amount: 1000 })
+    const others = [
+      mk({ id: 'a', amount: 1500, daysAgo: 5 }), // bigger
+      mk({ id: 'b', amount: 2000, daysAgo: 3 }), // bigger
+      mk({ id: 'c', amount: 800, daysAgo: 7 }), // smaller
+    ]
+    const r = buildExpenseContext({
+      expense: target,
+      allExpenses: [target, ...others],
+      now: NOW,
+    })
+    expect(r!.monthRank).toBe(3) // 2 bigger → rank 3
+    expect(r!.monthCount).toBe(4)
+  })
+
+  it('rank ignores other-month expenses', () => {
+    const target = mk({ id: 'target', amount: 100 })
+    const others = [mk({ id: 'a', amount: 999, daysAgo: 60 })] // outside month
+    const r = buildExpenseContext({
+      expense: target,
+      allExpenses: [target, ...others],
+      now: NOW,
+    })
+    expect(r!.monthRank).toBe(1)
+    expect(r!.monthCount).toBe(1)
+  })
+
+  it('sameDescriptionCount excludes self', () => {
+    const target = mk({ id: 'target', description: '午餐', amount: 100 })
+    const r = buildExpenseContext({ expense: target, allExpenses: [target], now: NOW })
+    expect(r!.sameDescriptionCount).toBe(0)
+  })
+
+  it('sameDescriptionCount counts matches across history (case-insensitive)', () => {
+    const target = mk({ id: 'target', description: '午餐', amount: 100 })
+    const others = [
+      mk({ id: 'a', description: '午餐 ', amount: 120, daysAgo: 5 }),
+      mk({ id: 'b', description: 'LUNCH', amount: 80, daysAgo: 30 }), // different normalized? case → 'lunch' vs '午餐'
+      mk({ id: 'c', description: '午餐', amount: 110, daysAgo: 100 }),
+    ]
+    const r = buildExpenseContext({
+      expense: target,
+      allExpenses: [target, ...others],
+      now: NOW,
+    })
+    expect(r!.sameDescriptionCount).toBe(2) // 午餐 only, lunch is different string
+    expect(r!.sameDescriptionAverage).toBe(115) // (120 + 110) / 2
+  })
+
+  it('sameDescriptionCount respects descriptionWindowDays', () => {
+    const target = mk({ id: 'target', description: '午餐', amount: 100 })
+    const others = [
+      mk({ id: 'inside', description: '午餐', amount: 120, daysAgo: 100 }),
+      mk({ id: 'outside', description: '午餐', amount: 999, daysAgo: 400 }),
+    ]
+    const r = buildExpenseContext({
+      expense: target,
+      allExpenses: [target, ...others],
+      now: NOW,
+      descriptionWindowDays: 365,
+    })
+    expect(r!.sameDescriptionCount).toBe(1)
+  })
+
+  it('sameCategoryMonthTotal excludes self and sums same-category month', () => {
+    const target = mk({ id: 'target', category: 'food', amount: 100 })
+    const others = [
+      mk({ id: 'a', category: 'food', amount: 200, daysAgo: 3 }), // same month + cat
+      mk({ id: 'b', category: 'food', amount: 150, daysAgo: 10 }), // same month + cat
+      mk({ id: 'c', category: 'transport', amount: 999, daysAgo: 5 }), // diff cat
+      mk({ id: 'd', category: 'food', amount: 999, daysAgo: 60 }), // diff month
+    ]
+    const r = buildExpenseContext({
+      expense: target,
+      allExpenses: [target, ...others],
+      now: NOW,
+    })
+    expect(r!.sameCategoryMonthTotal).toBe(350)
+    expect(r!.sameCategoryMonthCount).toBe(2)
+  })
+
+  it('sameCategoryMonthTotal handles empty category as 其他', () => {
+    const target = { ...mk({ id: 'target', amount: 100 }), category: '' } as unknown as Expense
+    const others = [
+      { ...mk({ id: 'a', amount: 200, daysAgo: 3 }), category: '' } as unknown as Expense,
+    ]
+    const r = buildExpenseContext({
+      expense: target,
+      allExpenses: [target, ...others],
+      now: NOW,
+    })
+    expect(r!.sameCategoryMonthTotal).toBe(200)
+    expect(r!.sameCategoryMonthCount).toBe(1)
+  })
+
+  it('skips bad amount records', () => {
+    const target = mk({ id: 'target', amount: 100 })
+    const bad = mk({ id: 'bad', amount: NaN, daysAgo: 3 })
+    const r = buildExpenseContext({
+      expense: target,
+      allExpenses: [target, bad],
+      now: NOW,
+    })
+    expect(r!.monthCount).toBe(1) // bad excluded
+  })
+
+  it('skips bad date records (other than target)', () => {
+    const target = mk({ id: 'target', amount: 100 })
+    const bad = { ...mk({ id: 'bad', amount: 100 }), date: 'oops' } as unknown as Expense
+    const r = buildExpenseContext({
+      expense: target,
+      allExpenses: [target, bad],
+      now: NOW,
+    })
+    expect(r!.monthCount).toBe(1)
+  })
+
+  it('handles empty description gracefully (no description matches counted)', () => {
+    const target = { ...mk({ id: 'target', amount: 100 }), description: '' } as unknown as Expense
+    const others = [
+      { ...mk({ id: 'a', amount: 200, daysAgo: 5 }), description: '' } as unknown as Expense,
+    ]
+    const r = buildExpenseContext({
+      expense: target,
+      allExpenses: [target, ...others],
+      now: NOW,
+    })
+    expect(r!.sameDescriptionCount).toBe(0) // empty target description → no matches
+  })
+})

--- a/src/app/(auth)/expense/[id]/page.tsx
+++ b/src/app/(auth)/expense/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { doc, getDoc } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
 import { ExpenseForm } from '@/components/expense-form'
+import { ExpenseContextStrip } from '@/components/expense-context-strip'
 import { useExpenses } from '@/lib/hooks/use-expenses'
 import { logger } from '@/lib/logger'
 import type { Expense } from '@/lib/types'
@@ -61,8 +62,10 @@ export default function EditExpensePage({ params }: { params: Promise<{ id: stri
   }
 
   return (
-    <div className="p-4 md:p-8 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">編輯支出</h1>
+    <div className="p-4 md:p-8 max-w-2xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">編輯支出</h1>
+      {/* Context strip (Issue #319) — 本月排名 + 同名 + 同類別累計 */}
+      <ExpenseContextStrip expense={expense} allExpenses={expenses} />
       <ExpenseForm existingExpense={expense} onSaved={() => router.push('/records')} />
     </div>
   )

--- a/src/components/expense-context-strip.tsx
+++ b/src/components/expense-context-strip.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useMemo } from 'react'
+import { buildExpenseContext } from '@/lib/expense-context'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface ExpenseContextStripProps {
+  expense: Expense
+  allExpenses: Expense[]
+}
+
+/**
+ * Inline context for the expense detail / edit page (Issue #319). A
+ * single-line bar that surfaces three small data points:
+ *  - Where this expense ranks within its calendar month
+ *  - How many times this exact description appeared in the last year
+ *  - This-month accumulation in the same category
+ *
+ * Renders silently when nothing meaningful to say (e.g. month with only
+ * this expense and no description matches and no other category items).
+ */
+export function ExpenseContextStrip({ expense, allExpenses }: ExpenseContextStripProps) {
+  const data = useMemo(
+    () => buildExpenseContext({ expense, allExpenses }),
+    [expense, allExpenses],
+  )
+
+  if (!data) return null
+
+  const facts: string[] = []
+
+  // Month rank — only meaningful if there are >= 3 expenses in month
+  if (data.monthCount >= 3) {
+    facts.push(`本月第 ${data.monthRank} 大支出（共 ${data.monthCount} 筆）`)
+  }
+
+  // Same-description history
+  if (data.sameDescriptionCount > 0) {
+    const desc = (expense.description || '').trim() || '此 description'
+    facts.push(
+      `「${desc}」買過 ${data.sameDescriptionCount} 次（平均 ${currency(data.sameDescriptionAverage)}）`,
+    )
+  }
+
+  // Same-category month accumulation
+  if (data.sameCategoryMonthCount > 0) {
+    const category = (expense.category || '其他').trim() || '其他'
+    facts.push(
+      `本月「${category}」累計 ${currency(data.sameCategoryMonthTotal)}（${data.sameCategoryMonthCount} 筆）`,
+    )
+  }
+
+  if (facts.length === 0) return null
+
+  return (
+    <div
+      className="rounded-md px-3 py-2 text-xs flex flex-wrap gap-x-3 gap-y-1 animate-fade-up"
+      style={{
+        backgroundColor: 'color-mix(in oklch, var(--primary) 6%, transparent)',
+        borderLeft: '2px solid var(--primary)',
+      }}
+      role="note"
+    >
+      <span aria-hidden className="text-[var(--muted-foreground)]">
+        ★
+      </span>
+      {facts.map((fact, i) => (
+        <span key={i} className="text-[var(--foreground)]">
+          {fact}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/lib/expense-context.ts
+++ b/src/lib/expense-context.ts
@@ -1,0 +1,124 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface ExpenseContextData {
+  /** 1-indexed rank within current calendar month (1 = biggest). */
+  monthRank: number
+  /** Total expenses in same calendar month (denominator). */
+  monthCount: number
+  /** Same-description count over last 365 days, excluding the expense itself. */
+  sameDescriptionCount: number
+  /** Mean amount across sameDescriptionCount matches. 0 when zero matches. */
+  sameDescriptionAverage: number
+  /** Same-category total in current calendar month, excluding the expense itself. */
+  sameCategoryMonthTotal: number
+  /** Same-category count in current calendar month, excluding the expense itself. */
+  sameCategoryMonthCount: number
+}
+
+interface BuildOptions {
+  expense: Expense
+  allExpenses: Expense[]
+  /** History window for same-description match. Default 365 days. */
+  descriptionWindowDays?: number
+  /** Now in epoch ms; defaults to Date.now(). */
+  now?: number
+}
+
+function normalize(s: string): string {
+  return (s ?? '').trim().toLowerCase()
+}
+
+/**
+ * Builds the in-form context strip data for the expense detail page
+ * (Issue #319). Pure function: takes a target expense + all-expenses
+ * snapshot, returns rank-in-month plus same-description / same-category
+ * aggregates with the target excluded.
+ *
+ * Returns null only when the target's date is unreadable — empty
+ * months and zero-history descriptions are still meaningful answers
+ * (rank=1 of 1, sameDescriptionCount=0).
+ */
+export function buildExpenseContext({
+  expense,
+  allExpenses,
+  descriptionWindowDays = 365,
+  now = Date.now(),
+}: BuildOptions): ExpenseContextData | null {
+  let expenseDate: Date
+  try {
+    expenseDate = toDate(expense.date)
+  } catch {
+    return null
+  }
+  if (!Number.isFinite(expenseDate.getTime())) return null
+
+  const targetYear = expenseDate.getFullYear()
+  const targetMonth = expenseDate.getMonth()
+  const targetDescription = normalize(expense.description)
+  const targetCategory = (expense.category || '其他').trim() || '其他'
+  const targetAmount = Number(expense.amount)
+
+  let monthRank = 1
+  let monthCount = 0
+  let sameDescriptionCount = 0
+  let sameDescriptionTotal = 0
+  let sameCategoryMonthTotal = 0
+  let sameCategoryMonthCount = 0
+
+  const cutoff = now - descriptionWindowDays * 86_400_000
+
+  for (const e of allExpenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+
+    const isSelf = e.id === expense.id
+    const inSameMonth =
+      d.getFullYear() === targetYear && d.getMonth() === targetMonth
+
+    if (inSameMonth) {
+      monthCount++
+      if (
+        !isSelf &&
+        Number.isFinite(targetAmount) &&
+        amount > targetAmount
+      ) {
+        monthRank++
+      }
+
+      const category = (e.category || '其他').trim() || '其他'
+      if (!isSelf && category === targetCategory) {
+        sameCategoryMonthTotal += amount
+        sameCategoryMonthCount++
+      }
+    }
+
+    if (
+      !isSelf &&
+      targetDescription &&
+      normalize(e.description) === targetDescription &&
+      d.getTime() >= cutoff &&
+      d.getTime() <= now
+    ) {
+      sameDescriptionCount++
+      sameDescriptionTotal += amount
+    }
+  }
+
+  return {
+    monthRank,
+    monthCount,
+    sameDescriptionCount,
+    sameDescriptionAverage:
+      sameDescriptionCount > 0 ? sameDescriptionTotal / sameDescriptionCount : 0,
+    sameCategoryMonthTotal,
+    sameCategoryMonthCount,
+  }
+}


### PR DESCRIPTION
## 為什麼

點開單筆 expense 編輯時，使用者會問：
- 這筆比平常貴嗎？
- 這個月此類別累計多少？
- 同 description 我買過幾次？

這些都需要心算或翻 records。**inline 在編輯頁顯示**就是 right time。

## 做了什麼

`src/lib/expense-context.ts` — 純函式：
- 排除 self（rank/sameDescription/sameCategory 都 exclude 自己）
- monthRank：amount 比 self 大的數量 + 1
- sameDescription：normalized case-insensitive 365 天視窗
- sameCategory：當月同類別累計（excluding self）
- 跳過 bad amount/date 紀錄

`src/components/expense-context-strip.tsx` — UI：
- 緊湊 ★ 標誌 + multi inline facts
- threshold：`monthCount >= 3` 才顯示排名（避免「本月第 1 大（共 1 筆）」廢話）
- 沒可顯示的 fact 全靜默不 render

`src/app/(auth)/expense/[id]/page.tsx`：在 form 上方插入

## 範例輸出

> ★ 本月第 3 大支出（共 42 筆）｜「香港機票」買過 2 次（平均 NT\$3,200）｜本月「交通」累計 NT\$12,500（8 筆）

## 測試

12 個單元測試 ✅
- null on bad target date
- monthRank 邊界（1 筆 / N 筆 / self exclude）
- 跨月紀錄排除
- sameDescription normalize（case + padding）
- descriptionWindowDays 視窗
- sameCategory exclude self + 同月限定
- bad amount/date defensive
- empty fields fallback

整套：1239/1239 passed (新增 12 個).

Closes #319