### PR TITLE
feat(quick-add): Category chips 按使用頻率智能排序 (Closes #336)

### DIFF
--- a/__tests__/category-order.test.ts
+++ b/__tests__/category-order.test.ts
@@ -1,0 +1,181 @@
+import { sortCategoriesByFrequency } from '@/lib/category-order'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime()
+
+function mk(id: string, daysAgo: number, category: string): Expense {
+  const d = new Date(NOW - daysAgo * 86_400_000)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount: 100,
+    category,
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('sortCategoriesByFrequency', () => {
+  it('returns empty array for empty categories', () => {
+    expect(sortCategoriesByFrequency({ categories: [], expenses: [], now: NOW })).toEqual([])
+  })
+
+  it('preserves original order when no expenses', () => {
+    const r = sortCategoriesByFrequency({
+      categories: ['餐飲', '交通', '購物'],
+      expenses: [],
+      now: NOW,
+    })
+    expect(r).toEqual(['餐飲', '交通', '購物'])
+  })
+
+  it('sorts by count desc', () => {
+    const expenses = [
+      ...Array.from({ length: 10 }, (_, i) => mk(`a${i}`, i, '交通')),
+      ...Array.from({ length: 5 }, (_, i) => mk(`b${i}`, i, '餐飲')),
+      ...Array.from({ length: 2 }, (_, i) => mk(`c${i}`, i, '購物')),
+    ]
+    const r = sortCategoriesByFrequency({
+      categories: ['餐飲', '交通', '購物'],
+      expenses,
+      now: NOW,
+    })
+    expect(r).toEqual(['交通', '餐飲', '購物'])
+  })
+
+  it('preserves original order for ties', () => {
+    const expenses = [
+      mk('a', 0, '餐飲'),
+      mk('b', 0, '交通'),
+      mk('c', 0, '購物'),
+    ]
+    const r = sortCategoriesByFrequency({
+      categories: ['購物', '餐飲', '交通'],
+      expenses,
+      now: NOW,
+    })
+    // All 1 count → keep original ['購物', '餐飲', '交通']
+    expect(r).toEqual(['購物', '餐飲', '交通'])
+  })
+
+  it('unused categories sort to end (preserving relative order)', () => {
+    const expenses = Array.from({ length: 5 }, (_, i) => mk(`a${i}`, i, '交通'))
+    const r = sortCategoriesByFrequency({
+      categories: ['餐飲', '交通', '購物'],
+      expenses,
+      now: NOW,
+    })
+    // 交通 first, then 餐飲, 購物 (both unused, original order)
+    expect(r).toEqual(['交通', '餐飲', '購物'])
+  })
+
+  it('does not mutate input arrays', () => {
+    const cats = ['餐飲', '交通']
+    const exps = [mk('a', 0, '交通')]
+    const original = cats.slice()
+    sortCategoriesByFrequency({ categories: cats, expenses: exps, now: NOW })
+    expect(cats).toEqual(original)
+  })
+
+  it('respects days window', () => {
+    const expenses = [
+      mk('recent', 5, '餐飲'),
+      mk('old', 60, '交通'), // outside default 30 days
+    ]
+    const r = sortCategoriesByFrequency({
+      categories: ['餐飲', '交通'],
+      expenses,
+      days: 30,
+      now: NOW,
+    })
+    expect(r[0]).toBe('餐飲')
+  })
+
+  it('skips bad amount/date', () => {
+    const bad = { ...mk('bad', 1, '交通'), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mk('a', 1, '餐飲'),
+      mk('b', 1, '餐飲'),
+      mk('c', 1, '交通'),
+      mk('zero', 1, '交通'),
+      bad,
+    ]
+    // Adjust: bad date → excluded; zero amount → check
+    const expensesAdjusted = [
+      mk('a', 1, '餐飲'),
+      mk('b', 1, '餐飲'),
+      mk('c', 1, '交通'),
+      { ...mk('zero', 1, '交通'), amount: 0 } as unknown as Expense,
+      bad,
+    ]
+    const r = sortCategoriesByFrequency({
+      categories: ['餐飲', '交通'],
+      expenses: expensesAdjusted,
+      now: NOW,
+    })
+    expect(r).toEqual(['餐飲', '交通']) // 餐飲=2, 交通=1 (bad+zero excluded)
+  })
+
+  it('skips empty category strings', () => {
+    const expenses = [
+      mk('a', 1, '餐飲'),
+      mk('b', 1, ''),
+      mk('c', 1, '   '),
+    ]
+    const r = sortCategoriesByFrequency({
+      categories: ['餐飲', '交通'],
+      expenses,
+      now: NOW,
+    })
+    expect(r[0]).toBe('餐飲') // empty/whitespace not counted
+  })
+
+  it('counts expenses not amount totals', () => {
+    // 1 expense @ 5000 vs 5 expenses @ 100 → 5 wins
+    const expenses = [
+      { ...mk('big', 0, '餐飲'), amount: 5000 } as unknown as Expense,
+      ...Array.from({ length: 5 }, (_, i) => mk(`small${i}`, i, '交通')),
+    ]
+    const r = sortCategoriesByFrequency({
+      categories: ['餐飲', '交通'],
+      expenses,
+      now: NOW,
+    })
+    expect(r[0]).toBe('交通') // 5 count > 1 count
+  })
+
+  it('handles future-dated expenses (excludes them)', () => {
+    const expenses = [
+      mk('past', 5, '餐飲'),
+      mk('future', -10, '交通'), // future
+    ]
+    const r = sortCategoriesByFrequency({
+      categories: ['餐飲', '交通'],
+      expenses,
+      now: NOW,
+    })
+    expect(r[0]).toBe('餐飲')
+  })
+
+  it('handles category names with extra whitespace', () => {
+    const expenses = [
+      mk('a', 1, '餐飲 '), // trailing space
+      mk('b', 1, ' 餐飲'), // leading space
+    ]
+    const r = sortCategoriesByFrequency({
+      categories: ['餐飲', '交通'],
+      expenses,
+      now: NOW,
+    })
+    expect(r[0]).toBe('餐飲') // trim normalizes
+  })
+})

--- a/src/components/quick-add-bar.tsx
+++ b/src/components/quick-add-bar.tsx
@@ -7,6 +7,7 @@ import { useMembers } from '@/lib/hooks/use-members'
 import { useCategories } from '@/lib/hooks/use-categories'
 import { useCurrentMember } from '@/lib/hooks/use-current-member'
 import { useExpenses, useRecentExpenses } from '@/lib/hooks/use-expenses'
+import { sortCategoriesByFrequency } from '@/lib/category-order'
 import { useAuth } from '@/lib/auth'
 import { addExpense, type ExpenseInput } from '@/lib/services/expense-service'
 import { parseExpense } from '@/lib/services/local-expense-parser'
@@ -83,10 +84,11 @@ export function QuickAddBar() {
     speech.reset()
   }, [speech.error, speech, addToast])
 
-  const activeCategories = useMemo(
-    () => categories.filter((c) => c.isActive).map((c) => c.name).slice(0, 6),
-    [categories],
-  )
+  const activeCategories = useMemo(() => {
+    const active = categories.filter((c) => c.isActive).map((c) => c.name)
+    const sorted = sortCategoriesByFrequency({ categories: active, expenses })
+    return sorted.slice(0, 6)
+  }, [categories, expenses])
 
   const draftKey = buildDraftKey(group?.id, user?.uid)
 

--- a/src/lib/category-order.ts
+++ b/src/lib/category-order.ts
@@ -1,0 +1,56 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+interface SortOptions {
+  categories: string[]
+  expenses: Expense[]
+  /** Days back to consider for frequency. Default 30. */
+  days?: number
+  /** Now in epoch ms; defaults to Date.now(). */
+  now?: number
+}
+
+/**
+ * Reorder a list of category names by recent usage frequency. The result
+ * preserves all input categories (no drops) — categories that haven't been
+ * used recently keep their original relative order, sorted to the end.
+ *
+ * Pure: input arrays are not mutated.
+ */
+export function sortCategoriesByFrequency({
+  categories,
+  expenses,
+  days = 30,
+  now = Date.now(),
+}: SortOptions): string[] {
+  if (categories.length === 0) return []
+
+  const cutoff = now - days * 86_400_000
+  const counts = new Map<string, number>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    const ts = d.getTime()
+    if (!Number.isFinite(ts) || ts < cutoff || ts > now) continue
+    const cat = (e.category || '').trim()
+    if (!cat) continue
+    counts.set(cat, (counts.get(cat) ?? 0) + 1)
+  }
+
+  const indexInOriginal = new Map<string, number>()
+  categories.forEach((c, i) => indexInOriginal.set(c, i))
+
+  return categories.slice().sort((a, b) => {
+    const ca = counts.get(a) ?? 0
+    const cb = counts.get(b) ?? 0
+    if (ca !== cb) return cb - ca
+    return (indexInOriginal.get(a) ?? 0) - (indexInOriginal.get(b) ?? 0)
+  })
+}


