### PR TITLE
feat(records): 搜尋時 highlight 匹配字串於列表 (Closes #340)

### DIFF
--- a/__tests__/highlight-text.test.ts
+++ b/__tests__/highlight-text.test.ts
@@ -1,0 +1,110 @@
+import { splitForHighlight } from '@/lib/highlight-text'
+
+describe('splitForHighlight', () => {
+  it('returns empty array for empty text', () => {
+    expect(splitForHighlight('', 'foo')).toEqual([])
+  })
+
+  it('returns single non-match segment for empty query', () => {
+    expect(splitForHighlight('hello world', '')).toEqual([
+      { text: 'hello world', isMatch: false },
+    ])
+  })
+
+  it('returns single non-match segment for whitespace-only query', () => {
+    expect(splitForHighlight('hello world', '   ')).toEqual([
+      { text: 'hello world', isMatch: false },
+    ])
+  })
+
+  it('returns single non-match when no matches found', () => {
+    expect(splitForHighlight('hello world', 'xyz')).toEqual([
+      { text: 'hello world', isMatch: false },
+    ])
+  })
+
+  it('highlights single match', () => {
+    expect(splitForHighlight('hello world', 'world')).toEqual([
+      { text: 'hello ', isMatch: false },
+      { text: 'world', isMatch: true },
+    ])
+  })
+
+  it('highlights match at start', () => {
+    expect(splitForHighlight('hello world', 'hello')).toEqual([
+      { text: 'hello', isMatch: true },
+      { text: ' world', isMatch: false },
+    ])
+  })
+
+  it('highlights match in middle', () => {
+    expect(splitForHighlight('hello world', 'lo wo')).toEqual([
+      { text: 'hel', isMatch: false },
+      { text: 'lo wo', isMatch: true },
+      { text: 'rld', isMatch: false },
+    ])
+  })
+
+  it('highlights multiple matches', () => {
+    const r = splitForHighlight('foo bar foo baz foo', 'foo')
+    expect(r).toEqual([
+      { text: 'foo', isMatch: true },
+      { text: ' bar ', isMatch: false },
+      { text: 'foo', isMatch: true },
+      { text: ' baz ', isMatch: false },
+      { text: 'foo', isMatch: true },
+    ])
+  })
+
+  it('case-insensitive matching preserves original case', () => {
+    const r = splitForHighlight('Hello WORLD', 'hello')
+    expect(r).toEqual([
+      { text: 'Hello', isMatch: true },
+      { text: ' WORLD', isMatch: false },
+    ])
+  })
+
+  it('escapes regex special chars in query', () => {
+    // 不應該炸 — query "(test)" 含 regex special
+    const r = splitForHighlight('this is (test) example', '(test)')
+    expect(r).toEqual([
+      { text: 'this is ', isMatch: false },
+      { text: '(test)', isMatch: true },
+      { text: ' example', isMatch: false },
+    ])
+  })
+
+  it('handles dot in query as literal dot, not regex any-char', () => {
+    const r = splitForHighlight('a.b a-b acb', '.')
+    expect(r).toEqual([
+      { text: 'a', isMatch: false },
+      { text: '.', isMatch: true },
+      { text: 'b a-b acb', isMatch: false },
+    ])
+  })
+
+  it('Chinese characters work correctly', () => {
+    const r = splitForHighlight('週三午餐便當', '午餐')
+    expect(r).toEqual([
+      { text: '週三', isMatch: false },
+      { text: '午餐', isMatch: true },
+      { text: '便當', isMatch: false },
+    ])
+  })
+
+  it('trims query whitespace', () => {
+    expect(splitForHighlight('hello world', '  world  ')).toEqual([
+      { text: 'hello ', isMatch: false },
+      { text: 'world', isMatch: true },
+    ])
+  })
+
+  it('handles consecutive matches without gap', () => {
+    const r = splitForHighlight('aaa', 'a')
+    expect(r).toEqual([
+      { text: 'a', isMatch: true },
+      { text: 'a', isMatch: true },
+      { text: 'a', isMatch: true },
+    ])
+  })
+})

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -11,6 +11,7 @@ import {
 import { AmountRangeChips } from '@/components/amount-range-chips'
 import { DescriptionPriceTrend } from '@/components/description-price-trend'
 import { computeFilterStats } from '@/lib/filter-stats'
+import { HighlightedText } from '@/components/highlighted-text'
 import { useSwipe } from '@/hooks/use-swipe'
 import { usePullToRefresh } from '@/hooks/use-pull-to-refresh'
 import { useGroup } from '@/lib/hooks/use-group'
@@ -664,13 +665,17 @@ export default function RecordsPage() {
                           )
                         })()}
                         <div className="flex-1 min-w-0">
