### PR TITLE
feat(records): notes 加入搜尋 haystack

### DIFF
--- a/src/app/(auth)/records/page.tsx
+++ b/src/app/(auth)/records/page.tsx
@@ -214,7 +214,7 @@ export default function RecordsPage() {
 
       // Keyword search
       if (searchQuery) {
-        const haystack = `${e.description} ${e.category} ${e.payerName}`.toLowerCase()
+        const haystack = `${e.description} ${e.category} ${e.payerName} ${e.note ?? ''}`.toLowerCase()
         if (!haystack.includes(searchQuery)) return false
       }
 


### PR DESCRIPTION
Records page search 原本只查 description / category / payerName。
但很多紀錄的關鍵資訊在 note 欄位（例如「機票編號 ABC123」「醫院名稱」），搜尋不到很可惜。

加上 e.note 進 haystack 讓 note 內容也可被搜尋到。

**Diff**: 1 line
**Schema change**: none
**Test**: existing pass