### PR TITLE
feat(expense-form): 大金額顯示中文大寫 inline 提示 (Closes #338)

### DIFF
--- a/__tests__/chinese-numeral.test.ts
+++ b/__tests__/chinese-numeral.test.ts
@@ -1,0 +1,75 @@
+import { toChineseNumeral } from '@/lib/chinese-numeral'
+
+describe('toChineseNumeral', () => {
+  it('returns empty string for invalid input', () => {
+    expect(toChineseNumeral(NaN)).toBe('')
+    expect(toChineseNumeral(Infinity)).toBe('')
+    expect(toChineseNumeral(-100)).toBe('')
+    expect(toChineseNumeral(0)).toBe('')
+  })
+
+  it('handles single digits', () => {
+    expect(toChineseNumeral(1)).toBe('壹元')
+    expect(toChineseNumeral(5)).toBe('伍元')
+    expect(toChineseNumeral(9)).toBe('玖元')
+  })
+
+  it('handles tens', () => {
+    expect(toChineseNumeral(10)).toBe('壹拾元')
+    expect(toChineseNumeral(25)).toBe('貳拾伍元')
+    expect(toChineseNumeral(99)).toBe('玖拾玖元')
+  })
+
+  it('handles hundreds', () => {
+    expect(toChineseNumeral(100)).toBe('壹佰元')
+    expect(toChineseNumeral(123)).toBe('壹佰貳拾參元')
+    expect(toChineseNumeral(105)).toBe('壹佰零伍元')
+  })
+
+  it('handles thousands', () => {
+    expect(toChineseNumeral(1000)).toBe('壹仟元')
+    expect(toChineseNumeral(1234)).toBe('壹仟貳佰參拾肆元')
+    expect(toChineseNumeral(1005)).toBe('壹仟零伍元')
+  })
+
+  it('handles ten-thousands (萬)', () => {
+    expect(toChineseNumeral(10000)).toBe('壹萬元')
+    expect(toChineseNumeral(12345)).toBe('壹萬貳仟參佰肆拾伍元')
+    expect(toChineseNumeral(10001)).toBe('壹萬零壹元')
+  })
+
+  it('handles hundred-thousands', () => {
+    expect(toChineseNumeral(100000)).toBe('壹拾萬元')
+    expect(toChineseNumeral(123456)).toBe('壹拾貳萬參仟肆佰伍拾陸元')
+  })
+
+  it('handles million-range (億)', () => {
+    expect(toChineseNumeral(100000000)).toBe('壹億元')
+    expect(toChineseNumeral(123456789)).toBe('壹億貳仟參佰肆拾伍萬陸仟柒佰捌拾玖元')
+  })
+
+  it('handles decimals (角分)', () => {
+    expect(toChineseNumeral(0.5)).toBe('零元伍角')
+    expect(toChineseNumeral(0.05)).toBe('零元伍分')
+    expect(toChineseNumeral(0.55)).toBe('零元伍角伍分')
+    expect(toChineseNumeral(1.5)).toBe('壹元伍角')
+    expect(toChineseNumeral(1234.56)).toBe('壹仟貳佰參拾肆元伍角陸分')
+  })
+
+  it('rounds decimal to 2 places', () => {
+    expect(toChineseNumeral(1.234)).toBe('壹元貳角參分')
+    expect(toChineseNumeral(1.235)).toBe('壹元貳角肆分') // round half to even / up
+  })
+
+  it('handles values beyond 兆 by returning empty (out-of-range)', () => {
+    // 1 兆兆 = 10^16 way beyond 4 sections
+    const huge = 1e20
+    expect(toChineseNumeral(huge)).toBe('')
+  })
+
+  it('handles 萬 boundary correctly', () => {
+    // 100000000 = 1億, NOT 10000萬
+    expect(toChineseNumeral(100000000)).toBe('壹億元')
+    expect(toChineseNumeral(99999999)).toBe('玖仟玖佰玖拾玖萬玖仟玖佰玖拾玖元')
+  })
+})

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -23,6 +23,7 @@ import { findPossibleDuplicate } from '@/lib/duplicate-expense-detector'
 import { detectAmountOutlier } from '@/lib/amount-outlier'
 import { evaluateAmountExpression } from '@/lib/amount-expression'
 import { AmountChips } from '@/components/amount-chips'
+import { toChineseNumeral } from '@/lib/chinese-numeral'
 import { hapticFeedback } from '@/lib/haptic'
 import { findLastExpenseByCategory, relativeDays } from '@/lib/last-category-expense'
 import { currency as fmtCurrency } from '@/lib/utils'
@@ -709,6 +710,21 @@ export function ExpenseForm({ existingExpense, duplicateFrom, initialDate, onSav
             className="w-full h-11 rounded-lg border border-[var(--border)] bg-[var(--card)] pl-12 pr-3 text-sm" />
         </div>
         <AmountChips value={amount} onChange={setAmount} className="mt-2" />
+        {/* 中文大寫提示 (Issue #338) — 大金額正式記錄用 */}
+        {(() => {
+          const evaluated = parseFloat(amount)
+          if (!Number.isFinite(evaluated) || evaluated < 1000) return null
+          const chinese = toChineseNumeral(evaluated)
+          if (!chinese) return null
+          return (
+            <p
+              className="mt-1.5 text-xs text-[var(--muted-foreground)] italic"
+              title="中文大寫（紅包/支票格式）"
+            >
+              大寫：{chinese}
+            </p>
+          )
+        })()}
       </div>
 
       {/* Possible-duplicate warning (Issue #211). Shown only when description +

--- a/src/lib/chinese-numeral.ts
+++ b/src/lib/chinese-numeral.ts
@@ -1,0 +1,93 @@
+const DIGITS = ['零', '壹', '貳', '參', '肆', '伍', '陸', '柒', '捌', '玖']
+const SECTION_UNITS = ['', '萬', '億', '兆']
+const PLACE_UNITS = ['', '拾', '佰', '仟']
+
+function convertSection(n: number): string {
+  // n is 0..9999
+  if (n === 0) return ''
+  let result = ''
+  let zeroPending = false
+  let started = false
+
+  for (let placeIdx = 3; placeIdx >= 0; placeIdx--) {
+    const divisor = Math.pow(10, placeIdx)
+    const digit = Math.floor(n / divisor) % 10
+
+    if (digit === 0) {
+      if (started) zeroPending = true
+    } else {
+      if (zeroPending) {
+        result += DIGITS[0]
+        zeroPending = false
+      }
+      result += DIGITS[digit] + PLACE_UNITS[placeIdx]
+      started = true
+    }
+  }
+
+  return result
+}
+
+/**
+ * Convert a non-negative integer/decimal amount to traditional Chinese
+ * formal numerals (used on red envelopes, checks, formal receipts).
+ *
+ * Examples:
+ *   1234 → 壹仟貳佰參拾肆元
+ *   10000 → 壹萬元
+ *   1234.56 → 壹仟貳佰參拾肆元伍角陸分
+ *
+ * Returns empty string for invalid / zero / negative input — caller
+ * decides whether to render.
+ */
+export function toChineseNumeral(amount: number): string {
+  if (!Number.isFinite(amount) || amount <= 0) return ''
+
+  const integerPart = Math.floor(amount)
+  const decimalPart = Math.round((amount - integerPart) * 100)
+
+  let result = ''
+
+  if (integerPart === 0) {
+    result = DIGITS[0]
+  } else {
+    // Split into 4-digit sections from the right: 億 萬 (units)
+    const sections: number[] = []
+    let remaining = integerPart
+    while (remaining > 0) {
+      sections.push(remaining % 10000)
+      remaining = Math.floor(remaining / 10000)
+    }
+
+    if (sections.length > SECTION_UNITS.length) {
+      // Beyond 兆 — rare for personal ledger; just bail
+      return ''
+    }
+
+    let prevSectionWasZero = false
+    for (let i = sections.length - 1; i >= 0; i--) {
+      const section = sections[i]
+      if (section === 0) {
+        prevSectionWasZero = true
+        continue
+      }
+      // If previous section ended without filling all 4 digits, prepend 零
+      if (result && (prevSectionWasZero || section < 1000)) {
+        result += DIGITS[0]
+      }
+      result += convertSection(section) + SECTION_UNITS[i]
+      prevSectionWasZero = false
+    }
+  }
+
+  result += '元'
+
+  if (decimalPart > 0) {
+    const jiao = Math.floor(decimalPart / 10)
+    const fen = decimalPart % 10
+    if (jiao > 0) result += DIGITS[jiao] + '角'
+    if (fen > 0) result += DIGITS[fen] + '分'
+  }
+
+  return result
+}


### PR DESCRIPTION
## 為什麼

家庭中有時需要正式記錄大筆支出（孝親紅包、白包、保險費）。傳統紅包/支票常用中文大寫金額（壹萬貳仟）防止竄改。

在 expense form 顯示中文大寫提示，使用者可直接複製作為紅包金額或支票備註。Cultural touch——唯一非分析非 UX 的 ship。

## 做了什麼

`src/lib/chinese-numeral.ts` — 純函式：
- 整數按 4 位 section（萬/億/兆）切分
- 每 section 內按拾佰仟單位轉換
- 跨 section 處理「零」前綴（10001 = 壹萬零壹）
- 角分（小數兩位）支援
- 超過兆 → 空字串

`src/components/expense-form.tsx`：
- amount >= NT\$1000 時 inline 顯示
- 小字 + 灰色 + italic + tooltip

## 範例輸出

> 金額: NT\$ 12345.56
> [計算機 chips]
> *大寫：壹萬貳仟參佰肆拾伍元伍角陸分*

## 測試

12 個單元測試 ✅
- 無效 (NaN/Infinity/負數/0) → ''
- 單位邊界（個/拾/佰/仟/萬/億）
- 零的 prepending（壹佰零伍）
- 角分
- 四捨五入
- 億邊界（99999999 vs 100000000）
- out-of-range （> 兆）

整套：1346/1346 passed (新增 12 個).

Closes #338