### PR TITLE
feat(home): 同月去年對比 — 跨年同期比較揭露季節性消費模式 (Closes #323)

### DIFF
--- a/__tests__/same-month-last-year.test.ts
+++ b/__tests__/same-month-last-year.test.ts
@@ -1,0 +1,161 @@
+import { compareSameMonthLastYear } from '@/lib/same-month-last-year'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, 2026
+
+function mkOnDate(id: string, amount: number, year: number, month: number, day: number, category = 'X'): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category,
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('compareSameMonthLastYear', () => {
+  it('returns null when too early in month', () => {
+    const day3 = new Date(2026, 3, 3, 12, 0, 0).getTime()
+    expect(compareSameMonthLastYear({ expenses: [], now: day3 })).toBeNull()
+  })
+
+  it('returns null when no current month data', () => {
+    const expenses = [mkOnDate('a', 1000, 2025, 3, 15)]
+    expect(compareSameMonthLastYear({ expenses, now: NOW })).toBeNull()
+  })
+
+  it('returns null when no last year same month data', () => {
+    const expenses = [mkOnDate('a', 1000, 2026, 3, 5)]
+    expect(compareSameMonthLastYear({ expenses, now: NOW })).toBeNull()
+  })
+
+  it('computes delta and deltaPct correctly', () => {
+    const expenses = [
+      mkOnDate('curr', 15000, 2026, 3, 5),
+      mkOnDate('ly', 12000, 2025, 3, 5),
+    ]
+    const r = compareSameMonthLastYear({ expenses, now: NOW })
+    expect(r!.monthLabel).toBe('2026-04')
+    expect(r!.lastYearLabel).toBe('2025-04')
+    expect(r!.current.total).toBe(15000)
+    expect(r!.lastYear.total).toBe(12000)
+    expect(r!.delta).toBe(3000)
+    expect(r!.deltaPct).toBeCloseTo(0.25)
+  })
+
+  it('topCategoryShift sorted by abs delta desc', () => {
+    const expenses = [
+      mkOnDate('a1', 11200, 2026, 3, 5, '餐飲'),
+      mkOnDate('a2', 8000, 2025, 3, 5, '餐飲'),
+      mkOnDate('b1', 1500, 2026, 3, 7, '交通'),
+      mkOnDate('b2', 5000, 2025, 3, 7, '交通'),
+    ]
+    const r = compareSameMonthLastYear({ expenses, now: NOW })
+    // |delta|: 交通 = 3500, 餐飲 = 3200 → 交通 first
+    expect(r!.topCategoryShift[0].category).toBe('交通')
+    expect(r!.topCategoryShift[0].delta).toBe(-3500)
+    expect(r!.topCategoryShift[1].category).toBe('餐飲')
+    expect(r!.topCategoryShift[1].delta).toBe(3200)
+  })
+
+  it('topCategoryShift filters trivial deltas', () => {
+    const expenses = [
+      mkOnDate('a1', 100, 2026, 3, 5, 'small'),
+      mkOnDate('a2', 200, 2025, 3, 5, 'small'),
+      mkOnDate('b1', 5000, 2026, 3, 7, 'big'),
+      mkOnDate('b2', 2000, 2025, 3, 7, 'big'),
+    ]
+    const r = compareSameMonthLastYear({ expenses, now: NOW })
+    expect(r!.topCategoryShift.length).toBe(1)
+    expect(r!.topCategoryShift[0].category).toBe('big')
+  })
+
+  it('limits topCategoryShift to 3', () => {
+    const cats = ['A', 'B', 'C', 'D', 'E']
+    const expenses = cats.flatMap((c, i) => [
+      mkOnDate(`curr${c}`, 5000 + i * 100, 2026, 3, 5, c),
+      mkOnDate(`ly${c}`, 1000, 2025, 3, 5, c),
+    ])
+    const r = compareSameMonthLastYear({ expenses, now: NOW })
+    expect(r!.topCategoryShift.length).toBe(3)
+  })
+
+  it('skips bad amount/date defensively', () => {
+    const bad = { ...mkOnDate('bad', 100, 2026, 3, 5), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mkOnDate('valid', 1000, 2026, 3, 5),
+      mkOnDate('ly', 800, 2025, 3, 5),
+      mkOnDate('zero', 0, 2026, 3, 5),
+      mkOnDate('nan', NaN, 2026, 3, 5),
+      bad,
+    ]
+    const r = compareSameMonthLastYear({ expenses, now: NOW })
+    expect(r!.current.total).toBe(1000)
+  })
+
+  it('does not count current-month expenses dated past today', () => {
+    const expenses = [
+      mkOnDate('past', 1000, 2026, 3, 5),
+      mkOnDate('future', 999, 2026, 3, 25), // April 25 — future as of April 15
+      mkOnDate('ly', 800, 2025, 3, 5),
+    ]
+    const r = compareSameMonthLastYear({ expenses, now: NOW })
+    expect(r!.current.total).toBe(1000) // future excluded
+  })
+
+  it('handles new categories (no last year baseline)', () => {
+    const expenses = [
+      mkOnDate('curr1', 1000, 2026, 3, 5, '醫療'), // new this year
+      mkOnDate('curr2', 2000, 2026, 3, 5, '餐飲'),
+      mkOnDate('ly', 1500, 2025, 3, 5, '餐飲'),
+    ]
+    const r = compareSameMonthLastYear({
+      expenses,
+      now: NOW,
+      minCategoryDelta: 100,
+    })
+    const newCat = r!.topCategoryShift.find((s) => s.category === '醫療')
+    expect(newCat!.previous).toBe(0)
+    expect(newCat!.delta).toBe(1000)
+    expect(newCat!.deltaPct).toBeNull() // pct undefined when prev=0
+  })
+
+  it('preserves count metric in current and last year buckets', () => {
+    const expenses = [
+      mkOnDate('curr1', 100, 2026, 3, 1),
+      mkOnDate('curr2', 200, 2026, 3, 5),
+      mkOnDate('curr3', 300, 2026, 3, 10),
+      mkOnDate('ly1', 500, 2025, 3, 1),
+      mkOnDate('ly2', 100, 2025, 3, 15),
+    ]
+    const r = compareSameMonthLastYear({ expenses, now: NOW })
+    expect(r!.current.count).toBe(3)
+    expect(r!.lastYear.count).toBe(2)
+  })
+
+  it('handles cross-year correctly (Jan vs Dec previous year)', () => {
+    // Wait — same month, so Jan 2027 vs Jan 2026, not vs Dec 2026.
+    const jan15_2027 = new Date(2027, 0, 15, 12, 0, 0).getTime()
+    const expenses = [
+      mkOnDate('curr', 1000, 2027, 0, 5),
+      mkOnDate('lyJan', 800, 2026, 0, 5), // Jan 2026 — match
+      mkOnDate('lyDec', 999, 2026, 11, 5), // Dec 2026 — should NOT match
+    ]
+    const r = compareSameMonthLastYear({ expenses, now: jan15_2027 })
+    expect(r!.monthLabel).toBe('2027-01')
+    expect(r!.lastYearLabel).toBe('2026-01')
+    expect(r!.current.total).toBe(1000)
+    expect(r!.lastYear.total).toBe(800)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -28,6 +28,7 @@ import { MostFrequentItems } from '@/components/most-frequent-items'
 import { BiggestExpenseSpotlight } from '@/components/biggest-expense-spotlight'
 import { YearRecap } from '@/components/year-recap'
 import { TodayInPastYears } from '@/components/today-in-past-years'
+import { SameMonthLastYear } from '@/components/same-month-last-year'
 import { NextMonthLockedIn } from '@/components/next-month-locked-in'
 import { BudgetOverrunAlert } from '@/components/budget-overrun-alert'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
@@ -274,6 +275,9 @@ export default function HomePage() {
 
       {/* 年度回顧 mini (Issue #305) — YTD 累計 + 預估全年 + 對比去年同期 */}
       <YearRecap expenses={expenses} />
+
+      {/* 同月去年對比 (Issue #323) — 季節性消費模式對比 */}
+      <SameMonthLastYear expenses={expenses} />
 
       {/* X 年前的今天 (Issue #315) — Facebook Memories 式時間旅行 */}
       <TodayInPastYears expenses={expenses} />

--- a/src/components/same-month-last-year.tsx
+++ b/src/components/same-month-last-year.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useMemo } from 'react'
+import { compareSameMonthLastYear, type CategoryShift } from '@/lib/same-month-last-year'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface SameMonthLastYearProps {
+  expenses: Expense[]
+}
+
+function describeShift(s: CategoryShift): string {
+  if (s.previous === 0) {
+    return `${s.category} 新增 ${currency(s.current)}`
+  }
+  if (s.current === 0) {
+    return `${s.category} 消失（去年 ${currency(s.previous)}）`
+  }
+  if (s.deltaPct === null) return s.category
+  const pct = Math.round(s.deltaPct * 100)
+  const arrow = pct > 0 ? '↑' : pct < 0 ? '↓' : '→'
+  return `${arrow} ${s.category} ${pct > 0 ? '+' : ''}${pct}% (${currency(s.previous)} → ${currency(s.current)})`
+}
+
+/**
+ * Year-over-year same-month compare (Issue #323). Surfaces seasonal
+ * patterns invisible in MoM (CategoryMoM) — winter vs winter, holiday
+ * season, summer break. Useful for asking "is this month's spending
+ * normal for our family?"
+ */
+export function SameMonthLastYear({ expenses }: SameMonthLastYearProps) {
+  const data = useMemo(
+    () => compareSameMonthLastYear({ expenses }),
+    [expenses],
+  )
+
+  if (!data) return null
+
+  const pctText =
+    data.deltaPct !== null
+      ? `${data.deltaPct > 0 ? '+' : ''}${Math.round(data.deltaPct * 100)}%`
+      : ''
+  const trendColor =
+    data.delta > 0
+      ? 'var(--destructive)'
+      : data.delta < 0
+        ? 'var(--primary)'
+        : 'var(--muted-foreground)'
+  const trendArrow = data.delta > 0 ? '↑' : data.delta < 0 ? '↓' : '→'
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        📆 本月 vs 去年同月（{data.lastYearLabel}）
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <div className="space-y-0.5">
+          <div className="text-[11px] text-[var(--muted-foreground)]">本月</div>
+          <div className="font-semibold text-[var(--foreground)]">
+            {currency(data.current.total)}
+          </div>
+          <div className="text-[11px] text-[var(--muted-foreground)]">
+            {data.current.count} 筆
+          </div>
+        </div>
+        <div className="space-y-0.5">
+          <div className="text-[11px] text-[var(--muted-foreground)]">去年同月</div>
+          <div className="font-semibold text-[var(--foreground)]">
+            {currency(data.lastYear.total)}
+          </div>
+          <div className="text-[11px] text-[var(--muted-foreground)]">
+            {data.lastYear.count} 筆
+          </div>
+        </div>
+      </div>
+
+      <p className="text-sm" style={{ color: trendColor }}>
+        {trendArrow} {data.delta > 0 ? '多' : data.delta < 0 ? '少' : '相當'}{' '}
+        {currency(Math.abs(data.delta))}
+        {pctText && ` (${pctText})`}
+      </p>
+
+      {data.topCategoryShift.length > 0 && (
+        <div className="pt-2 border-t border-[var(--border)] space-y-1">
+          <p className="text-[11px] font-medium text-[var(--muted-foreground)]">
+            類別變化
+          </p>
+          {data.topCategoryShift.map((s) => (
+            <p
+              key={s.category}
+              className="text-xs text-[var(--foreground)]"
+            >
+              {describeShift(s)}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/same-month-last-year.ts
+++ b/src/lib/same-month-last-year.ts
@@ -1,0 +1,128 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface CategoryShift {
+  category: string
+  current: number
+  previous: number
+  delta: number
+  deltaPct: number | null
+}
+
+export interface SameMonthLastYearData {
+  /** "YYYY-MM" of current month. */
+  monthLabel: string
+  /** "YYYY-MM" of same month last year. */
+  lastYearLabel: string
+  current: {
+    total: number
+    count: number
+  }
+  lastYear: {
+    total: number
+    count: number
+  }
+  delta: number
+  /** delta / lastYear.total. null when lastYear.total is 0. */
+  deltaPct: number | null
+  /** Up to 3 categories with biggest absolute change, sorted by |delta| desc. */
+  topCategoryShift: CategoryShift[]
+}
+
+interface CompareOptions {
+  expenses: Expense[]
+  now?: number
+  /** Min days into current month before producing comparison. Default 7. */
+  minDaysSoFar?: number
+  /** Min |delta| (NT$) for category to qualify as significant shift. Default 500. */
+  minCategoryDelta?: number
+}
+
+function monthKey(year: number, month: number): string {
+  return `${year}-${String(month + 1).padStart(2, '0')}`
+}
+
+/**
+ * Year-over-year same-month comparison. Surfaces seasonal patterns that
+ * MoM misses (winter vs winter, holiday season, summer break) — useful
+ * for asking "is this April normal for us?"
+ *
+ * Returns null when current month is too young, has no spending, or
+ * matching last-year month has no data — in those cases the comparison
+ * isn't meaningful.
+ */
+export function compareSameMonthLastYear({
+  expenses,
+  now = Date.now(),
+  minDaysSoFar = 7,
+  minCategoryDelta = 500,
+}: CompareOptions): SameMonthLastYearData | null {
+  const today = new Date(now)
+  if (today.getDate() < minDaysSoFar) return null
+
+  const year = today.getFullYear()
+  const month = today.getMonth()
+  const lastYear = year - 1
+
+  let currentTotal = 0
+  let currentCount = 0
+  let lastYearTotal = 0
+  let lastYearCount = 0
+  const currentByCategory = new Map<string, number>()
+  const lastYearByCategory = new Map<string, number>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+
+    const category = (e.category || '其他').trim() || '其他'
+
+    if (d.getFullYear() === year && d.getMonth() === month && d.getTime() <= now) {
+      currentTotal += amount
+      currentCount++
+      currentByCategory.set(category, (currentByCategory.get(category) ?? 0) + amount)
+    } else if (d.getFullYear() === lastYear && d.getMonth() === month) {
+      lastYearTotal += amount
+      lastYearCount++
+      lastYearByCategory.set(category, (lastYearByCategory.get(category) ?? 0) + amount)
+    }
+  }
+
+  if (currentTotal <= 0) return null
+  if (lastYearTotal <= 0) return null
+
+  const delta = currentTotal - lastYearTotal
+  const deltaPct = lastYearTotal > 0 ? delta / lastYearTotal : null
+
+  const allCategories = new Set<string>([
+    ...currentByCategory.keys(),
+    ...lastYearByCategory.keys(),
+  ])
+  const shifts: CategoryShift[] = []
+  for (const category of allCategories) {
+    const current = currentByCategory.get(category) ?? 0
+    const previous = lastYearByCategory.get(category) ?? 0
+    const cDelta = current - previous
+    if (Math.abs(cDelta) < minCategoryDelta) continue
+    const cDeltaPct = previous > 0 ? cDelta / previous : null
+    shifts.push({ category, current, previous, delta: cDelta, deltaPct: cDeltaPct })
+  }
+  shifts.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+
+  return {
+    monthLabel: monthKey(year, month),
+    lastYearLabel: monthKey(lastYear, month),
+    current: { total: currentTotal, count: currentCount },
+    lastYear: { total: lastYearTotal, count: lastYearCount },
+    delta,
+    deltaPct,
+    topCategoryShift: shifts.slice(0, 3),
+  }
+}


### PR DESCRIPTION
## 為什麼

之前的對比 widget：
- CategoryMoM (#298)：本月 vs 上月（短期）
- YearRecap (#305)：YTD vs 去年同期 sliding YTD（年累積）

但都看不到**季節對比**——「去年 4 月你也這樣花嗎？」寒暑假、年節、生日季的支出 pattern 必須跨年同月才看得清楚。

## 做了什麼

`src/lib/same-month-last-year.ts` — 純函式：
- 本月 vs `(year-1, same month)`
- total + count + 類別 breakdown
- topCategoryShift 排序 by `|delta|` desc，前 3 名
- 跳過 future-dated（current month 截止到 today）
- 月初 < 7 天 → null
- 兩月任一無資料 → null
- **跨年正確**（Jan 2027 比 Jan 2026 而非 Dec 2026）

`src/components/same-month-last-year.tsx` — UI：
- top: 兩欄並列（本月 vs 去年同月）
- middle: 整體 delta 著色（多紅、少綠、相當灰）
- bottom: top 3 類別 shift（含 new / gone）

## 範例輸出

> 📆 本月 vs 去年同月（2025-04）
>
> 本月            去年同月
> NT\$15,000     NT\$12,000
> 42 筆          38 筆
>
> ↑ 多 NT\$3,000 (+25%)
>
> ─── 類別變化 ───
> ↑ 餐飲 +40% (NT\$8,000 → NT\$11,200)
> ↓ 交通 -50% (NT\$3,000 → NT\$1,500)
> 醫療 新增 NT\$1,200

## 測試

12 個單元測試 ✅
- 月初太早/兩月任一無資料 → null
- delta + deltaPct
- |delta| 排序 / limit 3
- 類別 trivial filter
- bad amount/date defensive
- future date exclude
- 新類別 prev=0 → deltaPct null
- count 度量
- **跨年正確（Jan vs Jan，非 Dec）**

整套：1263/1263 passed (新增 12 個).

Closes #323