### PR TITLE
feat(statistics): 月報生成 + 分享 — 一鍵 LINE/clipboard 給家人 (Closes #345)

### DIFF
--- a/__tests__/monthly-report.test.ts
+++ b/__tests__/monthly-report.test.ts
@@ -1,0 +1,157 @@
+import { generateMonthlyReport } from '@/lib/monthly-report'
+import type { Expense } from '@/lib/types'
+
+function mk(id: string, amount: number, year: number, month: number, day: number, opts: Partial<Expense> = {}): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: opts.description ?? `e-${id}`,
+    amount,
+    category: opts.category ?? 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('generateMonthlyReport', () => {
+  it('returns empty when no data for month', () => {
+    const r = generateMonthlyReport({ expenses: [], year: 2026, month: 3 })
+    expect(r.hasData).toBe(false)
+    expect(r.text).toBe('')
+  })
+
+  it('generates basic report with total + count', () => {
+    const expenses = [
+      mk('a', 1000, 2026, 3, 5),
+      mk('b', 2000, 2026, 3, 15),
+    ]
+    const r = generateMonthlyReport({ expenses, year: 2026, month: 3 })
+    expect(r.hasData).toBe(true)
+    expect(r.total).toBe(3000)
+    expect(r.count).toBe(2)
+    expect(r.text).toContain('2026/04 家計月報')
+    expect(r.text).toContain('NT$3,000')
+    expect(r.text).toContain('2 筆')
+  })
+
+  it('includes prev month delta when supplied (positive)', () => {
+    const expenses = [mk('a', 12000, 2026, 3, 5)]
+    const r = generateMonthlyReport({
+      expenses,
+      year: 2026,
+      month: 3,
+      previousMonthTotal: 10000,
+    })
+    expect(r.text).toContain('📈')
+    expect(r.text).toContain('+20%')
+    expect(r.text).toContain('NT$2,000')
+  })
+
+  it('includes prev month delta when supplied (negative)', () => {
+    const expenses = [mk('a', 8000, 2026, 3, 5)]
+    const r = generateMonthlyReport({
+      expenses,
+      year: 2026,
+      month: 3,
+      previousMonthTotal: 10000,
+    })
+    expect(r.text).toContain('📉')
+    expect(r.text).toContain('-20%')
+  })
+
+  it('handles previousMonthTotal === 0 gracefully (no delta line)', () => {
+    const expenses = [mk('a', 1000, 2026, 3, 5)]
+    const r = generateMonthlyReport({
+      expenses,
+      year: 2026,
+      month: 3,
+      previousMonthTotal: 0,
+    })
+    expect(r.text).not.toContain('📈')
+    expect(r.text).not.toContain('📉')
+  })
+
+  it('biggest expense surfaces description', () => {
+    const expenses = [
+      mk('a', 100, 2026, 3, 5, { description: '咖啡' }),
+      mk('big', 5500, 2026, 3, 10, { description: '香港機票' }),
+      mk('c', 200, 2026, 3, 15, { description: '午餐' }),
+    ]
+    const r = generateMonthlyReport({ expenses, year: 2026, month: 3 })
+    expect(r.text).toContain('🏆')
+    expect(r.text).toContain('香港機票')
+    expect(r.text).toContain('NT$5,500')
+  })
+
+  it('top 3 categories sorted by amount', () => {
+    const expenses = [
+      mk('a', 5000, 2026, 3, 5, { category: '餐飲' }),
+      mk('b', 3000, 2026, 3, 6, { category: '交通' }),
+      mk('c', 2000, 2026, 3, 7, { category: '日用品' }),
+      mk('d', 100, 2026, 3, 8, { category: '其他' }),
+    ]
+    const r = generateMonthlyReport({ expenses, year: 2026, month: 3 })
+    const lines = r.text.split('\n')
+    const catLines = lines.filter((l) => /^[123]\./.test(l))
+    expect(catLines.length).toBe(3)
+    expect(catLines[0]).toContain('餐飲')
+    expect(catLines[1]).toContain('交通')
+    expect(catLines[2]).toContain('日用品')
+  })
+
+  it('skips other-month expenses', () => {
+    const expenses = [
+      mk('curr', 1000, 2026, 3, 5),
+      mk('mar', 9999, 2026, 2, 28),
+      mk('may', 9999, 2026, 4, 1),
+    ]
+    const r = generateMonthlyReport({ expenses, year: 2026, month: 3 })
+    expect(r.total).toBe(1000)
+  })
+
+  it('skips bad amount/date defensively', () => {
+    const bad = { ...mk('bad', 100, 2026, 3, 5), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mk('valid', 100, 2026, 3, 5),
+      mk('nan', NaN, 2026, 3, 5),
+      mk('zero', 0, 2026, 3, 5),
+      mk('neg', -50, 2026, 3, 5),
+      bad,
+    ]
+    const r = generateMonthlyReport({ expenses, year: 2026, month: 3 })
+    expect(r.count).toBe(1)
+  })
+
+  it('handles empty description / category fallback', () => {
+    const e = {
+      ...mk('a', 1000, 2026, 3, 5),
+      description: '',
+      category: '',
+    } as unknown as Expense
+    const r = generateMonthlyReport({ expenses: [e], year: 2026, month: 3 })
+    expect(r.text).toContain('(無描述)')
+    expect(r.text).toContain('其他')
+  })
+
+  it('formatted month label uses zero-padded MM', () => {
+    const expenses = [mk('a', 100, 2026, 0, 5)] // January
+    const r = generateMonthlyReport({ expenses, year: 2026, month: 0 })
+    expect(r.text).toContain('2026/01')
+  })
+
+  it('text is multi-line with line separators', () => {
+    const expenses = [mk('a', 1000, 2026, 3, 5)]
+    const r = generateMonthlyReport({ expenses, year: 2026, month: 3 })
+    expect(r.text).toContain('\n')
+    expect(r.text.split('\n').length).toBeGreaterThan(3)
+  })
+})

--- a/src/app/(auth)/statistics/page.tsx
+++ b/src/app/(auth)/statistics/page.tsx
@@ -10,6 +10,7 @@ import { aggregateYearStats } from '@/lib/year-stats'
 import { TopExpensesCard } from '@/components/top-expenses-card'
 import { MoneyDiary } from '@/components/money-diary'
 import { YearHeatmap } from '@/components/year-heatmap'
+import { MonthlyReportShare } from '@/components/monthly-report-share'
 import type { Expense } from '@/lib/types'
 import type { StatisticsChartsProps } from '@/components/statistics-charts'
 
@@ -301,6 +302,15 @@ export default function StatisticsPage() {
         previousMonthTotal={previousMonthTotal > 0 ? previousMonthTotal : null}
         selectedMonth={selectedMonth}
       />
+
+      {/* 分享月報 (Issue #345) */}
+      <div className="flex justify-end">
+        <MonthlyReportShare
+          expenses={monthExpenses}
+          selectedMonth={selectedMonth}
+          previousMonthTotal={previousMonthTotal > 0 ? previousMonthTotal : null}
+        />
+      </div>
 
       {/* 全年熱力圖 (Issue #313) — 7×52 GitHub-style 年度視窗 */}
       <YearHeatmap expenses={expenses} year={selectedMonth.year} />

--- a/src/components/monthly-report-share.tsx
+++ b/src/components/monthly-report-share.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { generateMonthlyReport } from '@/lib/monthly-report'
+import { useToast } from '@/components/toast'
+import type { Expense } from '@/lib/types'
+
+interface MonthlyReportShareProps {
+  expenses: Expense[]
+  /** Selected month (year + 0-indexed month). */
+  selectedMonth: { year: number; month: number }
+  /** Optional previous-month total for delta calculation. */
+  previousMonthTotal?: number | null
+}
+
+/**
+ * One-click monthly report sharing (Issue #345). Generates a multi-line
+ * formatted text and either invokes Web Share API (mobile-friendly,
+ * routes to LINE/WhatsApp/SMS picker) or copies to clipboard as
+ * fallback. Renders silently when no data for selected month.
+ */
+export function MonthlyReportShare({
+  expenses,
+  selectedMonth,
+  previousMonthTotal,
+}: MonthlyReportShareProps) {
+  const [busy, setBusy] = useState(false)
+  const { addToast } = useToast()
+
+  const report = useMemo(
+    () =>
+      generateMonthlyReport({
+        expenses,
+        year: selectedMonth.year,
+        month: selectedMonth.month,
+        previousMonthTotal,
+      }),
+    [expenses, selectedMonth.year, selectedMonth.month, previousMonthTotal],
+  )
+
+  if (!report.hasData) return null
+
+  async function handleShare() {
+    if (busy) return
+    setBusy(true)
+    try {
+      const monthLabel = `${selectedMonth.year}/${String(selectedMonth.month + 1).padStart(2, '0')}`
+      if (typeof navigator !== 'undefined' && 'share' in navigator) {
+        try {
+          await navigator.share({
+            title: `${monthLabel} 家計月報`,
+            text: report.text,
+          })
+          return
+        } catch (e) {
+          // AbortError = user cancelled — silent.
+          if (e instanceof Error && e.name === 'AbortError') return
+          // Otherwise fall through to clipboard
+        }
+      }
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(report.text)
+        addToast('已複製月報到剪貼板', 'success')
+      } else {
+        addToast('無法分享', 'warning')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      disabled={busy}
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border border-[var(--border)] hover:bg-[var(--muted)] transition disabled:opacity-50"
+      aria-label="分享月報"
+      title="分享月度摘要文字"
+    >
+      <span aria-hidden>📋</span>
+      分享月報
+    </button>
+  )
+}

--- a/src/lib/monthly-report.ts
+++ b/src/lib/monthly-report.ts
@@ -1,0 +1,113 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface MonthlyReportData {
+  /** Multi-line shareable text. */
+  text: string
+  /** Total amount in this month. */
+  total: number
+  /** Total count in this month. */
+  count: number
+  hasData: boolean
+}
+
+interface GenerateOptions {
+  expenses: Expense[]
+  year: number
+  /** 0-indexed month. */
+  month: number
+  /** Previous month total for delta calculation. null when unavailable. */
+  previousMonthTotal?: number | null
+}
+
+function fmtCurrency(amount: number): string {
+  return `NT$${Math.round(amount).toLocaleString('en-US')}`
+}
+
+/**
+ * Generate a formatted month-summary text suitable for LINE / WhatsApp /
+ * Telegram sharing. Pure function — caller wires it to navigator.share or
+ * clipboard.
+ */
+export function generateMonthlyReport({
+  expenses,
+  year,
+  month,
+  previousMonthTotal,
+}: GenerateOptions): MonthlyReportData {
+  let total = 0
+  let count = 0
+  let biggest: { description: string; amount: number } | null = null
+  const byCategory = new Map<string, number>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+    if (d.getFullYear() !== year || d.getMonth() !== month) continue
+    total += amount
+    count++
+    const category = (e.category || '其他').trim() || '其他'
+    byCategory.set(category, (byCategory.get(category) ?? 0) + amount)
+    const description = (e.description || '(無描述)').trim() || '(無描述)'
+    if (!biggest || amount > biggest.amount) {
+      biggest = { description, amount }
+    }
+  }
+
+  if (count === 0) {
+    return { text: '', total: 0, count: 0, hasData: false }
+  }
+
+  const monthLabel = `${year}/${String(month + 1).padStart(2, '0')}`
+  const lines: string[] = []
+  lines.push(`📊 ${monthLabel} 家計月報`)
+  lines.push('')
+  lines.push(`💰 總支出：${fmtCurrency(total)}（${count} 筆）`)
+
+  if (
+    typeof previousMonthTotal === 'number' &&
+    Number.isFinite(previousMonthTotal) &&
+    previousMonthTotal > 0
+  ) {
+    const delta = total - previousMonthTotal
+    const pct = Math.round((delta / previousMonthTotal) * 100)
+    if (delta > 0) {
+      lines.push(`📈 比上月多 ${fmtCurrency(delta)} (+${pct}%)`)
+    } else if (delta < 0) {
+      lines.push(`📉 比上月少 ${fmtCurrency(Math.abs(delta))} (${pct}%)`)
+    } else {
+      lines.push(`➖ 與上月相當`)
+    }
+  }
+
+  if (biggest) {
+    lines.push('')
+    lines.push(`🏆 最大筆：${fmtCurrency(biggest.amount)}（${biggest.description}）`)
+  }
+
+  const topCategories = Array.from(byCategory.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+  if (topCategories.length > 0) {
+    lines.push('')
+    lines.push('📂 主要類別：')
+    topCategories.forEach(([cat, amt], i) => {
+      const pct = Math.round((amt / total) * 100)
+      lines.push(`${i + 1}. ${cat} ${fmtCurrency(amt)} (${pct}%)`)
+    })
+  }
+
+  return {
+    text: lines.join('\n'),
+    total,
+    count,
+    hasData: true,
+  }
+}


### PR DESCRIPTION
## 為什麼

家庭月底常需要討論支出。但資訊散在多個 widget——使用者要截圖多次或抄寫。

提供「📋 分享月報」按鈕，自動生成格式化的月度摘要文字，可一鍵透過 Web Share API 分享到 LINE / WhatsApp，或複製到剪貼板。

## 做了什麼

`src/lib/monthly-report.ts` — 純函式：
- 計算當月 total + count + biggest + top 3 categories
- 包含 prev month delta（如果提供）
- 多行格式化文字輸出

`src/components/monthly-report-share.tsx` — UI：
- `navigator.share` API（行動裝置原生 share sheet → LINE/WhatsApp/...）
- fallback to `navigator.clipboard.writeText`
- AbortError（使用者取消）silent
- toast 確認

## 範例輸出

```
📊 2026/04 家計月報

💰 總支出：NT$15,234（42 筆）
📈 比上月多 NT$2,000 (+15%)

🏆 最大筆：NT$5,500（香港機票）

📂 主要類別：
1. 餐飲 NT$5,200 (34%)
2. 交通 NT$3,800 (25%)
3. 日用品 NT$2,100 (14%)
```

## 測試

12 個單元測試 ✅
- hasData false（無資料）
- total / count
- prev delta（positive/negative/0/null）
- biggest expense
- top 3 categories sort
- 跨月排除
- bad data defensive
- empty description/category fallback
- 月份 zero-pad
- multi-line 結構

整套：1387/1387 passed (新增 12 個).

Closes #345