### PR TITLE
feat(records): 篩選結果加 average/median/max/min 統計列 (Closes #325)

### DIFF
--- a/__tests__/filter-stats.test.ts
+++ b/__tests__/filter-stats.test.ts
@@ -1,0 +1,112 @@
+import { computeFilterStats } from '@/lib/filter-stats'
+import type { Expense } from '@/lib/types'
+
+function mk(id: string, amount: number): Expense {
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: new Date(),
+    createdAt: new Date(),
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('computeFilterStats', () => {
+  it('returns null below min count', () => {
+    expect(computeFilterStats({ expenses: [] })).toBeNull()
+    expect(computeFilterStats({ expenses: [mk('a', 100)] })).toBeNull()
+    expect(computeFilterStats({ expenses: [mk('a', 100), mk('b', 200)] })).toBeNull()
+  })
+
+  it('computes basic stats for odd count', () => {
+    const expenses = [mk('a', 100), mk('b', 200), mk('c', 300)]
+    const r = computeFilterStats({ expenses })
+    expect(r!.count).toBe(3)
+    expect(r!.total).toBe(600)
+    expect(r!.average).toBe(200)
+    expect(r!.median).toBe(200)
+    expect(r!.max).toBe(300)
+    expect(r!.min).toBe(100)
+  })
+
+  it('median for even count is average of two middle values', () => {
+    const expenses = [mk('a', 100), mk('b', 200), mk('c', 300), mk('d', 400)]
+    const r = computeFilterStats({ expenses })
+    expect(r!.median).toBe(250) // (200+300)/2
+  })
+
+  it('skips bad amount records', () => {
+    const expenses = [
+      mk('valid1', 100),
+      mk('valid2', 200),
+      mk('valid3', 300),
+      mk('nan', NaN),
+      mk('zero', 0),
+      mk('neg', -50),
+      mk('inf', Infinity),
+    ]
+    const r = computeFilterStats({ expenses })
+    expect(r!.count).toBe(3)
+  })
+
+  it('respects custom minCount', () => {
+    const expenses = [mk('a', 100), mk('b', 200)]
+    expect(computeFilterStats({ expenses, minCount: 2 })).not.toBeNull()
+    expect(computeFilterStats({ expenses, minCount: 3 })).toBeNull()
+  })
+
+  it('handles unsorted input correctly', () => {
+    const expenses = [mk('c', 300), mk('a', 100), mk('b', 200)]
+    const r = computeFilterStats({ expenses })
+    expect(r!.min).toBe(100)
+    expect(r!.max).toBe(300)
+    expect(r!.median).toBe(200)
+  })
+
+  it('handles all-same amounts', () => {
+    const expenses = [mk('a', 100), mk('b', 100), mk('c', 100)]
+    const r = computeFilterStats({ expenses })
+    expect(r!.average).toBe(100)
+    expect(r!.median).toBe(100)
+    expect(r!.max).toBe(100)
+    expect(r!.min).toBe(100)
+  })
+
+  it('detects extreme outlier impact (avg > median)', () => {
+    const expenses = [
+      mk('small1', 100),
+      mk('small2', 100),
+      mk('small3', 100),
+      mk('outlier', 9700),
+    ]
+    const r = computeFilterStats({ expenses })
+    expect(r!.average).toBe(2500) // (100+100+100+9700)/4
+    expect(r!.median).toBe(100) // (100+100)/2
+    // Median << average reveals outlier
+  })
+
+  it('large dataset (1000 items)', () => {
+    const expenses = Array.from({ length: 1000 }, (_, i) => mk(String(i), i + 1))
+    const r = computeFilterStats({ expenses })
+    expect(r!.count).toBe(1000)
+    expect(r!.min).toBe(1)
+    expect(r!.max).toBe(1000)
+    expect(r!.median).toBe(500.5) // (500 + 501) / 2
+  })
+
+  it('total = sum of all amounts', () => {
+    const expenses = [mk('a', 100), mk('b', 250), mk('c', 75)]
+    const r = computeFilterStats({ expenses })
+    expect(r!.total).toBe(425)
+  })
+})

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/amount-range-filter'
 import { AmountRangeChips } from '@/components/amount-range-chips'
 import { DescriptionPriceTrend } from '@/components/description-price-trend'
+import { computeFilterStats } from '@/lib/filter-stats'
 import { useSwipe } from '@/hooks/use-swipe'
 import { usePullToRefresh } from '@/hooks/use-pull-to-refresh'
 import { useGroup } from '@/lib/hooks/use-group'
@@ -241,6 +242,7 @@ export default function RecordsPage() {
   }, [filtered])
 
   const totalFiltered = useMemo(() => filtered.reduce((s, e) => s + e.amount, 0), [filtered])
+  const filterStats = useMemo(() => computeFilterStats({ expenses: filtered }), [filtered])
   const isFiltering = searchQuery || hasAdvancedFilter
 
   function clearFilters() {
@@ -541,7 +543,8 @@ export default function RecordsPage() {
 
       {/* Filter summary + export */}
       {!loading && filtered.length > 0 && (
-        <div className="text-sm text-[var(--muted-foreground)] mb-3 flex items-center justify-between flex-wrap gap-2">
+        <div className="mb-3 space-y-1">
+        <div className="text-sm text-[var(--muted-foreground)] flex items-center justify-between flex-wrap gap-2">
           {isFiltering ? (
             <span>
               顯示 <span className="font-semibold text-[var(--foreground)]">{filtered.length}</span> 筆
@@ -571,6 +574,15 @@ export default function RecordsPage() {
               ⤓ 匯出 CSV
             </button>
           </div>
+        </div>
+        {filterStats && (
+          <div className="text-xs text-[var(--muted-foreground)] flex items-center flex-wrap gap-x-3 gap-y-0.5">
+            <span>avg <span className="text-[var(--foreground)] font-medium">{currency(filterStats.average)}</span></span>
+            <span>median <span className="text-[var(--foreground)] font-medium">{currency(filterStats.median)}</span></span>
+            <span>max <span className="text-[var(--foreground)] font-medium">{currency(filterStats.max)}</span></span>
+            <span>min <span className="text-[var(--foreground)] font-medium">{currency(filterStats.min)}</span></span>
+          </div>
+        )}
         </div>
       )}
 

--- a/src/lib/filter-stats.ts
+++ b/src/lib/filter-stats.ts
@@ -1,0 +1,47 @@
+import type { Expense } from './types'
+
+export interface FilterStatsData {
+  count: number
+  total: number
+  average: number
+  median: number
+  max: number
+  min: number
+}
+
+interface ComputeOptions {
+  expenses: Expense[]
+  /** Min count before stats are meaningful. Default 3. */
+  minCount?: number
+}
+
+/**
+ * Distribution stats over a filtered slice of expenses. Complements the
+ * existing "count + total" line on /records by showing the *shape* of
+ * the slice: average, median, range. Returns null below a small-sample
+ * threshold where stats would be misleading.
+ */
+export function computeFilterStats({
+  expenses,
+  minCount = 3,
+}: ComputeOptions): FilterStatsData | null {
+  const amounts: number[] = []
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    amounts.push(amount)
+  }
+
+  if (amounts.length < minCount) return null
+
+  amounts.sort((a, b) => a - b)
+  const n = amounts.length
+  const total = amounts.reduce((s, x) => s + x, 0)
+  const average = total / n
+  const median =
+    n % 2 === 1 ? amounts[(n - 1) / 2] : (amounts[n / 2 - 1] + amounts[n / 2]) / 2
+  const max = amounts[n - 1]
+  const min = amounts[0]
+
+  return { count: n, total, average, median, max, min }
+}


### PR DESCRIPTION
## 為什麼

records page 篩選後只顯示「合計 NT\$X」。但對「這些篩選結果分布如何？」沒有答案。

加 **average / median / max / min** 後，使用者一眼看到分布形狀：
- 平均每筆多少
- avg vs median 差距 → 是否有 outlier 拉高 average
- max vs min spread

## 做了什麼

`src/lib/filter-stats.ts` — 純函式：
- minCount 預設 3，< 3 筆 stats 沒意義 → null
- 跳過 bad amount（NaN/Infinity/zero/negative）
- median 處理 even count（取兩中間平均）

`src/app/(auth)/records/page.tsx`：
- 既有 filter summary line 下方加小字 stats line
- 只在 filtered.length >= 3 時顯示

## 範例輸出

> 顯示 23 筆（共 156 筆）· 合計 NT\$8,420            清除所有篩選 · ⤓ 匯出 CSV
> avg NT\$366  median NT\$200  max NT\$3,500  min NT\$50

## 測試

10 個單元測試 ✅
- minCount threshold (空 / 1 / 2 → null, 3 → ok)
- odd / even count median
- bad amount defensive
- unsorted input
- all-same amounts
- **outlier impact (avg >> median)**
- large dataset (1000 items)
- custom minCount

整套：1273/1273 passed (新增 10 個).

Closes #325