### PR TITLE
feat(settings): Lifetime Achievements card — 終身記帳成就 (Closes #327)

### DIFF
--- a/__tests__/lifetime-stats.test.ts
+++ b/__tests__/lifetime-stats.test.ts
@@ -1,0 +1,159 @@
+import { aggregateLifetimeStats } from '@/lib/lifetime-stats'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, 2026
+
+function mk(id: string, amount: number, daysAgo: number, opts: Partial<Expense> = {}): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description: opts.description ?? `e-${id}`,
+    amount,
+    category: opts.category ?? 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('aggregateLifetimeStats', () => {
+  it('returns null when no expenses', () => {
+    expect(aggregateLifetimeStats({ expenses: [], now: NOW })).toBeNull()
+  })
+
+  it('returns null when only invalid records', () => {
+    const bad = { ...mk('a', 100, 1), date: 'oops' } as unknown as Expense
+    const expenses = [bad, mk('zero', 0, 1), mk('nan', NaN, 1), mk('neg', -50, 1)]
+    expect(aggregateLifetimeStats({ expenses, now: NOW })).toBeNull()
+  })
+
+  it('returns null when first record < minDaysSinceFirst', () => {
+    const expenses = [mk('a', 100, 5)]
+    expect(
+      aggregateLifetimeStats({ expenses, now: NOW, minDaysSinceFirst: 14 }),
+    ).toBeNull()
+  })
+
+  it('basic stats: total count, amount, first record date', () => {
+    const expenses = [
+      mk('a', 100, 60),
+      mk('b', 200, 30),
+      mk('c', 300, 10),
+    ]
+    const r = aggregateLifetimeStats({ expenses, now: NOW })
+    expect(r!.totalCount).toBe(3)
+    expect(r!.totalAmount).toBe(600)
+    expect(r!.firstRecordDate).toBe('2026-02-14') // 60 days ago
+  })
+
+  it('totalDaysSinceFirst includes today', () => {
+    const expenses = [mk('a', 100, 30)]
+    const r = aggregateLifetimeStats({ expenses, now: NOW })
+    expect(r!.totalDaysSinceFirst).toBe(31) // 30 days back + today
+  })
+
+  it('daysRecorded counts distinct calendar days', () => {
+    const expenses = [
+      mk('a', 100, 30),
+      mk('b', 200, 30), // same day as a
+      mk('c', 300, 20),
+      mk('d', 400, 10),
+    ]
+    const r = aggregateLifetimeStats({ expenses, now: NOW })
+    expect(r!.daysRecorded).toBe(3)
+  })
+
+  it('recordingRate = daysRecorded / totalDaysSinceFirst', () => {
+    const expenses = [
+      mk('a', 100, 30),
+      mk('b', 200, 25),
+      mk('c', 300, 20),
+    ]
+    const r = aggregateLifetimeStats({ expenses, now: NOW })
+    // 3 distinct days / 31 day span ≈ 0.0968
+    expect(r!.recordingRate).toBeCloseTo(3 / 31)
+  })
+
+  it('biggestSingleExpense is largest by amount', () => {
+    const expenses = [
+      mk('a', 1000, 30, { description: '機票' }),
+      mk('b', 8500, 20, { description: '香港機票', category: '交通' }),
+      mk('c', 500, 10),
+    ]
+    const r = aggregateLifetimeStats({ expenses, now: NOW })
+    expect(r!.biggestSingleExpense.description).toBe('香港機票')
+    expect(r!.biggestSingleExpense.amount).toBe(8500)
+    expect(r!.biggestSingleExpense.category).toBe('交通')
+  })
+
+  it('highestMonth finds calendar month with max total', () => {
+    const expenses = [
+      mk('a', 5000, 60), // Feb 2026
+      mk('b', 3000, 60), // Feb 2026 → 8000
+      mk('c', 4000, 30), // March 2026
+      mk('d', 1000, 10), // April 2026
+    ]
+    const r = aggregateLifetimeStats({ expenses, now: NOW })
+    expect(r!.highestMonth.label).toBe('2026-02')
+    expect(r!.highestMonth.amount).toBe(8000)
+  })
+
+  it('longestStreak finds best consecutive run', () => {
+    // 3 consecutive days, then gap, then 5 consecutive days
+    const expenses = [
+      mk('a', 100, 30),
+      mk('b', 100, 29),
+      mk('c', 100, 28),
+      // gap at 27..21
+      mk('d', 100, 20),
+      mk('e', 100, 19),
+      mk('f', 100, 18),
+      mk('g', 100, 17),
+      mk('h', 100, 16),
+    ]
+    const r = aggregateLifetimeStats({ expenses, now: NOW })
+    expect(r!.longestStreak).toBe(5)
+  })
+
+  it('skips bad amount records but keeps valid ones', () => {
+    const bad = { ...mk('bad', 100, 30), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mk('valid', 100, 30),
+      mk('nan', NaN, 30),
+      mk('zero', 0, 30),
+      bad,
+      mk('valid2', 200, 20),
+    ]
+    const r = aggregateLifetimeStats({ expenses, now: NOW })
+    expect(r!.totalCount).toBe(2)
+    expect(r!.totalAmount).toBe(300)
+  })
+
+  it('handles empty description / category gracefully', () => {
+    const e = {
+      ...mk('a', 5000, 30),
+      description: '',
+      category: '',
+    } as unknown as Expense
+    const r = aggregateLifetimeStats({ expenses: [e], now: NOW })
+    expect(r!.biggestSingleExpense.description).toBe('(無描述)')
+    expect(r!.biggestSingleExpense.category).toBe('其他')
+  })
+
+  it('large dataset (200 expenses) does not error', () => {
+    const expenses = Array.from({ length: 200 }, (_, i) =>
+      mk(String(i), (i + 1) * 10, i + 1),
+    )
+    const r = aggregateLifetimeStats({ expenses, now: NOW })
+    expect(r).not.toBeNull()
+    expect(r!.totalCount).toBe(200)
+  })
+})

--- a/src/app/(auth)/settings/page.tsx
+++ b/src/app/(auth)/settings/page.tsx
@@ -17,6 +17,8 @@ import { BudgetSection } from '@/components/budget-section'
 import { OrphanCleanupSection } from '@/components/orphan-cleanup-section'
 import { RuleCleanupSection } from '@/components/rule-cleanup-section'
 import { EmailPreferenceSection } from '@/components/email-preference-section'
+import { LifetimeAchievements } from '@/components/lifetime-achievements'
+import { useExpenses } from '@/lib/hooks/use-expenses'
 import type { FamilyMember, Category } from '@/lib/types'
 
 import { useToast } from '@/components/toast'
@@ -640,6 +642,7 @@ function GroupManagementSection() {
 export default function SettingsPage() {
   const { user, signOut } = useAuth()
   const { group, loading } = useGroup()
+  const { expenses } = useExpenses()
   const router = useRouter()
 
   async function handleSignOut() {
@@ -662,6 +665,9 @@ export default function SettingsPage() {
   return (
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-4">
       <h1 className="text-xl font-bold">⚙️ 設定</h1>
+
+      {/* Lifetime Achievements (Issue #327) — emotional 自我紀念 */}
+      <LifetimeAchievements expenses={expenses} />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
         <Section title="📂 群組管理">

--- a/src/components/lifetime-achievements.tsx
+++ b/src/components/lifetime-achievements.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useMemo } from 'react'
+import { aggregateLifetimeStats } from '@/lib/lifetime-stats'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface LifetimeAchievementsProps {
+  expenses: Expense[]
+}
+
+/**
+ * Lifetime self-narrative card for the settings page (Issue #327). All
+ * other widgets are analytical / temporal; this one is commemorative —
+ * "我們的記帳成就". For long-running families it grows in emotional
+ * value over time.
+ */
+export function LifetimeAchievements({ expenses }: LifetimeAchievementsProps) {
+  const data = useMemo(
+    () => aggregateLifetimeStats({ expenses }),
+    [expenses],
+  )
+
+  if (!data) return null
+
+  const recordingPct = Math.round(data.recordingRate * 100)
+  const yearLabel =
+    data.highestMonth.label && /^\d{4}-\d{2}$/.test(data.highestMonth.label)
+      ? `${data.highestMonth.label.slice(0, 4)} 年 ${parseInt(data.highestMonth.label.slice(5), 10)} 月`
+      : data.highestMonth.label
+
+  return (
+    <div
+      className="card p-5 md:p-6 space-y-3 animate-fade-up"
+      style={{
+        backgroundColor: 'color-mix(in oklch, var(--primary) 4%, transparent)',
+      }}
+    >
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        🏆 我們的記帳成就
+      </div>
+
+      <p className="text-sm text-[var(--foreground)]">
+        從 <span className="font-semibold">{data.firstRecordDate}</span> 開始記帳
+        （已 {data.totalDaysSinceFirst} 天）
+      </p>
+      <p className="text-sm text-[var(--foreground)]">
+        累計 <span className="font-semibold">{data.totalCount}</span> 筆 ·{' '}
+        <span className="font-semibold text-[var(--primary)]">
+          {currency(data.totalAmount)}
+        </span>
+      </p>
+
+      <ul className="space-y-1 text-xs text-[var(--foreground)] pt-1 border-t border-[var(--border)]">
+        <li>
+          🥇 最大單筆：
+          <span className="font-medium">
+            {currency(data.biggestSingleExpense.amount)}
+          </span>{' '}
+          <span className="text-[var(--muted-foreground)]">
+            ({data.biggestSingleExpense.description}, {data.biggestSingleExpense.date})
+          </span>
+        </li>
+        <li>
+          📅 最高月：
+          <span className="font-medium">{currency(data.highestMonth.amount)}</span>{' '}
+          <span className="text-[var(--muted-foreground)]">({yearLabel})</span>
+        </li>
+        <li>
+          🔥 最長連續記帳：
+          <span className="font-medium">{data.longestStreak}</span> 天
+        </li>
+        <li>
+          📊 記帳率：
+          <span className="font-medium">{recordingPct}%</span>{' '}
+          <span className="text-[var(--muted-foreground)]">
+            ({data.daysRecorded} / {data.totalDaysSinceFirst} 天有記)
+          </span>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/src/lib/lifetime-stats.ts
+++ b/src/lib/lifetime-stats.ts
@@ -1,0 +1,147 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface LifetimeStatsData {
+  /** YYYY-MM-DD of earliest recorded expense (by date field). */
+  firstRecordDate: string
+  /** Days from firstRecordDate to today (inclusive). */
+  totalDaysSinceFirst: number
+  /** Total expense count (excludes bad data). */
+  totalCount: number
+  /** Sum of all amounts. */
+  totalAmount: number
+  /** Distinct calendar days with at least one recorded expense. */
+  daysRecorded: number
+  /** daysRecorded / totalDaysSinceFirst, 0..1. */
+  recordingRate: number
+  /** Largest single expense ever. */
+  biggestSingleExpense: {
+    description: string
+    amount: number
+    date: string
+    category: string
+  }
+  /** Calendar month with highest total spend. */
+  highestMonth: {
+    label: string // YYYY-MM
+    amount: number
+  }
+  /** Longest consecutive run of recorded calendar days. */
+  longestStreak: number
+}
+
+interface AggregateOptions {
+  expenses: Expense[]
+  now?: number
+  /** Min days from firstRecord before producing stats. Default 14. */
+  minDaysSinceFirst?: number
+}
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function monthKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+}
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d)
+  x.setHours(0, 0, 0, 0)
+  return x
+}
+
+function computeLongestStreak(dateKeys: Set<string>): number {
+  if (dateKeys.size === 0) return 0
+  const sorted = Array.from(dateKeys).sort()
+  let longest = 0
+  let runLen = 0
+  let prevTs = -Infinity
+  for (const k of sorted) {
+    const [y, m, d] = k.split('-').map(Number)
+    const ts = new Date(y, m - 1, d).getTime()
+    if (prevTs !== -Infinity && ts - prevTs === 86_400_000) {
+      runLen++
+    } else {
+      runLen = 1
+    }
+    if (runLen > longest) longest = runLen
+    prevTs = ts
+  }
+  return longest
+}
+
+/**
+ * Lifetime self-narrative for the settings page (Issue #327). Distinct
+ * from analytical widgets — this is emotional / commemorative, like a
+ * static "since you started" summary card.
+ */
+export function aggregateLifetimeStats({
+  expenses,
+  now = Date.now(),
+  minDaysSinceFirst = 14,
+}: AggregateOptions): LifetimeStatsData | null {
+  let totalCount = 0
+  let totalAmount = 0
+  let earliestTs = Infinity
+  let biggest: LifetimeStatsData['biggestSingleExpense'] | null = null
+  const monthTotals = new Map<string, number>()
+  const dateKeys = new Set<string>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    const ts = d.getTime()
+    if (!Number.isFinite(ts) || ts <= 0) continue
+    if (ts < earliestTs) earliestTs = ts
+    totalCount++
+    totalAmount += amount
+    monthTotals.set(monthKey(d), (monthTotals.get(monthKey(d)) ?? 0) + amount)
+    dateKeys.add(dateKey(d))
+    if (!biggest || amount > biggest.amount) {
+      biggest = {
+        description: (e.description || '(無描述)').trim() || '(無描述)',
+        amount,
+        date: dateKey(d),
+        category: (e.category || '其他').trim() || '其他',
+      }
+    }
+  }
+
+  if (totalCount === 0 || !biggest) return null
+  if (!Number.isFinite(earliestTs)) return null
+
+  const today = startOfDay(new Date(now))
+  const firstRecordDay = startOfDay(new Date(earliestTs))
+  const totalDaysSinceFirst = Math.max(
+    1,
+    Math.floor((today.getTime() - firstRecordDay.getTime()) / 86_400_000) + 1,
+  )
+
+  if (totalDaysSinceFirst < minDaysSinceFirst) return null
+
+  let highestMonth: LifetimeStatsData['highestMonth'] = { label: '', amount: 0 }
+  for (const [label, amount] of monthTotals) {
+    if (amount > highestMonth.amount) {
+      highestMonth = { label, amount }
+    }
+  }
+
+  return {
+    firstRecordDate: dateKey(firstRecordDay),
+    totalDaysSinceFirst,
+    totalCount,
+    totalAmount,
+    daysRecorded: dateKeys.size,
+    recordingRate: dateKeys.size / totalDaysSinceFirst,
+    biggestSingleExpense: biggest,
+    highestMonth,
+    longestStreak: computeLongestStreak(dateKeys),
+  }
+}


### PR DESCRIPTION
## 為什麼

Settings 頁全部是 functional config（預算、成員、類別、theme...）。**沒有任何「自我紀念」內容**。

對長期使用者，「我已經用這個 app 多久了？累計記了多少？」是個重要的情感連結點。Spotify Wrapped 證明了 lifetime 數字的力量。

## 做了什麼

`src/lib/lifetime-stats.ts` — 純函式：
- firstRecordDate + totalDaysSinceFirst（含今天）
- totalCount + totalAmount
- daysRecorded + recordingRate（達成率）
- biggestSingleExpense（lifetime max）
- highestMonth（calendar month with max total）
- longestStreak（重用 streak 邏輯，不依賴 recording-streak.ts 避免耦合）

`src/components/lifetime-achievements.tsx` — UI achievements 卡片：
- 起點 + 持續天數
- 累計筆數 + 金額
- 4 個 emoji 成就：🥇 最大單筆｜📅 最高月｜🔥 最長 streak｜📊 記帳率

`src/app/(auth)/settings/page.tsx`：放在頂部（一打開設定先看到成就）

## 範例輸出

> 🏆 我們的記帳成就
>
> 從 2024-08-15 開始記帳（已 612 天）
> 累計 1,247 筆 · NT\$485,000
>
> 🥇 最大單筆：NT\$8,500（香港機票, 2024-12-20）
> 📅 最高月：NT\$32,000（2025 年 12 月）
> 🔥 最長連續記帳：47 天
> 📊 記帳率：68% (412 / 612 天有記)

## 測試

13 個單元測試 ✅
- 空資料 / 全 bad → null
- minDaysSinceFirst threshold
- totalDaysSinceFirst 含今天
- daysRecorded distinct only
- recordingRate 公式
- biggestSingleExpense
- highestMonth
- longestStreak
- bad data defensive
- empty fields fallback
- large dataset

整套：1286/1286 passed (新增 13 個).

Closes #327