-                          <div className="font-medium truncate">{e.description}</div>
+                          <div className="font-medium truncate">
+                            <HighlightedText text={e.description} query={searchQuery} />
+                          </div>
                           <div className="text-xs text-[var(--muted-foreground)] mt-0.5">
-                            {e.category} ·{' '}
+                            <HighlightedText text={e.category} query={searchQuery} /> ·{' '}
                             {currentMemberId && e.payerId === currentMemberId ? (
                               <span className="font-semibold text-[var(--foreground)]">我付</span>
                             ) : (
-                              <>{e.payerName}付</>
+                              <>
+                                <HighlightedText text={e.payerName} query={searchQuery} />付
+                              </>
                             )}
                           </div>
                         </div>

--- a/src/components/highlighted-text.tsx
+++ b/src/components/highlighted-text.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useMemo } from 'react'
+import { splitForHighlight } from '@/lib/highlight-text'
+
+interface HighlightedTextProps {
+  text: string
+  query: string
+  className?: string
+}
+
+/**
+ * Renders text with case-insensitive substring matches wrapped in `<mark>`
+ * for visual highlight (Issue #340). Used by the records list to make
+ * matched search terms pop within long descriptions.
+ */
+export function HighlightedText({ text, query, className }: HighlightedTextProps) {
+  const segments = useMemo(() => splitForHighlight(text, query), [text, query])
+  if (segments.length === 0) return null
+  if (segments.length === 1 && !segments[0].isMatch) {
+    return <span className={className}>{segments[0].text}</span>
+  }
+  return (
+    <span className={className}>
+      {segments.map((seg, i) =>
+        seg.isMatch ? (
+          <mark
+            key={i}
+            className="bg-[var(--primary)]/20 text-[var(--foreground)] rounded-[2px] px-0.5"
+          >
+            {seg.text}
+          </mark>
+        ) : (
+          <span key={i}>{seg.text}</span>
+        ),
+      )}
+    </span>
+  )
+}

--- a/src/lib/highlight-text.ts
+++ b/src/lib/highlight-text.ts
@@ -1,0 +1,45 @@
+export interface HighlightSegment {
+  text: string
+  isMatch: boolean
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Split text into segments alternating non-match / match for highlighting.
+ * Case-insensitive substring match. Returns a single non-match segment when
+ * either input is empty or no matches found, so the caller can render
+ * uniformly.
+ */
+export function splitForHighlight(
+  text: string,
+  query: string,
+): HighlightSegment[] {
+  if (!text) return []
+  const trimmedQuery = (query ?? '').trim()
+  if (!trimmedQuery) return [{ text, isMatch: false }]
+
+  const escaped = escapeRegExp(trimmedQuery)
+  const re = new RegExp(escaped, 'gi')
+  const segments: HighlightSegment[] = []
+  let lastIndex = 0
+  let m: RegExpExecArray | null = re.exec(text)
+
+  while (m !== null) {
+    if (m.index > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, m.index), isMatch: false })
+    }
+    segments.push({ text: m[0], isMatch: true })
+    lastIndex = m.index + m[0].length
+    if (m[0].length === 0) re.lastIndex++
+    m = re.exec(text)
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex), isMatch: false })
+  }
+
+  return segments.length === 0 ? [{ text, isMatch: false }] : segments
+}


### PR DESCRIPTION
## 為什麼

records page 搜尋後返回多筆結果，使用者必須逐行掃描尋找匹配字串。Inline highlight 讓眼睛立即跳到關鍵字位置。

## 做了什麼

`src/lib/highlight-text.ts` — 純函式 `splitForHighlight`：
- Case-insensitive 子字串匹配
- 多次出現都標記
- regex special chars escape（query 含 `.` `(` 不會炸）
- 中文字符正常工作

`src/components/highlighted-text.tsx` — UI：
- `<HighlightedText text query />` 用 `<mark>` 包匹配片段
- primary tint 背景 + foreground 字色
- empty/no-match 直接 render 純文字

`src/app/(auth)/records/page.tsx`：
- description / category / payerName 都用 HighlightedText

## 測試

14 個單元測試 ✅
- empty/whitespace query
- no match
- 單/多匹配
- 位置（start/middle/end）
- case-insensitive
- regex escape（含 `.` `(test)` 等特殊字元）
- Chinese characters
- query whitespace trim
- consecutive matches

整套：1360/1360 passed (新增 14 個).

Closes #340