### PR TITLE
feat(records): 日期範圍快速 chips — 本月/上月/本週/今天 一鍵切換 (Closes #342)

### DIFF
--- a/__tests__/date-range-presets.test.ts
+++ b/__tests__/date-range-presets.test.ts
@@ -1,0 +1,123 @@
+import {
+  getRangePreset,
+  matchActivePreset,
+  presetLabel,
+  PRESET_KEYS,
+} from '@/lib/date-range-presets'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15, 2026 = Wed
+
+describe('getRangePreset', () => {
+  it('today returns single-day range', () => {
+    expect(getRangePreset('today', NOW)).toEqual({
+      start: '2026-04-15',
+      end: '2026-04-15',
+    })
+  })
+
+  it('this-week returns Mon-Sun for current week', () => {
+    // April 15 = Wed → Mon = April 13, Sun = April 19
+    expect(getRangePreset('this-week', NOW)).toEqual({
+      start: '2026-04-13',
+      end: '2026-04-19',
+    })
+  })
+
+  it('this-month returns 1st..last-day of current month', () => {
+    expect(getRangePreset('this-month', NOW)).toEqual({
+      start: '2026-04-01',
+      end: '2026-04-30',
+    })
+  })
+
+  it('last-month returns entire previous calendar month', () => {
+    expect(getRangePreset('last-month', NOW)).toEqual({
+      start: '2026-03-01',
+      end: '2026-03-31',
+    })
+  })
+
+  it('last-7 returns 7-day inclusive range', () => {
+    expect(getRangePreset('last-7', NOW)).toEqual({
+      start: '2026-04-09',
+      end: '2026-04-15',
+    })
+  })
+
+  it('last-30 returns 30-day inclusive range', () => {
+    expect(getRangePreset('last-30', NOW)).toEqual({
+      start: '2026-03-17',
+      end: '2026-04-15',
+    })
+  })
+
+  it('this-week handles Sunday as end of week', () => {
+    // April 19, 2026 = Sunday
+    const sunday = new Date(2026, 3, 19, 12, 0, 0).getTime()
+    expect(getRangePreset('this-week', sunday)).toEqual({
+      start: '2026-04-13', // Monday
+      end: '2026-04-19', // Sunday
+    })
+  })
+
+  it('this-week handles Monday as start of week', () => {
+    const monday = new Date(2026, 3, 13, 12, 0, 0).getTime()
+    expect(getRangePreset('this-week', monday)).toEqual({
+      start: '2026-04-13',
+      end: '2026-04-19',
+    })
+  })
+
+  it('last-month crosses year (Jan → previous Dec)', () => {
+    const jan15_2027 = new Date(2027, 0, 15, 12, 0, 0).getTime()
+    expect(getRangePreset('last-month', jan15_2027)).toEqual({
+      start: '2026-12-01',
+      end: '2026-12-31',
+    })
+  })
+
+  it('this-month handles February (28-day)', () => {
+    const feb15 = new Date(2026, 1, 15, 12, 0, 0).getTime()
+    expect(getRangePreset('this-month', feb15)).toEqual({
+      start: '2026-02-01',
+      end: '2026-02-28',
+    })
+  })
+
+  it('this-month handles February in leap year', () => {
+    const feb15_2024 = new Date(2024, 1, 15, 12, 0, 0).getTime()
+    expect(getRangePreset('this-month', feb15_2024)).toEqual({
+      start: '2024-02-01',
+      end: '2024-02-29',
+    })
+  })
+})
+
+describe('matchActivePreset', () => {
+  it('returns matching preset key when range matches', () => {
+    expect(matchActivePreset('2026-04-15', '2026-04-15', NOW)).toBe('today')
+    expect(matchActivePreset('2026-04-13', '2026-04-19', NOW)).toBe('this-week')
+    expect(matchActivePreset('2026-04-01', '2026-04-30', NOW)).toBe('this-month')
+    expect(matchActivePreset('2026-03-01', '2026-03-31', NOW)).toBe('last-month')
+  })
+
+  it('returns null when range does not match any preset', () => {
+    expect(matchActivePreset('2026-04-10', '2026-04-12', NOW)).toBeNull()
+    expect(matchActivePreset('', '', NOW)).toBeNull()
+  })
+})
+
+describe('PRESET_KEYS and presetLabel', () => {
+  it('PRESET_KEYS contains all 6 keys', () => {
+    expect(PRESET_KEYS.length).toBe(6)
+  })
+
+  it('presetLabel returns Chinese label for each key', () => {
+    expect(presetLabel('today')).toBe('今天')
+    expect(presetLabel('this-week')).toBe('本週')
+    expect(presetLabel('this-month')).toBe('本月')
+    expect(presetLabel('last-month')).toBe('上月')
+    expect(presetLabel('last-7')).toBe('近 7 天')
+    expect(presetLabel('last-30')).toBe('近 30 天')
+  })
+})

--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -12,6 +12,13 @@ import { AmountRangeChips } from '@/components/amount-range-chips'
 import { DescriptionPriceTrend } from '@/components/description-price-trend'
 import { computeFilterStats } from '@/lib/filter-stats'
 import { HighlightedText } from '@/components/highlighted-text'
+import {
+  getRangePreset,
+  matchActivePreset,
+  presetLabel,
+  PRESET_KEYS,
+  type DateRangePresetKey,
+} from '@/lib/date-range-presets'
 import { useSwipe } from '@/hooks/use-swipe'
 import { usePullToRefresh } from '@/hooks/use-pull-to-refresh'
 import { useGroup } from '@/lib/hooks/use-group'
@@ -483,6 +490,38 @@ export default function RecordsPage() {
       {/* Advanced filter panel */}
       {showAdvanced && (
         <div className="card p-4 mb-3 space-y-3">
+          {/* 日期範圍快速 chips (Issue #342) */}
+          {(() => {
+            const active = matchActivePreset(dateStart, dateEnd)
+            return (
+              <div className="flex flex-wrap gap-1.5">
+                <span className="text-[11px] text-[var(--muted-foreground)] self-center mr-1">
+                  快速選擇：
+                </span>
+                {PRESET_KEYS.map((key: DateRangePresetKey) => {
+                  const isActive = active === key
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => {
+                        const r = getRangePreset(key)
+                        setDateStart(r.start)
+                        setDateEnd(r.end)
+                      }}
+                      className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
+                        isActive
+                          ? 'bg-[var(--primary)] text-[var(--primary-foreground,_white)]'
+                          : 'bg-[var(--muted)] text-[var(--muted-foreground)] hover:bg-[var(--border)]'
+                      }`}
+                    >
+                      {presetLabel(key)}
+                    </button>
+                  )
+                })}
+              </div>
+            )
+          })()}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="space-y-1">
               <label className="text-xs font-medium text-[var(--muted-foreground)]">開始日期</label>

--- a/src/lib/date-range-presets.ts
+++ b/src/lib/date-range-presets.ts
@@ -1,0 +1,126 @@
+export type DateRangePresetKey =
+  | 'today'
+  | 'this-week'
+  | 'this-month'
+  | 'last-month'
+  | 'last-7'
+  | 'last-30'
+
+export interface DateRange {
+  start: string // YYYY-MM-DD
+  end: string // YYYY-MM-DD
+}
+
+const LABELS: Record<DateRangePresetKey, string> = {
+  today: '今天',
+  'this-week': '本週',
+  'this-month': '本月',
+  'last-month': '上月',
+  'last-7': '近 7 天',
+  'last-30': '近 30 天',
+}
+
+export function presetLabel(key: DateRangePresetKey): string {
+  return LABELS[key]
+}
+
+export const PRESET_KEYS: DateRangePresetKey[] = [
+  'today',
+  'this-week',
+  'this-month',
+  'last-month',
+  'last-7',
+  'last-30',
+]
+
+function ymd(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d)
+  x.setHours(0, 0, 0, 0)
+  return x
+}
+
+/**
+ * Compute Mon-Sun week start for the given date (Sunday belongs to the
+ * previous week so it's the LAST day of week).
+ */
+function mondayOf(d: Date): Date {
+  const x = startOfDay(d)
+  const dow = x.getDay()
+  const offset = dow === 0 ? 6 : dow - 1
+  x.setDate(x.getDate() - offset)
+  return x
+}
+
+/**
+ * Returns a YYYY-MM-DD inclusive range for a given preset key. Range
+ * semantics:
+ *   - `today` = single-day range
+ *   - `this-week` = Mon..Sun of current week
+ *   - `this-month` = 1st..last-day of current month
+ *   - `last-month` = entire previous calendar month (cross-year safe)
+ *   - `last-7` = (today-6)..today (7 days inclusive)
+ *   - `last-30` = (today-29)..today
+ */
+export function getRangePreset(
+  key: DateRangePresetKey,
+  now: number = Date.now(),
+): DateRange {
+  const today = startOfDay(new Date(now))
+
+  switch (key) {
+    case 'today': {
+      const s = ymd(today)
+      return { start: s, end: s }
+    }
+    case 'this-week': {
+      const start = mondayOf(today)
+      const end = new Date(start)
+      end.setDate(end.getDate() + 6)
+      return { start: ymd(start), end: ymd(end) }
+    }
+    case 'this-month': {
+      const y = today.getFullYear()
+      const m = today.getMonth()
+      const start = new Date(y, m, 1)
+      const end = new Date(y, m + 1, 0) // last day of month
+      return { start: ymd(start), end: ymd(end) }
+    }
+    case 'last-month': {
+      const y = today.getFullYear()
+      const m = today.getMonth()
+      const start = new Date(y, m - 1, 1)
+      const end = new Date(y, m, 0) // last day of previous month
+      return { start: ymd(start), end: ymd(end) }
+    }
+    case 'last-7': {
+      const start = new Date(today)
+      start.setDate(start.getDate() - 6)
+      return { start: ymd(start), end: ymd(today) }
+    }
+    case 'last-30': {
+      const start = new Date(today)
+      start.setDate(start.getDate() - 29)
+      return { start: ymd(start), end: ymd(today) }
+    }
+  }
+}
+
+/**
+ * Inverse: given a (start, end) pair, return the preset key that matches
+ * exactly, or null. Used to highlight the active chip.
+ */
+export function matchActivePreset(
+  start: string,
+  end: string,
+  now: number = Date.now(),
+): DateRangePresetKey | null {
+  for (const key of PRESET_KEYS) {
+    const r = getRangePreset(key, now)
+    if (r.start === start && r.end === end) return key
+  }
+  return null
+}


### PR DESCRIPTION
## 為什麼

records page 日期過濾用 HTML date input，每次手動選 start/end 太繁瑣。常用範圍如「本月」「上月」「本週」「今天」一鍵切換更快。

## 做了什麼

`src/lib/date-range-presets.ts` — 純函式：
- `today` / `this-week` / `this-month` / `last-month` / `last-7` / `last-30`
- 跨年正確（Jan → 上月為前年 12 月）
- Feb 28/29 leap year 正確
- 週切分 Mon-Sun
- `matchActivePreset` 反查當前範圍對應 preset key

`src/app/(auth)/records/page.tsx`：
- advanced filter section 上方加 chip 列
- Active chip 用 primary 色突顯（match 反查命中）
- 點擊立即 apply

## 測試

15 個單元測試 ✅
- 6 個 preset 各自正確
- Sun/Mon 週邊界
- last-month 跨年（Jan 2027 → Dec 2026）
- Feb 28（2026 非閏）vs 29（2024 閏）
- matchActivePreset 反查
- PRESET_KEYS / presetLabel

整套：1375/1375 passed (新增 15 個).

Closes #342