### PR TITLE
feat(home): 週對週支出加速警告 — 短期 acceleration banner (Closes #331)

### DIFF
--- a/__tests__/wow-acceleration.test.ts
+++ b/__tests__/wow-acceleration.test.ts
@@ -1,0 +1,161 @@
+import { checkWowAcceleration } from '@/lib/wow-acceleration'
+import type { Expense } from '@/lib/types'
+
+// April 15, 2026 = Wednesday → Monday is April 13
+// Previous week: April 6 (Mon) - April 12 (Sun)
+// Current week so far: April 13 - April 15 (3 days into week)
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime()
+
+function mkOnDate(id: string, amount: number, year: number, month: number, day: number): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('checkWowAcceleration', () => {
+  it('returns null when too early in week (< minDaysIntoWeek)', () => {
+    // Monday April 13, 2026 = day 1 of week → minDays default 2 → null
+    const monday = new Date(2026, 3, 13, 12, 0, 0).getTime()
+    const expenses = [
+      mkOnDate('curr', 1500, 2026, 3, 13),
+      mkOnDate('prev', 500, 2026, 3, 6),
+    ]
+    expect(checkWowAcceleration({ expenses, now: monday })).toBeNull()
+  })
+
+  it('returns null when previous week has no spending', () => {
+    const expenses = [mkOnDate('curr', 1000, 2026, 3, 14)]
+    expect(checkWowAcceleration({ expenses, now: NOW })).toBeNull()
+  })
+
+  it('returns null when current week has no spending', () => {
+    const expenses = [mkOnDate('prev', 1000, 2026, 3, 8)]
+    expect(checkWowAcceleration({ expenses, now: NOW })).toBeNull()
+  })
+
+  it('returns null when not accelerating (< 1.5x trigger)', () => {
+    // Prev week 7000, curr 3 days = 2000 → est 4666.67, ratio = 0.67 → no fire
+    const expenses = [
+      mkOnDate('prev', 7000, 2026, 3, 8),
+      mkOnDate('curr', 2000, 2026, 3, 14),
+    ]
+    expect(checkWowAcceleration({ expenses, now: NOW })).toBeNull()
+  })
+
+  it('returns mild warning at >= 1.5x', () => {
+    // Prev: 1000. Curr: 750 over 3 days → est 1750, ratio 1.75 → mild
+    const expenses = [
+      mkOnDate('prev', 1000, 2026, 3, 8),
+      mkOnDate('curr', 750, 2026, 3, 14),
+    ]
+    const r = checkWowAcceleration({ expenses, now: NOW })
+    expect(r).not.toBeNull()
+    expect(r!.severity).toBe('mild')
+    expect(r!.previousWeekTotal).toBe(1000)
+    expect(r!.currentWeekTotal).toBe(750)
+    expect(r!.daysIntoWeek).toBe(3) // Mon, Tue, Wed
+    expect(r!.estimatedFullWeek).toBeCloseTo(1750)
+  })
+
+  it('returns sharp warning at >= 2x', () => {
+    // Prev 500, curr 1500 over 3 days → est 3500, ratio 7 → sharp
+    const expenses = [
+      mkOnDate('prev', 500, 2026, 3, 8),
+      mkOnDate('curr', 1500, 2026, 3, 14),
+    ]
+    const r = checkWowAcceleration({ expenses, now: NOW })
+    expect(r!.severity).toBe('sharp')
+  })
+
+  it('counts only Mon-Sun previous week', () => {
+    // Prev Sunday April 5, prev Monday April 6
+    // April 5 (Sun) is in week-before-prev — should be excluded
+    const expenses = [
+      mkOnDate('beforeprev', 9999, 2026, 3, 5), // April 5 Sunday — excluded
+      mkOnDate('prev', 1000, 2026, 3, 8), // April 8 — prev week
+      mkOnDate('curr', 750, 2026, 3, 14), // April 14 — curr week
+    ]
+    const r = checkWowAcceleration({ expenses, now: NOW })
+    expect(r!.previousWeekTotal).toBe(1000) // 9999 excluded
+  })
+
+  it('respects custom triggerThreshold', () => {
+    const expenses = [
+      mkOnDate('prev', 1000, 2026, 3, 8),
+      mkOnDate('curr', 500, 2026, 3, 14), // 3 days → est 1166, ratio 1.17
+    ]
+    expect(
+      checkWowAcceleration({ expenses, now: NOW, triggerThreshold: 1.1 }),
+    ).not.toBeNull()
+    expect(
+      checkWowAcceleration({ expenses, now: NOW, triggerThreshold: 1.2 }),
+    ).toBeNull()
+  })
+
+  it('skips bad amount/date defensively', () => {
+    const bad = { ...mkOnDate('bad', 100, 2026, 3, 14), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mkOnDate('prev', 500, 2026, 3, 8),
+      mkOnDate('curr', 750, 2026, 3, 14),
+      mkOnDate('nan', NaN, 2026, 3, 14),
+      mkOnDate('zero', 0, 2026, 3, 14),
+      bad,
+    ]
+    const r = checkWowAcceleration({ expenses, now: NOW })
+    expect(r!.currentWeekTotal).toBe(750)
+  })
+
+  it('handles Sunday as last day of week', () => {
+    // April 12, 2026 = Sunday — Sunday belongs to previous-week (since Mon is week start)
+    const sunday = new Date(2026, 3, 12, 12, 0, 0).getTime()
+    // For sunday now: Monday of week containing Sunday = April 6
+    // Previous Mon-Sun: March 30 - April 5
+    const expenses = [
+      mkOnDate('prev', 500, 2026, 3, 1), // April 1 (Wed) — in prev week (Mar 30-Apr 5)
+      mkOnDate('curr', 1500, 2026, 3, 8), // April 8 (Wed) — in curr week (Apr 6-12)
+    ]
+    const r = checkWowAcceleration({ expenses, now: sunday })
+    // Day 7 of week (Sunday) → daysIntoWeek = 7
+    expect(r!.daysIntoWeek).toBe(7)
+    expect(r!.previousWeekTotal).toBe(500)
+    expect(r!.currentWeekTotal).toBe(1500)
+    expect(r!.estimatedFullWeek).toBe(1500) // already full week
+  })
+
+  it('does not count expenses dated past today', () => {
+    const expenses = [
+      mkOnDate('prev', 1000, 2026, 3, 8),
+      mkOnDate('past', 750, 2026, 3, 14),
+      mkOnDate('future', 9999, 2026, 3, 17), // April 17 — future of NOW (Apr 15)
+    ]
+    const r = checkWowAcceleration({ expenses, now: NOW })
+    expect(r!.currentWeekTotal).toBe(750) // future excluded
+  })
+
+  it('estimatedFullWeek extrapolation correct', () => {
+    // 2 days into week, spent 800 → est 800/2*7 = 2800
+    const tuesday = new Date(2026, 3, 14, 12, 0, 0).getTime()
+    const expenses = [
+      mkOnDate('prev', 1000, 2026, 3, 8),
+      mkOnDate('curr', 800, 2026, 3, 14),
+    ]
+    const r = checkWowAcceleration({ expenses, now: tuesday })
+    expect(r!.daysIntoWeek).toBe(2)
+    expect(r!.estimatedFullWeek).toBe(2800)
+  })
+})

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -32,6 +32,7 @@ import { TodayInPastYears } from '@/components/today-in-past-years'
 import { SameMonthLastYear } from '@/components/same-month-last-year'
 import { NextMonthLockedIn } from '@/components/next-month-locked-in'
 import { BudgetOverrunAlert } from '@/components/budget-overrun-alert'
+import { WowAccelerationAlert } from '@/components/wow-acceleration-alert'
 import { useRecurringExpenses } from '@/lib/hooks/use-recurring-expenses'
 import { generatePendingRecurring, confirmPendingExpense } from '@/lib/services/recurring-generator'
 import { maybeSendBudgetAlert } from '@/lib/services/budget-alert-service'
@@ -201,6 +202,9 @@ export default function HomePage() {
 
       {/* 預算超支預警 (Issue #321) — 預估月底超預算時主動 banner */}
       <BudgetOverrunAlert expenses={expenses} group={group} />
+
+      {/* 週對週加速預警 (Issue #331) — 本週支出 >= 1.5× 上週 */}
+      <WowAccelerationAlert expenses={expenses} />
 
       {/* Catch-up 提醒 (Issue #288) — 超過 3 天沒記時溫和提示 */}
       <CatchupNudge expenses={expenses} />

--- a/src/components/wow-acceleration-alert.tsx
+++ b/src/components/wow-acceleration-alert.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useMemo } from 'react'
+import { checkWowAcceleration } from '@/lib/wow-acceleration'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface WowAccelerationAlertProps {
+  expenses: Expense[]
+}
+
+/**
+ * Short-horizon WoW acceleration banner (Issue #331). Triggers when
+ * this-week's extrapolated total ≥1.5× last week. Acts as an early
+ * version of BudgetOverrunAlert (#321) — week-level signal often
+ * precedes month-level budget breach by 1-2 weeks.
+ */
+export function WowAccelerationAlert({ expenses }: WowAccelerationAlertProps) {
+  const data = useMemo(
+    () => checkWowAcceleration({ expenses }),
+    [expenses],
+  )
+
+  if (!data) return null
+
+  const isSharp = data.severity === 'sharp'
+  const pctText = `+${Math.round(data.deltaPct * 100)}%`
+
+  return (
+    <div
+      className="rounded-2xl border p-4 space-y-1.5 animate-fade-up"
+      style={{
+        borderColor: isSharp
+          ? 'color-mix(in oklch, var(--destructive), var(--card) 60%)'
+          : 'color-mix(in oklch, oklch(0.80 0.15 75), var(--card) 65%)',
+        backgroundColor: isSharp
+          ? 'color-mix(in oklch, var(--destructive), var(--card) 88%)'
+          : 'color-mix(in oklch, oklch(0.85 0.10 75), var(--card) 88%)',
+      }}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 text-sm font-semibold">
+        <span aria-hidden>⚡</span>
+        <span>
+          本週花費加速：
+          <span className="font-bold">{currency(data.currentWeekTotal)}</span>{' '}
+          <span className="text-xs">（上週 {currency(data.previousWeekTotal)}，{pctText}）</span>
+        </span>
+      </div>
+      <p className="text-xs text-[var(--muted-foreground)]">
+        已過 {data.daysIntoWeek} 天｜照目前速度全週估計{' '}
+        <span className="text-[var(--foreground)]">{currency(data.estimatedFullWeek)}</span>
+      </p>
+    </div>
+  )
+}

--- a/src/lib/wow-acceleration.ts
+++ b/src/lib/wow-acceleration.ts
@@ -1,0 +1,113 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export type WowSeverity = 'mild' | 'sharp'
+
+export interface WowAccelerationData {
+  /** Sum of current week so far. */
+  currentWeekTotal: number
+  /** Sum of previous full week (Mon-Sun). */
+  previousWeekTotal: number
+  /** Days into current week (1..7). */
+  daysIntoWeek: number
+  /** Linear extrapolation: currentWeekTotal × 7 / daysIntoWeek. */
+  estimatedFullWeek: number
+  /** estimatedFullWeek - previousWeekTotal. */
+  delta: number
+  /** delta / previousWeekTotal. */
+  deltaPct: number
+  /** 'mild' for ≥1.5×, 'sharp' for ≥2×. */
+  severity: WowSeverity
+}
+
+interface CheckOptions {
+  expenses: Expense[]
+  now?: number
+  /** Min days into current week before checking. Default 2. */
+  minDaysIntoWeek?: number
+  /** Trigger threshold (estimated full-week / previous). Default 1.5. */
+  triggerThreshold?: number
+  /** Sharp threshold. Default 2.0. */
+  sharpThreshold?: number
+}
+
+/**
+ * Returns the start-of-day Date for the Monday of the calendar week
+ * containing `d` (Mon..Sun convention, so Sunday belongs to the previous week).
+ */
+function mondayOf(d: Date): Date {
+  const x = new Date(d)
+  x.setHours(0, 0, 0, 0)
+  const dow = x.getDay() // Sun=0..Sat=6
+  const daysSinceMonday = dow === 0 ? 6 : dow - 1
+  x.setDate(x.getDate() - daysSinceMonday)
+  return x
+}
+
+/**
+ * Short-horizon acceleration warning. Triggers when this-week's
+ * extrapolated total exceeds last week's by ≥1.5×. Acts as an early
+ * version of BudgetOverrunAlert (#321) — if the user is accelerating,
+ * they'll usually overshoot the budget in 1-2 weeks.
+ */
+export function checkWowAcceleration({
+  expenses,
+  now = Date.now(),
+  minDaysIntoWeek = 2,
+  triggerThreshold = 1.5,
+  sharpThreshold = 2.0,
+}: CheckOptions): WowAccelerationData | null {
+  const today = new Date(now)
+  const thisMonday = mondayOf(today)
+  const prevMonday = new Date(thisMonday)
+  prevMonday.setDate(prevMonday.getDate() - 7)
+  const prevSunday = new Date(thisMonday.getTime() - 1)
+
+  const daysIntoWeek = Math.floor(
+    (today.getTime() - thisMonday.getTime()) / 86_400_000,
+  ) + 1
+
+  if (daysIntoWeek < minDaysIntoWeek) return null
+
+  let currentWeekTotal = 0
+  let previousWeekTotal = 0
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    const ts = d.getTime()
+    if (!Number.isFinite(ts)) continue
+    if (ts >= thisMonday.getTime() && ts <= now) {
+      currentWeekTotal += amount
+    } else if (ts >= prevMonday.getTime() && ts <= prevSunday.getTime()) {
+      previousWeekTotal += amount
+    }
+  }
+
+  if (previousWeekTotal <= 0) return null
+  if (currentWeekTotal <= 0) return null
+
+  const estimatedFullWeek = (currentWeekTotal / daysIntoWeek) * 7
+  const ratio = estimatedFullWeek / previousWeekTotal
+  if (ratio < triggerThreshold) return null
+
+  const severity: WowSeverity = ratio >= sharpThreshold ? 'sharp' : 'mild'
+  const delta = estimatedFullWeek - previousWeekTotal
+  const deltaPct = delta / previousWeekTotal
+
+  return {
+    currentWeekTotal,
+    previousWeekTotal,
+    daysIntoWeek,
+    estimatedFullWeek,
+    delta,
+    deltaPct,
+    severity,
+  }
+}


