### PR TITLE
feat(statistics): 每日累計支出曲線 — 本月 vs 上月 pace 對比 (Closes #348)

### DIFF
--- a/__tests__/cumulative-month-curve.test.ts
+++ b/__tests__/cumulative-month-curve.test.ts
@@ -1,0 +1,167 @@
+import { buildCumulativeMonthCurve } from '@/lib/cumulative-month-curve'
+import type { Expense } from '@/lib/types'
+
+const NOW = new Date(2026, 3, 15, 12, 0, 0).getTime() // April 15
+
+function mkOnDate(id: string, amount: number, year: number, month: number, day: number): Expense {
+  const d = new Date(year, month, day, 10, 0, 0)
+  return {
+    id,
+    groupId: 'g1',
+    description: 'e',
+    amount,
+    category: 'X',
+    payerId: 'm1',
+    payerName: '爸',
+    isShared: true,
+    splitMethod: 'equal',
+    splits: [],
+    paymentMethod: 'cash',
+    date: d,
+    createdAt: d,
+    createdBy: 'u1',
+    receiptPaths: [],
+  } as unknown as Expense
+}
+
+describe('buildCumulativeMonthCurve', () => {
+  it('returns null when month too young (< minDays)', () => {
+    const day2 = new Date(2026, 3, 2, 12, 0, 0).getTime()
+    expect(
+      buildCumulativeMonthCurve({
+        expenses: [mkOnDate('a', 100, 2026, 3, 1)],
+        year: 2026,
+        month: 3,
+        now: day2,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when no current month data', () => {
+    expect(
+      buildCumulativeMonthCurve({
+        expenses: [mkOnDate('a', 100, 2026, 2, 28)],
+        year: 2026,
+        month: 3,
+        now: NOW,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null for future month', () => {
+    expect(
+      buildCumulativeMonthCurve({
+        expenses: [],
+        year: 2026,
+        month: 5, // June
+        now: NOW,
+      }),
+    ).toBeNull()
+  })
+
+  it('builds curve for current month up to today', () => {
+    const expenses = [
+      mkOnDate('a', 100, 2026, 3, 1),
+      mkOnDate('b', 200, 2026, 3, 5),
+      mkOnDate('c', 300, 2026, 3, 10),
+    ]
+    const r = buildCumulativeMonthCurve({ expenses, year: 2026, month: 3, now: NOW })
+    expect(r!.todayDay).toBe(15)
+    expect(r!.daysInMonth).toBe(30)
+    expect(r!.current.length).toBe(15)
+    // Day 1 → 100
+    expect(r!.current[0]).toEqual({ day: 1, cumulative: 100 })
+    // Day 5 → 100 + 200 = 300
+    expect(r!.current[4]).toEqual({ day: 5, cumulative: 300 })
+    // Day 10 → 300 + 300 = 600
+    expect(r!.current[9]).toEqual({ day: 10, cumulative: 600 })
+    expect(r!.todayCumulative).toBe(600)
+  })
+
+  it('builds previous month full curve when data exists', () => {
+    const expenses = [
+      mkOnDate('curr', 1000, 2026, 3, 5),
+      mkOnDate('prev1', 500, 2026, 2, 10), // March 10
+      mkOnDate('prev2', 800, 2026, 2, 25), // March 25
+    ]
+    const r = buildCumulativeMonthCurve({ expenses, year: 2026, month: 3, now: NOW })
+    expect(r!.previous).not.toBeNull()
+    expect(r!.previous!.length).toBe(31) // March has 31 days
+    expect(r!.previous![24].cumulative).toBe(1300) // 500 + 800 by day 25
+    expect(r!.previousMonthLabel).toBe('2026-03')
+  })
+
+  it('previous null when no prev month data', () => {
+    const expenses = [mkOnDate('curr', 1000, 2026, 3, 5)]
+    const r = buildCumulativeMonthCurve({ expenses, year: 2026, month: 3, now: NOW })
+    expect(r!.previous).toBeNull()
+    expect(r!.prevSameDayCumulative).toBeNull()
+  })
+
+  it('prevSameDayCumulative aligns to current todayDay (capped at prev month length)', () => {
+    // Today = April 15. Prev month = March (31 days). Day 15 of March should align.
+    const expenses = [
+      mkOnDate('curr', 1000, 2026, 3, 5),
+      ...Array.from({ length: 20 }, (_, i) => mkOnDate(`prev${i}`, 100, 2026, 2, i + 1)), // 100/day Mar 1..20
+    ]
+    const r = buildCumulativeMonthCurve({ expenses, year: 2026, month: 3, now: NOW })
+    // March 15 cumulative: days 1..15 each 100 → 1500
+    expect(r!.prevSameDayCumulative).toBe(1500)
+  })
+
+  it('prevSameDayCumulative caps when prev month shorter (Feb)', () => {
+    // April has 30 days, but March has 31. Test reverse: query March (31 days), prev = Feb (28).
+    // Today = March 30 → prevSameDay should cap to Feb 28
+    const mar30 = new Date(2026, 2, 30, 12, 0, 0).getTime()
+    const expenses = [
+      mkOnDate('curr', 1000, 2026, 2, 5),
+      ...Array.from({ length: 28 }, (_, i) => mkOnDate(`prev${i}`, 100, 2026, 1, i + 1)),
+    ]
+    const r = buildCumulativeMonthCurve({ expenses, year: 2026, month: 2, now: mar30 })
+    expect(r!.todayDay).toBe(30)
+    // Feb 28 cumulative = 28 * 100 = 2800
+    expect(r!.prevSameDayCumulative).toBe(2800)
+  })
+
+  it('crosses year (Jan → previous Dec)', () => {
+    const jan15 = new Date(2027, 0, 15, 12, 0, 0).getTime()
+    const expenses = [
+      mkOnDate('jan', 1000, 2027, 0, 5),
+      mkOnDate('dec', 500, 2026, 11, 10),
+    ]
+    const r = buildCumulativeMonthCurve({ expenses, year: 2027, month: 0, now: jan15 })
+    expect(r!.monthLabel).toBe('2027-01')
+    expect(r!.previousMonthLabel).toBe('2026-12')
+    expect(r!.previous).not.toBeNull()
+  })
+
+  it('renders past month fully (todayDay = daysInMonth)', () => {
+    // Query March from April 15 perspective (past month)
+    const expenses = [mkOnDate('a', 1000, 2026, 2, 15)]
+    const r = buildCumulativeMonthCurve({ expenses, year: 2026, month: 2, now: NOW })
+    expect(r!.todayDay).toBe(31) // capped at March's last day
+    expect(r!.current.length).toBe(31)
+  })
+
+  it('skips bad amount/date defensively', () => {
+    const bad = { ...mkOnDate('bad', 100, 2026, 3, 5), date: 'oops' } as unknown as Expense
+    const expenses = [
+      mkOnDate('valid', 100, 2026, 3, 5),
+      mkOnDate('nan', NaN, 2026, 3, 5),
+      mkOnDate('zero', 0, 2026, 3, 5),
+      bad,
+    ]
+    const r = buildCumulativeMonthCurve({ expenses, year: 2026, month: 3, now: NOW })
+    expect(r!.todayCumulative).toBe(100)
+  })
+
+  it('cumulative is monotonically non-decreasing', () => {
+    const expenses = Array.from({ length: 10 }, (_, i) =>
+      mkOnDate(String(i), 100, 2026, 3, i + 1),
+    )
+    const r = buildCumulativeMonthCurve({ expenses, year: 2026, month: 3, now: NOW })
+    for (let i = 1; i < r!.current.length; i++) {
+      expect(r!.current[i].cumulative).toBeGreaterThanOrEqual(r!.current[i - 1].cumulative)
+    }
+  })
+})

--- a/src/app/(auth)/statistics/page.tsx
+++ b/src/app/(auth)/statistics/page.tsx
@@ -11,6 +11,7 @@ import { TopExpensesCard } from '@/components/top-expenses-card'
 import { MoneyDiary } from '@/components/money-diary'
 import { YearHeatmap } from '@/components/year-heatmap'
 import { MonthlyReportShare } from '@/components/monthly-report-share'
+import { CumulativeMonthCurve } from '@/components/cumulative-month-curve'
 import type { Expense } from '@/lib/types'
 import type { StatisticsChartsProps } from '@/components/statistics-charts'
 
@@ -311,6 +312,9 @@ export default function StatisticsPage() {
           previousMonthTotal={previousMonthTotal > 0 ? previousMonthTotal : null}
         />
       </div>
+
+      {/* 每日累計支出曲線 (Issue #348) — 本月 vs 上月 pace 對比 */}
+      <CumulativeMonthCurve expenses={expenses} selectedMonth={selectedMonth} />
 
       {/* 全年熱力圖 (Issue #313) — 7×52 GitHub-style 年度視窗 */}
       <YearHeatmap expenses={expenses} year={selectedMonth.year} />

--- a/src/components/cumulative-month-curve.tsx
+++ b/src/components/cumulative-month-curve.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Tooltip,
+  ReferenceLine,
+} from 'recharts'
+import { buildCumulativeMonthCurve } from '@/lib/cumulative-month-curve'
+import { currency } from '@/lib/utils'
+import type { Expense } from '@/lib/types'
+
+interface CumulativeMonthCurveProps {
+  expenses: Expense[]
+  selectedMonth: { year: number; month: number }
+}
+
+/**
+ * Cumulative day-by-day spending curve (Issue #348). Dual-line chart
+ * showing current month's running total against last month's full
+ * trajectory — visual answer to "am I ahead or behind last month's pace
+ * today?". Renders silently when no current-month data or month too
+ * young.
+ */
+export function CumulativeMonthCurve({
+  expenses,
+  selectedMonth,
+}: CumulativeMonthCurveProps) {
+  const data = useMemo(
+    () =>
+      buildCumulativeMonthCurve({
+        expenses,
+        year: selectedMonth.year,
+        month: selectedMonth.month,
+      }),
+    [expenses, selectedMonth.year, selectedMonth.month],
+  )
+
+  if (!data) return null
+
+  // Merge into one array indexed by day so recharts can plot dual lines
+  const chartData: Array<{ day: number; current: number | null; previous: number | null }> = []
+  const maxDay = Math.max(
+    data.daysInMonth,
+    data.previous?.length ?? 0,
+  )
+  for (let day = 1; day <= maxDay; day++) {
+    chartData.push({
+      day,
+      current: data.current[day - 1]?.cumulative ?? null,
+      previous: data.previous?.[day - 1]?.cumulative ?? null,
+    })
+  }
+
+  let comparisonText: { text: string; color: string } | null = null
+  if (data.prevSameDayCumulative !== null && data.prevSameDayCumulative > 0) {
+    const delta = data.todayCumulative - data.prevSameDayCumulative
+    const pct = Math.round((delta / data.prevSameDayCumulative) * 100)
+    if (pct > 0) {
+      comparisonText = {
+        text: `↑ 比上月同期多 ${pct}%（${currency(Math.abs(delta))}）`,
+        color: 'var(--destructive)',
+      }
+    } else if (pct < 0) {
+      comparisonText = {
+        text: `↓ 比上月同期少 ${Math.abs(pct)}%（${currency(Math.abs(delta))}）`,
+        color: 'var(--primary)',
+      }
+    } else {
+      comparisonText = {
+        text: '→ 與上月同期相當',
+        color: 'var(--muted-foreground)',
+      }
+    }
+  }
+
+  return (
+    <div className="card p-5 md:p-6 space-y-3 animate-fade-up">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="text-xs font-semibold text-[var(--muted-foreground)]">
+          📈 每日累計支出 · {data.monthLabel}
+        </div>
+        {data.previous !== null && (
+          <div className="text-[11px] text-[var(--muted-foreground)]">
+            灰線：{data.previousMonthLabel}
+          </div>
+        )}
+      </div>
+
+      <div className="h-[180px] -mx-2">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData} margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
+            <XAxis
+              dataKey="day"
+              type="number"
+              domain={[1, maxDay]}
+              tick={{ fontSize: 10 }}
+              stroke="var(--muted-foreground)"
+              ticks={[1, 5, 10, 15, 20, 25, maxDay].filter((d) => d <= maxDay)}
+            />
+            <YAxis
+              tickFormatter={(v) => currency(v as number)}
+              tick={{ fontSize: 10 }}
+              stroke="var(--muted-foreground)"
+              width={70}
+            />
+            <Tooltip
+              content={({ active, payload, label }) => {
+                if (!active || !payload || payload.length === 0) return null
+                const p = payload[0].payload as {
+                  day: number
+                  current: number | null
+                  previous: number | null
+                }
+                return (
+                  <div className="rounded border border-[var(--border)] bg-[var(--card)] px-2 py-1 text-xs shadow space-y-0.5">
+                    <div className="font-medium">第 {label} 天</div>
+                    {p.current !== null && (
+                      <div className="text-[var(--primary)]">
+                        本月：{currency(p.current)}
+                      </div>
+                    )}
+                    {p.previous !== null && (
+                      <div className="text-[var(--muted-foreground)]">
+                        上月：{currency(p.previous)}
+                      </div>
+                    )}
+                  </div>
+                )
+              }}
+            />
+            {data.previous !== null && (
+              <Line
+                type="monotone"
+                dataKey="previous"
+                stroke="var(--muted-foreground)"
+                strokeWidth={1.5}
+                dot={false}
+                strokeDasharray="3 3"
+                connectNulls
+                isAnimationActive={false}
+              />
+            )}
+            <Line
+              type="monotone"
+              dataKey="current"
+              stroke="var(--primary)"
+              strokeWidth={2}
+              dot={false}
+              connectNulls
+              isAnimationActive={false}
+            />
+            <ReferenceLine
+              x={data.todayDay}
+              stroke="var(--foreground)"
+              strokeOpacity={0.2}
+              strokeDasharray="2 2"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs">
+        <span className="text-[var(--muted-foreground)]">
+          目前累計（第 {data.todayDay} 天）：
+        </span>
+        <span className="font-semibold text-[var(--foreground)]">
+          {currency(data.todayCumulative)}
+        </span>
+        {comparisonText && (
+          <span style={{ color: comparisonText.color }}>{comparisonText.text}</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/cumulative-month-curve.ts
+++ b/src/lib/cumulative-month-curve.ts
@@ -1,0 +1,140 @@
+import { toDate } from './utils'
+import type { Expense } from './types'
+
+export interface CumulativePoint {
+  day: number
+  cumulative: number
+}
+
+export interface CumulativeCurveData {
+  /** YYYY-MM label of current month. */
+  monthLabel: string
+  /** YYYY-MM label of previous month. */
+  previousMonthLabel: string
+  /** Current month points day=1..today (inclusive). */
+  current: CumulativePoint[]
+  /** Previous month points day=1..N (full month, if any data). null when no data. */
+  previous: CumulativePoint[] | null
+  /** Days in current calendar month (28..31). */
+  daysInMonth: number
+  /** Today's day-of-month (1..daysInMonth). */
+  todayDay: number
+  /** Cumulative spending up to and including today. */
+  todayCumulative: number
+  /** Cumulative spending in previous month at same day-of-month, capped at last day. null when no prev data. */
+  prevSameDayCumulative: number | null
+}
+
+interface BuildOptions {
+  expenses: Expense[]
+  year: number
+  /** 0-indexed month. */
+  month: number
+  now?: number
+  /** Min days into month before producing data. Default 3. */
+  minDays?: number
+}
+
+function dayOfMonth(d: Date): number {
+  return d.getDate()
+}
+
+function buildCumulativeForMonth(
+  expenses: Expense[],
+  year: number,
+  month: number,
+  endDay: number,
+): { points: CumulativePoint[]; total: number } {
+  const dailyTotals = new Map<number, number>()
+
+  for (const e of expenses) {
+    const amount = Number(e.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    let d: Date
+    try {
+      d = toDate(e.date)
+    } catch {
+      continue
+    }
+    if (!Number.isFinite(d.getTime())) continue
+    if (d.getFullYear() !== year || d.getMonth() !== month) continue
+    const day = dayOfMonth(d)
+    if (day < 1 || day > endDay) continue
+    dailyTotals.set(day, (dailyTotals.get(day) ?? 0) + amount)
+  }
+
+  const points: CumulativePoint[] = []
+  let cumulative = 0
+  for (let day = 1; day <= endDay; day++) {
+    cumulative += dailyTotals.get(day) ?? 0
+    points.push({ day, cumulative })
+  }
+  return { points, total: cumulative }
+}
+
+/**
+ * Cumulative day-by-day spending curve for a calendar month, paired with
+ * the previous month's curve for pace comparison. The dual-line view
+ * answers "am I ahead or behind last month's pace today?" in a single
+ * glance.
+ *
+ * Returns null when current month is too young (< minDays) or has no
+ * spending — neither case has a meaningful curve to draw.
+ */
+export function buildCumulativeMonthCurve({
+  expenses,
+  year,
+  month,
+  now = Date.now(),
+  minDays = 3,
+}: BuildOptions): CumulativeCurveData | null {
+  const today = new Date(now)
+  const isCurrentMonth = today.getFullYear() === year && today.getMonth() === month
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+
+  // todayDay caps at daysInMonth — handles future-month query (don't render)
+  // and past-month query (render full month).
+  let todayDay: number
+  if (isCurrentMonth) {
+    todayDay = today.getDate()
+  } else if (
+    today.getFullYear() > year ||
+    (today.getFullYear() === year && today.getMonth() > month)
+  ) {
+    todayDay = daysInMonth
+  } else {
+    return null // future month
+  }
+
+  if (todayDay < minDays) return null
+
+  const { points: current, total: currentTotal } = buildCumulativeForMonth(
+    expenses,
+    year,
+    month,
+    todayDay,
+  )
+  if (currentTotal <= 0) return null
+
+  const prevYear = month === 0 ? year - 1 : year
+  const prevMonth = month === 0 ? 11 : month - 1
+  const prevDaysInMonth = new Date(prevYear, prevMonth + 1, 0).getDate()
+  const prevResult = buildCumulativeForMonth(expenses, prevYear, prevMonth, prevDaysInMonth)
+  const previous = prevResult.total > 0 ? prevResult.points : null
+
+  // Day-of-month alignment for prevSameDay: cap to prev month's last day
+  const cappedPrevDay = Math.min(todayDay, prevDaysInMonth)
+  const prevSameDayCumulative =
+    previous?.[cappedPrevDay - 1]?.cumulative ?? null
+
+  return {
+    monthLabel: `${year}-${String(month + 1).padStart(2, '0')}`,
+    previousMonthLabel: `${prevYear}-${String(prevMonth + 1).padStart(2, '0')}`,
+    current,
+    previous,
+    daysInMonth,
+    todayDay,
+    todayCumulative: currentTotal,
+    prevSameDayCumulative,
+  }
+}


### PR DESCRIPTION
## 為什麼

MonthProjection (#296) 給「依目前速度月底會多少」單一數字。但**累計趨勢**才是直觀視覺——「我目前累計多少？vs 上月同期累計？」一眼可見。

第一個累計連續視角（之前都是 snapshot 或 discrete 點）。

## 做了什麼

`src/lib/cumulative-month-curve.ts` — 純函式：
- 當月 day 1..today + 上月整月累計
- prevSameDayCumulative 對齊 day-of-month（Feb 28 vs March 30 cap）
- 跨年（Jan → 上 Dec）正確
- 過去月份顯示完整

`src/components/cumulative-month-curve.tsx` — Recharts LineChart：
- 兩條線：本月 primary 實線、上月 muted 虛線
- 自定 tooltip 顯示日期 + 雙月累計
- 今日垂直 reference line
- 比較訊息著色（多紅、少綠、相當灰）

## 範例輸出

> 📈 每日累計支出 · 2026-04                灰線：2026-03
>
> [雙線 chart]
>
> 目前累計（第 15 天）：NT\$8,500
> ↑ 比上月同期多 21%（NT\$1,500）

## 測試

12 個單元測試 ✅
- minDays threshold
- null cases (no data / future month)
- curve 計算
- prev month full curve
- prevSameDay 對齊（Feb cap）
- 跨年
- 過去月顯示完整
- bad data defensive
- monotonic non-decreasing

整套：1399/1399 passed (新增 12 個).

Closes #348