### PR DESCRIPTION
## 為什麼

Quick-add bar 的 category chips 目前按 category 列表原始順序顯示。但每個家庭的「熱門類別」不同——爸爸常 餐飲/交通，媽媽常 日用品/水果。

按**過去 30 天使用頻率**排序，個人化 chips 順序，最常用的放前面 → 一鍵節省滑動。

## 做了什麼

`src/lib/category-order.ts` — 純函式：
- 計算每個 category 過去 30 天 expense 出現次數
- count desc，break tie 用原始 index
- 沒用過的維持原順序排到後面
- 跳過 future、bad amount/date、empty category
- trim normalize（'餐飲 ' 與 ' 餐飲' 同視）
- 不 mutate input arrays

`src/components/quick-add-bar.tsx`：activeCategories 改用排序版本。

## 為什麼是它

- Pure UX 改進——使用者最常按的 chip 永遠在第 1 位
- **不增加 widget，不增加 noise**
- 純函式可單元測試
- 個人化（每個家庭/使用者體驗不同）

## 測試

12 個單元測試 ✅
- 空陣列 / 無 expense → 維持原順序
- count desc 排序
- tie 用原始 index
- 未用 cat 排到後面
- days 視窗
- bad amount/date defensive
- 空字串 category 跳過
- 計數 expense 而非金額（1 筆 5000 vs 5 筆 100 → 5 筆勝出）
- future date 排除
- whitespace normalize

整套：1334/1334 passed (新增 12 個).

Closes #336