### PR DESCRIPTION
## 為什麼

BudgetOverrunAlert (#321) 是月度預警。但**短期** acceleration（這週突然多花）反而是**早期信號**——通常先在週度顯現，週後才推月度預警。

## 視角差異

| Widget | 時間粒度 | 性質 |
|--------|---------|------|
| BudgetOverrunAlert (#321) | 月度 | 事後（已快超預算） |
| **WowAcceleration (#331)** | **週度** | **事前 1-2 週信號** |

短期補長期——快發現快調整。

## 做了什麼

`src/lib/wow-acceleration.ts` — 純函式：
- Mon-Sun 週切分
- estimatedFullWeek = currentWeek / daysIntoWeek × 7
- **mild**: ≥1.5×｜**sharp**: ≥2.0×
- minDaysIntoWeek 預設 2（週一樣本不足不觸發）
- 跳過 future、bad data

`src/components/wow-acceleration-alert.tsx` — UI banner：
- ⚡ icon + 兩級 severity 著色
- 本週 vs 上週 + 全週 extrapolation

## 範例輸出

> ⚡ 本週花費加速：NT\$2,800（上週 NT\$1,500，+87%）
> 已過 4 天｜照目前速度全週估計 NT\$4,900

## 測試

12 個單元測試 ✅
- minDaysIntoWeek threshold
- 無上週/本週 → null
- < 1.5x → null
- mild / sharp severity
- Mon-Sun 邊界（含 Sunday=day 7）
- custom threshold
- bad data defensive
- future date 排除
- extrapolation 正確

整套：1310/1310 passed (新增 12 個).

Closes #331