### PR TITLE
feat(home): 預算超支預警 — 預估月底超預算主動 banner + 每日該省多少 (Closes #321)

### DIFF
--- a/__tests__/budget-overrun.test.ts
+++ b/__tests__/budget-overrun.test.ts
@@ -1,0 +1,141 @@
+import { checkBudgetOverrun } from '@/lib/budget-overrun'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15 (day 15 of 30)
+
+function mkOnDate(id: string, amount: number, year: number, month: number, day: number): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('checkBudgetOverrun', () => {
+  it('returns null when no budget set', () => {
+    const expenses = [mkOnDate('a', 1000, 2026, 3, 1)]
+    expect(
+      checkBudgetOverrun({ expenses, monthlyBudget: null, now: NOW }),
+    ).toBeNull()
+    expect(
+      checkBudgetOverrun({ expenses, monthlyBudget: undefined, now: NOW }),
+    ).toBeNull()
+    expect(
+      checkBudgetOverrun({ expenses, monthlyBudget: 0, now: NOW }),
+    ).toBeNull()
+  })
+
+  it('returns null when month too early (< 3 days)', () => {
+    const day1 = new Date(2026, 3, 1, 12, 0, 0).getTime()
+    expect(
+      checkBudgetOverrun({
+        expenses: [mkOnDate('a', 1000, 2026, 3, 1)],
+        monthlyBudget: 1000,
+        now: day1,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when no current-month spending', () => {
+    expect(
+      checkBudgetOverrun({ expenses: [], monthlyBudget: 10000, now: NOW }),
+    ).toBeNull()
+  })
+
+  it('returns null when projection within trigger threshold', () => {
+    // Day 15: spent NT$5000 → projected NT$10000. Budget NT$10000 → exactly equal, NOT exceed.
+    const expenses = [mkOnDate('a', 5000, 2026, 3, 1)]
+    expect(
+      checkBudgetOverrun({ expenses, monthlyBudget: 10000, now: NOW }),
+    ).toBeNull()
+  })
+
+  it('returns warning when projection > budget × 1.05', () => {
+    // Day 15: spent NT$6000 → projected NT$12000. Budget NT$10000 → 20% over → critical
+    // For warning case, want 5-20%: spent NT$5500 → projected NT$11000 → 10% over
+    const expenses = [mkOnDate('a', 5500, 2026, 3, 1)]
+    const r = checkBudgetOverrun({ expenses, monthlyBudget: 10000, now: NOW })
+    expect(r).not.toBeNull()
+    expect(r!.severity).toBe('warning')
+    expect(r!.projectedTotal).toBeCloseTo(11000)
+    expect(r!.budget).toBe(10000)
+    expect(r!.overrun).toBeCloseTo(1000)
+    expect(r!.overrunPct).toBeCloseTo(0.1)
+  })
+
+  it('returns critical when projection ≥ budget × 1.20', () => {
+    // Spent NT$6000 → projected NT$12000 = 20% over
+    const expenses = [mkOnDate('a', 6000, 2026, 3, 1)]
+    const r = checkBudgetOverrun({ expenses, monthlyBudget: 10000, now: NOW })
+    expect(r!.severity).toBe('critical')
+  })
+
+  it('computes daysRemaining correctly', () => {
+    // April 15 → 15 days remaining
+    const expenses = [mkOnDate('a', 6000, 2026, 3, 1)]
+    const r = checkBudgetOverrun({ expenses, monthlyBudget: 10000, now: NOW })
+    expect(r!.daysRemaining).toBe(15)
+  })
+
+  it('requiredDailyToHitBudget reflects remaining budget / remaining days', () => {
+    const expenses = [mkOnDate('a', 7000, 2026, 3, 1)]
+    const r = checkBudgetOverrun({ expenses, monthlyBudget: 10000, now: NOW })
+    // remaining: 10000 - 7000 = 3000, days remaining 15 → 200/day
+    expect(r!.requiredDailyToHitBudget).toBe(200)
+  })
+
+  it('requiredDailyToHitBudget negative when already over budget', () => {
+    const expenses = [mkOnDate('a', 12000, 2026, 3, 1)]
+    const r = checkBudgetOverrun({ expenses, monthlyBudget: 10000, now: NOW })
+    expect(r!.requiredDailyToHitBudget).toBeLessThan(0)
+    expect(r!.severity).toBe('critical')
+  })
+
+  it('currentDailyPace = spentSoFar / daysSoFar', () => {
+    const expenses = [mkOnDate('a', 7500, 2026, 3, 1)]
+    const r = checkBudgetOverrun({ expenses, monthlyBudget: 10000, now: NOW })
+    expect(r!.currentDailyPace).toBeCloseTo(500) // 7500 / 15
+  })
+
+  it('respects custom triggerThreshold', () => {
+    const expenses = [mkOnDate('a', 5100, 2026, 3, 1)] // ~2% over (5100/15 * 30 = 10200)
+    expect(
+      checkBudgetOverrun({
+        expenses,
+        monthlyBudget: 10000,
+        now: NOW,
+        triggerThreshold: 1.01,
+      }),
+    ).not.toBeNull()
+    expect(
+      checkBudgetOverrun({
+        expenses,
+        monthlyBudget: 10000,
+        now: NOW,
+        triggerThreshold: 1.1,
+      }),
+    ).toBeNull()
+  })
+
+  it('handles end-of-month edge (daysRemaining = 0)', () => {
+    const lastDay = new Date(2026, 3, 30, 23, 0, 0).getTime()
+    const expenses = [mkOnDate('a', 12000, 2026, 3, 15)]
+    const r = checkBudgetOverrun({ expenses, monthlyBudget: 10000, now: lastDay })
+    expect(r!.daysRemaining).toBe(0)
+    // requiredDaily falls back to total remaining (negative since over budget)
+    expect(r!.requiredDailyToHitBudget).toBeLessThan(0)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -29,6 +29,7 @@ import { BiggestExpenseSpotlight } from '@/components/biggest-expense-spotlight'
 import { YearRecap } from '@/components/year-recap'
 import { TodayInPastYears } from '@/components/today-in-past-years'
 import { NextMonthLockedIn } from '@/components/next-month-locked-in'
+import { BudgetOverrunAlert } from '@/components/budget-overrun-alert'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -195,6 +196,9 @@ export default function HomePage() {
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-4 md:space-y-6">
       {/* 快速記帳 */}
       <QuickAddBar />
+
+      {/* 預算超支預警 (Issue #321) — 預估月底超預算時主動 banner */}
+      <BudgetOverrunAlert expenses={expenses} group={group} />
 
       {/* Catch-up 提醒 (Issue #288) — 超過 3 天沒記時溫和提示 */}
       <CatchupNudge expenses={expenses} />

--- a/src/components/budget-overrun-alert.tsx
+++ b/src/components/budget-overrun-alert.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useMemo } from 'react'
+import { checkBudgetOverrun } from '@/lib/budget-overrun'
+import { currency } from '@/lib/utils'
+import type { Expense, FamilyGroup } from '@/lib/types'
+
+interface BudgetOverrunAlertProps {
+  expenses: Expense[]
+  group: FamilyGroup | null | undefined
+}
+
+/**
+ * Predictive budget banner (Issue #321). Renders only when current pace
+ * is meaningfully on track to exceed the monthly budget — uses a 5%
+ * buffer to absorb early-month noise. Different from BudgetProgress
+ * (passive snapshot) and MonthProjection (always-on forecast); this is
+ * action-triggering — appears only when the user can still change course.
+ */
+export function BudgetOverrunAlert({ expenses, group }: BudgetOverrunAlertProps) {
+  const data = useMemo(
+    () => checkBudgetOverrun({ expenses, monthlyBudget: group?.monthlyBudget }),
+    [expenses, group?.monthlyBudget],
+  )
+
+  if (!data) return null
+
+  const isCritical = data.severity === 'critical'
+  const overrunPctText = `${Math.round(data.overrunPct * 100)}%`
+
+  const actionableMessage =
+    data.requiredDailyToHitBudget < 0
+      ? '已超預算，無法在月內回到目標'
+      : data.daysRemaining === 0
+        ? `本月剩 0 天，已超預算 ${currency(data.overrun)}`
+        : `剩 ${data.daysRemaining} 天，每日需省下 ${currency(
+            Math.max(0, data.currentDailyPace - data.requiredDailyToHitBudget),
+          )} 才能達標`
+
+  return (
+    <div
+      className="rounded-2xl border p-4 space-y-1.5 animate-fade-up"
+      style={{
+        borderColor: isCritical
+          ? 'color-mix(in oklch, var(--destructive), var(--card) 50%)'
+          : 'color-mix(in oklch, oklch(0.80 0.15 75), var(--card) 60%)',
+        backgroundColor: isCritical
+          ? 'color-mix(in oklch, var(--destructive), var(--card) 80%)'
+          : 'color-mix(in oklch, oklch(0.85 0.10 75), var(--card) 80%)',
+      }}
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 text-sm font-semibold">
+        <span aria-hidden>{isCritical ? '🚨' : '⚠️'}</span>
+        <span>
+          預警：預估月底 <span className="font-bold">{currency(data.projectedTotal)}</span>，
+          超預算 {overrunPctText}（{currency(data.overrun)}）
+        </span>
+      </div>
+      <p className="text-xs text-[var(--foreground)]">{actionableMessage}</p>
+      <p className="text-[11px] text-[var(--muted-foreground)]">
+        目前每日平均 {currency(data.currentDailyPace)}｜預算 {currency(data.budget)}
+      </p>
+    </div>
+  )
+}

--- a/src/lib/budget-overrun.ts
+++ b/src/lib/budget-overrun.ts
@@ -1,0 +1,87 @@
+import { forecastCurrentMonth } from './month-projection'
+import type { Expense } from './types'
+
+export type OverrunSeverity = 'warning' | 'critical'
+
+export interface BudgetOverrunData {
+  /** Linear projection of month-end total spending. */
+  projectedTotal: number
+  /** Monthly budget target. */
+  budget: number
+  /** Total amount projected over budget (always > 0 when this returns non-null). */
+  overrun: number
+  /** overrun / budget (0..1+). */
+  overrunPct: number
+  /** Calendar-day pace so far (spentSoFar / daysSoFar). */
+  currentDailyPace: number
+  /** What the user would need to limit per remaining day to hit budget. Negative = impossible. */
+  requiredDailyToHitBudget: number
+  /** Days left in the current calendar month, ≥ 0. */
+  daysRemaining: number
+  /** spent so far. */
+  spentSoFar: number
+  severity: OverrunSeverity
+}
+
+interface CheckOptions {
+  expenses: Expense[]
+  /** Active monthly budget. Returns null if not provided / non-positive. */
+  monthlyBudget: number | null | undefined
+  now?: number
+  /** Buffer before triggering — projection must exceed budget × this to fire. Default 1.05 (5%). */
+  triggerThreshold?: number
+  /** Critical threshold for severity escalation. Default 1.20 (20%). */
+  criticalThreshold?: number
+}
+
+/**
+ * Predictive budget warning. Returns non-null only when the linear pace
+ * projection comfortably exceeds the budget — uses a 5% buffer by default
+ * to absorb noise from early-month days. Distinct from BudgetProgress
+ * (passive snapshot) and MonthProjection (always-on forecast): this one
+ * is action-triggering — a banner that appears only when the user can
+ * still change course.
+ */
+export function checkBudgetOverrun({
+  expenses,
+  monthlyBudget,
+  now = Date.now(),
+  triggerThreshold = 1.05,
+  criticalThreshold = 1.2,
+}: CheckOptions): BudgetOverrunData | null {
+  if (
+    typeof monthlyBudget !== 'number' ||
+    !Number.isFinite(monthlyBudget) ||
+    monthlyBudget <= 0
+  ) {
+    return null
+  }
+
+  const projection = forecastCurrentMonth({ expenses, now })
+  if (!projection) return null
+
+  const { projectedTotal, spentSoFar, daysSoFar, daysInMonth } = projection
+  if (projectedTotal <= monthlyBudget * triggerThreshold) return null
+
+  const overrun = projectedTotal - monthlyBudget
+  const overrunPct = overrun / monthlyBudget
+  const daysRemaining = Math.max(0, daysInMonth - daysSoFar)
+  const remainingBudget = monthlyBudget - spentSoFar
+  const requiredDailyToHitBudget =
+    daysRemaining > 0 ? remainingBudget / daysRemaining : remainingBudget
+  const currentDailyPace = spentSoFar / daysSoFar
+  const severity: OverrunSeverity =
+    projectedTotal >= monthlyBudget * criticalThreshold ? 'critical' : 'warning'
+
+  return {
+    projectedTotal,
+    budget: monthlyBudget,
+    overrun,
+    overrunPct,
+    currentDailyPace,
+    requiredDailyToHitBudget,
+    daysRemaining,
+    spentSoFar,
+    severity,
+  }
+}


### PR DESCRIPTION
## 為什麼

BudgetProgress 顯示**已花 vs 預算** snapshot（被動）。MonthProjection 預估**月底總額**（資訊）。但**沒有 widget 主動警告「依目前速度會超預算」**。

當預算將被擊破，**早期預警**才能讓使用者改變行為——少一杯咖啡、推遲一頓外食。

## 視角差異

| Widget | 性質 | 觸發 |
|--------|------|------|
| BudgetProgress | passive snapshot | always |
| MonthProjection (#296) | always-on forecast | always |
| **BudgetOverrunAlert (#321)** | **action-triggering banner** | **only when 危險** |

第一個 conditional banner widget——只在需要 user act 時出現。

## 做了什麼

`src/lib/budget-overrun.ts` — 純函式：
- 用 forecastCurrentMonth 預估月底
- 5% 緩衝（可調 triggerThreshold）才觸發
- 20%+ 升級為 critical severity
- 計算 requiredDailyToHitBudget = (budget - spent) / daysRemaining
- 已超預算 → requiredDaily 為負

`src/components/budget-overrun-alert.tsx` — UI banner：
- ⚠️ warning（黃系，5-20% 超）
- 🚨 critical（destructive red 系，>=20% 超）
- 三層訊息：預警頭條｜剩餘日該省多少｜目前 daily pace + 預算

## 範例輸出

> ⚠️ 預警：預估月底 NT\$22,000，超預算 10%（NT\$2,000）
> 剩 15 天，每日需省下 NT\$133 才能達標
> 目前每日平均 NT\$733｜預算 NT\$20,000

## 測試

12 個單元測試 ✅
- 無預算 / 月初 < 3 天 / 無花費 → null
- 緩衝以內不觸發
- warning vs critical threshold
- daysRemaining 計算
- requiredDailyToHitBudget 公式
- negative case (already over)
- custom threshold
- end-of-month edge

整套：1251/1251 passed (新增 12 個).

Closes #321