### PR TITLE
feat(home): 金錢時鐘 — hour-of-day 花費模式洞察 (Closes #329)

### DIFF
--- a/__tests__/hour-of-day.test.ts
+++ b/__tests__/hour-of-day.test.ts
@@ -1,0 +1,145 @@
+import { analyzeHourOfDay } from '@/lib/hour-of-day'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime()
+
+function mk(id: string, amount: number, daysAgo: number, hour: number): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  d.setHours(hour, 0, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('analyzeHourOfDay', () => {
+  it('returns null when days <= 0', () => {
+    expect(analyzeHourOfDay({ expenses: [], days: 0, now: NOW })).toBeNull()
+  })
+
+  it('returns null when below minExpenses', () => {
+    const expenses = Array.from({ length: 10 }, (_, i) => mk(String(i), 100, i, 12))
+    expect(
+      analyzeHourOfDay({ expenses, now: NOW, minExpenses: 30 }),
+    ).toBeNull()
+  })
+
+  it('aggregates by hour', () => {
+    // Use daysAgo>=1 to avoid future-time exclusion (NOW = today noon)
+    const expenses = [
+      ...Array.from({ length: 15 }, (_, i) => mk(`a${i}`, 200, i + 1, 12)),
+      ...Array.from({ length: 10 }, (_, i) => mk(`b${i}`, 300, i + 1, 19)),
+      ...Array.from({ length: 5 }, (_, i) => mk(`c${i}`, 100, i + 1, 9)),
+    ]
+    const r = analyzeHourOfDay({ expenses, days: 30, now: NOW })
+    expect(r).not.toBeNull()
+    expect(r!.hourBuckets[12]).toBe(15 * 200) // 3000
+    expect(r!.hourBuckets[19]).toBe(10 * 300) // 3000
+    expect(r!.hourBuckets[9]).toBe(500)
+  })
+
+  it('peakHour is hour with highest total amount', () => {
+    const expenses = [
+      ...Array.from({ length: 30 }, (_, i) => mk(`a${i}`, 200, i, 12)), // 12 = 6000
+      ...Array.from({ length: 5 }, (_, i) => mk(`b${i}`, 100, i, 18)), // 18 = 500
+    ]
+    const r = analyzeHourOfDay({ expenses, days: 30, now: NOW })
+    expect(r!.peakHour).toBe(12)
+  })
+
+  it('isUniform=true when distribution flat', () => {
+    // Spread across all 24 hours evenly
+    const expenses: Expense[] = []
+    for (let h = 0; h < 24; h++) {
+      for (let i = 0; i < 2; i++) {
+        expenses.push(mk(`${h}-${i}`, 100, i, h))
+      }
+    }
+    const r = analyzeHourOfDay({ expenses, now: NOW })
+    expect(r!.isUniform).toBe(true)
+  })
+
+  it('isUniform=false when peak is strong', () => {
+    const expenses = [
+      ...Array.from({ length: 30 }, (_, i) => mk(`peak${i}`, 500, i, 12)), // huge peak
+      ...Array.from({ length: 5 }, (_, i) => mk(`other${i}`, 50, i, 18)),
+    ]
+    const r = analyzeHourOfDay({ expenses, now: NOW })
+    expect(r!.isUniform).toBe(false)
+  })
+
+  it('segments cover all hours', () => {
+    const expenses = Array.from({ length: 30 }, (_, i) => mk(`a${i}`, 100, i, 12))
+    const r = analyzeHourOfDay({ expenses, now: NOW })
+    const totalShareAcrossSegments = r!.segments.reduce((s, seg) => s + seg.share, 0)
+    expect(totalShareAcrossSegments).toBeCloseTo(1)
+  })
+
+  it('skips expenses outside window', () => {
+    const expenses = [
+      ...Array.from({ length: 30 }, (_, i) => mk(`inside${i}`, 100, i, 12)),
+      mk('outside', 9999, 100, 3), // 100 days ago
+    ]
+    const r = analyzeHourOfDay({ expenses, days: 30, now: NOW })
+    expect(r!.totalAmount).toBe(30 * 100) // outside excluded
+  })
+
+  it('skips bad amount/date defensively', () => {
+    const bad = { ...mk('bad', 100, 0, 12), date: 'oops' } as unknown as Expense
+    const expenses = [
+      ...Array.from({ length: 30 }, (_, i) => mk(`v${i}`, 100, i, 12)),
+      mk('nan', NaN, 0, 12),
+      mk('zero', 0, 0, 12),
+      bad,
+    ]
+    const r = analyzeHourOfDay({ expenses, now: NOW })
+    expect(r!.count).toBe(30) // 3 bad excluded
+  })
+
+  it('lunch segment captures hours 11-14', () => {
+    const expenses = [
+      ...Array.from({ length: 10 }, (_, i) => mk(`a${i}`, 200, i + 1, 11)),
+      ...Array.from({ length: 10 }, (_, i) => mk(`b${i}`, 200, i + 1, 12)),
+      ...Array.from({ length: 10 }, (_, i) => mk(`c${i}`, 200, i + 1, 13)),
+      // 14 should NOT be in lunch (exclusive end)
+      ...Array.from({ length: 10 }, (_, i) => mk(`d${i}`, 200, i + 1, 14)),
+    ]
+    const r = analyzeHourOfDay({ expenses, now: NOW })
+    const lunch = r!.segments.find((s) => s.label.includes('午餐'))!
+    expect(lunch.total).toBe(30 * 200) // 11, 12, 13 only
+    const afternoon = r!.segments.find((s) => s.label.includes('下午'))!
+    expect(afternoon.total).toBe(10 * 200) // 14 onwards
+  })
+
+  it('handles all 24 hours represented in buckets', () => {
+    const expenses = Array.from({ length: 30 }, (_, i) => mk(`a${i}`, 100, i, 12))
+    const r = analyzeHourOfDay({ expenses, now: NOW })
+    expect(r!.hourBuckets.length).toBe(24)
+    expect(r!.hourCounts.length).toBe(24)
+  })
+
+  it('hourCounts reflect counts not amounts', () => {
+    const expenses = [
+      // Use daysAgo 0..29 (all within 30-day window, hour 9 always past today's noon)
+      ...Array.from({ length: 30 }, (_, i) => mk(`a${i}`, 1000, i, 9)),
+      // hour 10 still before today's noon — daysAgo=0 is past today
+      ...Array.from({ length: 5 }, (_, i) => mk(`b${i}`, 100, i, 10)),
+    ]
+    const r = analyzeHourOfDay({ expenses, now: NOW })
+    expect(r!.hourCounts[9]).toBe(30)
+    expect(r!.hourCounts[10]).toBe(5)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -21,6 +21,7 @@ import { SubscriptionSuggestions } from '@/components/subscription-suggestions'
 import { CatchupNudge } from '@/components/catchup-nudge'
 import { SpendingHeatmap } from '@/components/spending-heatmap'
 import { DowInsight } from '@/components/dow-insight'
+import { HourOfDayPattern } from '@/components/hour-of-day-pattern'
 import { RecordingStreak } from '@/components/recording-streak'
 import { MonthProjection } from '@/components/month-projection'
 import { CategoryMoM } from '@/components/category-mom'
@@ -287,6 +288,9 @@ export default function HomePage() {
 
       {/* 週幾花費模式洞察 (Issue #292) */}
       <DowInsight expenses={expenses} />
+
+      {/* 一天花費高峰 (Issue #329) — hour-of-day pattern */}
+      <HourOfDayPattern expenses={expenses} />
 
       {/* Dashboard grid: 桌面版 2 欄，手機版單欄 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 mt-4 md:mt-6">

--- a/src/components/hour-of-day-pattern.tsx
+++ b/src/components/hour-of-day-pattern.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useMemo } from 'react'
+import { analyzeHourOfDay } from '@/lib/hour-of-day'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface HourOfDayPatternProps {
+  expenses: Expense[]
+  /** Window length back from today. Default 30. */
+  days?: number
+}
+
+/**
+ * Hour-of-day spending pattern (Issue #329). Sub-day granularity — the
+ * one time scale no other widget covers. Renders silently when sample
+ * is too thin or distribution too uniform; the threshold check guards
+ * against noisy "noon-peak" insights from retroactive entries.
+ */
+export function HourOfDayPattern({ expenses, days = 30 }: HourOfDayPatternProps) {
+  const data = useMemo(
+    () => analyzeHourOfDay({ expenses, days }),
+    [expenses, days],
+  )
+
+  if (!data || data.isUniform) return null
+
+  const max = Math.max(...data.hourBuckets, 1)
+  const topSegments = [...data.segments]
+    .filter((s) => s.share >= 0.1)
+    .sort((a, b) => b.share - a.share)
+    .slice(0, 2)
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+        🕐 一天花費高峰（{days} 天分布）
+      </div>
+
+      {topSegments.length > 0 && (
+        <div className="space-y-1">
+          {topSegments.map((seg) => (
+            <p key={seg.start} className="text-sm text-[var(--foreground)]">
+              <span className="font-medium">{seg.label}</span> 佔 {Math.round(seg.share * 100)}%（
+              {currency(seg.total)}）
+            </p>
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-24 gap-px pt-1" style={{ gridTemplateColumns: 'repeat(24, 1fr)' }}>
+        {data.hourBuckets.map((amount, h) => {
+          const heightPct = max > 0 ? (amount / max) * 100 : 0
+          return (
+            <div
+              key={h}
+              className="flex flex-col items-center justify-end h-9"
+              title={`${String(h).padStart(2, '0')}:00 ${currency(amount)}`}
+            >
+              <div
+                className="w-full rounded-t-sm"
+                style={{
+                  height: `${heightPct}%`,
+                  minHeight: amount > 0 ? '2px' : '0',
+                  backgroundColor:
+                    h === data.peakHour
+                      ? 'var(--primary)'
+                      : 'color-mix(in oklch, var(--primary) 35%, transparent)',
+                }}
+                aria-label={`${h} 點 ${currency(amount)}`}
+              />
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="flex justify-between text-[10px] text-[var(--muted-foreground)]">
+        <span>0</span>
+        <span>6</span>
+        <span>12</span>
+        <span>18</span>
+        <span>24</span>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/hour-of-day.ts
+++ b/src/lib/hour-of-day.ts
@@ -1,0 +1,126 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface HourSegment {
+  /** Inclusive start hour 0..23. */
+  start: number
+  /** Exclusive end hour 0..24 (24 means end-of-day). */
+  end: number
+  label: string
+  total: number
+  share: number
+}
+
+export interface HourOfDayData {
+  /** Total amount per hour 0..23. */
+  hourBuckets: number[]
+  /** Count of expenses per hour 0..23. */
+  hourCounts: number[]
+  /** Hour with max amount. */
+  peakHour: number
+  /** Total amount across all hours. */
+  totalAmount: number
+  /** Curated 4-segment summary (morning, lunch, afternoon, evening, night). */
+  segments: HourSegment[]
+  /** Whether distribution is too uniform to be insightful. */
+  isUniform: boolean
+  /** Number of expenses contributing. */
+  count: number
+}
+
+interface AnalyzeOptions {
+  expenses: Expense[]
+  days?: number
+  now?: number
+  /** Min expenses required. Default 30. */
+  minExpenses?: number
+  /** Min peakAmount/avgAmount ratio to deem "non-uniform". Default 2. */
+  uniformityRatio?: number
+}
+
+const SEGMENT_DEFS: ReadonlyArray<{ start: number; end: number; label: string }> = [
+  { start: 6, end: 11, label: '清晨/早晨 (6-11)' },
+  { start: 11, end: 14, label: '午餐時段 (11-14)' },
+  { start: 14, end: 18, label: '下午 (14-18)' },
+  { start: 18, end: 22, label: '晚餐/通勤 (18-22)' },
+  { start: 22, end: 24, label: '深夜 (22-24)' },
+  { start: 0, end: 6, label: '凌晨 (0-6)' },
+]
+
+/**
+ * Hour-of-day spending pattern over a rolling window. Granularity below
+ * a single day — distinct from heatmap (per-day), DowInsight (per-week-
+ * day). Returns null when sample is too thin or distribution is too
+ * uniform to surface meaningful structure.
+ *
+ * Hour data quality is noisy because retroactive entries default to
+ * noon-ish, so the threshold check guards against false-positive
+ * "noon-peak" insights.
+ */
+export function analyzeHourOfDay({
+  expenses,
+  days = 30,
+  now = Date.now(),
+  minExpenses = 30,
+  uniformityRatio = 2,
+}: AnalyzeOptions): HourOfDayData | null {
+  if (!Number.isFinite(days) || days <= 0) return null
+
+  const cutoff = now - days * 86_400_000
+  const hourBuckets = Array<number>(24).fill(0)
+  const hourCounts = Array<number>(24).fill(0)
+  let count = 0
+  let totalAmount = 0
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    const ts = d.getTime()
+    if (!Number.isFinite(ts) || ts < cutoff || ts > now) continue
+    const hour = d.getHours()
+    if (hour < 0 || hour > 23) continue
+    hourBuckets[hour] += amount
+    hourCounts[hour]++
+    count++
+    totalAmount += amount
+  }
+
+  if (count < minExpenses || totalAmount <= 0) return null
+
+  let peakHour = 0
+  for (let h = 1; h < 24; h++) {
+    if (hourBuckets[h] > hourBuckets[peakHour]) peakHour = h
+  }
+
+  const avgAmount = totalAmount / 24
+  const peakAmount = hourBuckets[peakHour]
+  const isUniform = avgAmount > 0 ? peakAmount / avgAmount < uniformityRatio : true
+
+  const segments: HourSegment[] = SEGMENT_DEFS.map((seg) => {
+    let total = 0
+    for (let h = seg.start; h < seg.end; h++) total += hourBuckets[h]
+    return {
+      start: seg.start,
+      end: seg.end,
+      label: seg.label,
+      total,
+      share: totalAmount > 0 ? total / totalAmount : 0,
+    }
+  })
+
+  return {
+    hourBuckets,
+    hourCounts,
+    peakHour,
+    totalAmount,
+    segments,
+    isUniform,
+    count,
+  }
+}


### PR DESCRIPTION
## 為什麼

DowInsight (#292) 揭露**週幾**模式。但**一天之內幾點**最常花錢從未被觀察。

午休時段、下班高峰、深夜消費——這些時段差異對個人理財自我覺察有意義（「我都在凌晨網購？」）。

## 視角差異

| Widget | 時間粒度 |
|--------|---------|
| SpendingHeatmap (#290) | 每**天** |
| DowInsight (#292) | 每**週幾** |
| YearHeatmap (#313) | 每**天**（年度） |
| **HourOfDay (#329)** | **每**小時 |

第一個 sub-day 時間粒度。

## 做了什麼

`src/lib/hour-of-day.ts` — 純函式：
- 滾動 30 天視窗
- 24 個 hour buckets (total + count)
- 6 個 segments（清晨/午餐/下午/晚餐/深夜/凌晨）
- **isUniform 判定**：peakAmount / avgAmount < 2 → 視為平均 → null（防止 noisy retroactive 資料造成假 noon-peak）
- minExpenses 30 才產生資料

`src/components/hour-of-day-pattern.tsx` — UI：
- 24-hour mini bar chart
- peak hour 用 primary 色突顯
- top 2 顯著 segments inline 敘事

## 範例輸出

> 🕐 一天花費高峰（30 天分布）
>
> 午餐時段 (11-14) 佔 35%（NT\$5,200）
> 晚餐/通勤 (18-22) 佔 25%（NT\$3,700）
>
> [24-hour mini bar chart]
>   0    6    12    18    24

## 測試

12 個單元測試 ✅
- days <= 0 / minExpenses → null
- aggregation by hour
- peakHour identification
- isUniform true / false
- segments cover all 24 hours
- 視窗排除
- bad amount/date defensive
- 午餐 segment 邊界 (11-14 exclusive)
- 24 hours represented
- hourCounts vs amount

整套：1298/1298 passed (新增 12 個).

Closes #329